### PR TITLE
windows msi only fix to copy only msi artifacts

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -263,7 +263,7 @@ module Omnibus
 
         task "#{@name}:copy" => (package_types.map {|pkg_type| "#{@name}:#{pkg_type}"}) do
           if OHAI.platform == "windows"
-            cp_cmd = "xcopy #{config.package_dir}\\* pkg\\ /Y"
+            cp_cmd = "xcopy #{config.package_dir}\\*.msi pkg\\ /Y"
           else
             cp_cmd = "cp #{config.package_dir}/* pkg/"
           end


### PR DESCRIPTION
Currently .wixpdb symbol files are included as part of the release, and this results in those files being downloaded by users instead of the .msi file. This change copies only msi files to the release location.
