### PR TITLE
Chef11 compat fixes for windows build.

### DIFF
--- a/cookbooks/omnibus/metadata.rb
+++ b/cookbooks/omnibus/metadata.rb
@@ -9,6 +9,6 @@ version           "0.10.0"
   supports os
 end
 
-%w{ apt build-essential git opencsw python ruby_1.9 solaris_omgwtfbbq yum }.each do |cb|
+%w{ apt build-essential git opencsw python ruby_1.9 solaris_omgwtfbbq yum wix 7-zip}.each do |cb|
   depends cb
 end

--- a/cookbooks/windows/metadata.rb
+++ b/cookbooks/windows/metadata.rb
@@ -5,4 +5,4 @@ description      "Provides a set of useful Windows-specific primitives."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.3.4"
 supports         "windows"
-depends          "chef_handler"
+


### PR DESCRIPTION
Since wix is not specified as a dependency in omnibus, default attributes are not being loaded from wix cookbook during windows build. 

With adding wix and windows dependencies we also need to remove chef_handler dependency since it is not being used by omnibus and it doesn't exist under cookbooks.
