### PR TITLE
Fix build break installing Ruby on Windows -- replace /verysilent with /silent

### DIFF
--- a/cookbooks/ruby_1.9/recipes/windows.rb
+++ b/cookbooks/ruby_1.9/recipes/windows.rb
@@ -31,7 +31,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{ruby_name}" do
 end
 
 windows_batch "install ruby" do
-  command "#{Chef::Config[:file_cache_path]}/#{ruby_name} /verysilent /dir=C:\\Ruby193 /tasks=\"assocfiles\""
+  command "#{Chef::Config[:file_cache_path]}/#{ruby_name} /silent /dir=C:\\Ruby193 /tasks=\"assocfiles\""
   creates "C:\\Ruby193\\bin\\ruby.exe"
 end
 


### PR DESCRIPTION
The Ruby installer at http://rubyinstaller.org/ is documented to take a /veryslient flag, but this is failing with recent version fo the installer on Windows Jenkins boxes. The /silent flag succeeds even though it displays a graphical interface if you happen to be interactively logged on. This display is harmless (requires no user input and functions silently if no one is logged in interactively).

Without this fix, you must manually provision Ruby on the Jenkins box or the build will fail. With this fix, Ruby is installed successfully and there is no build break.
