### PR TITLE
Modify release script to copy only msi files as release artifacts

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -263,7 +263,7 @@ module Omnibus
 
         task "#{@name}:copy" => (package_types.map {|pkg_type| "#{@name}:#{pkg_type}"}) do
           if OHAI.platform == "windows"
-            cp_cmd = "xcopy #{config.package_dir}\\* pkg\\ /Y"
+            cp_cmd = "xcopy #{config.package_dir}\\*.msi pkg\\ /Y"
           else
             cp_cmd = "cp #{config.package_dir}/* pkg/"
           end


### PR DESCRIPTION
Currently .wixpdb files are being copied to the release point, which results in users downloading these useless (for them) files instead of the installation msi they need. This fix addresses this by releasing only the msi files.
