### PR TITLE
OC-6037: Parameterize msi files for omnibus-chef and omnibus-pushy

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -157,7 +157,7 @@ module Omnibus
                      "-loc #{install_path}\\msi-tmp\\#{package_name}-en-us.wxl",
                      "#{install_path}\\msi-tmp\\#{package_name}-Files.wixobj",
                      "#{install_path}\\msi-tmp\\#{package_name}.wixobj",
-                     "-out #{config.package_dir}\\#{package_name}-#{build_version}.msi"]
+                     "-out #{config.package_dir}\\#{package_name}-#{build_version}-#{iteration}.msi"]
 
       # Don't care about the 204 return code from light.exe since it's
       # about some expected warnings...


### PR DESCRIPTION
The Windows msi source files for msi_command always use names that are a variation of "chef client." This change parameterizes the Windows msi build to support building msi files with arbitrary source and output file name. This is necessary to enable building of a new msi file for omnibus-pushy on Windows.
