### PR TITLE
Add Features Related to Build Versions

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -15,6 +15,7 @@ require 'omnibus/s3_cacher'
 require 'omnibus/s3_tasks'
 require 'omnibus/health_check'
 require 'omnibus/clean_tasks'
+require 'omnibus/build_version'
 
 module Omnibus
 
@@ -24,17 +25,6 @@ module Omnibus
 
   def self.root
     @root
-  end
-
-  def self.build_version
-    @build_version ||= begin
-                         git_cmd = "git describe"
-                         shell = Mixlib::ShellOut.new(git_cmd,
-                                                      :cwd => Omnibus.root)
-                         shell.run_command
-                         shell.error!
-                         shell.stdout.chomp
-                       end
   end
 
   def self.gem_root=(root)

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -1,0 +1,49 @@
+module Omnibus
+  module BuildVersion
+
+    def self.full
+      build_version
+    end
+
+    def self.version_tag
+      major, minor, patch = version_composition
+      "#{major}.#{minor}.#{patch}"
+    end
+
+    def self.git_sha
+      sha_regexp = /g([0-9a-f]+)$/
+      match = sha_regexp.match(build_version)
+      match ? match[1] : nil
+    end
+
+    def self.commits_since_tag
+      commits_regexp = /^\d+\.\d+\.\d+\-(\d+)\-g[0-9a-f]+$/
+      match = commits_regexp.match(build_version)
+      match ? match[1].to_i : 0
+    end
+
+    def self.development_version?
+      major, minor, patch = version_composition
+      patch.to_i.odd?
+    end
+
+    private
+
+    def self.build_version
+      @build_version ||= begin
+                           git_cmd = "git describe"
+                           shell = Mixlib::ShellOut.new(git_cmd,
+                                                        :cwd => Omnibus.root)
+                           shell.run_command
+                           shell.error!
+                           shell.stdout.chomp
+                         end
+    end
+
+    def self.version_composition
+      version_regexp = /^(\d+)\.(\d+)\.(\d+)/
+      version_regexp.match(build_version)[1..3]
+    end
+
+  end
+end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -52,7 +52,7 @@ module Omnibus
     end
 
     def build_version
-      Omnibus.build_version
+      Omnibus::BuildVersion.full
     end
 
     def package_scripts_path


### PR DESCRIPTION
Adding additional helpers to the git-based build version detection will let us pull in dependencies in a conditional fashion:

``` ruby
name "private-chef-administration"

if Omnibus::BuildVersion.development_version?
  version "master"
else
  version Omnibus::BuildVersion.version_tag
end

dependencies ["rsync"]
```
