### PR TITLE
Change invalid command attribute to code for windows batch in ruby recipe

### DIFF
--- a/cookbooks/ruby_1.9/recipes/windows.rb
+++ b/cookbooks/ruby_1.9/recipes/windows.rb
@@ -31,7 +31,7 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{ruby_name}" do
 end
 
 windows_batch "install ruby" do
-  command "#{Chef::Config[:file_cache_path]}/#{ruby_name} /silent /dir=C:\\Ruby193 /tasks=\"assocfiles\""
+  code "#{Chef::Config[:file_cache_path]}/#{ruby_name} /silent /dir=C:\\Ruby193 /tasks=\"assocfiles\""
   creates "C:\\Ruby193\\bin\\ruby.exe"
 end
 


### PR DESCRIPTION
The ruby_1.9 windows recipe has an invalid "command" attribute used to specify the command to install Ruby 1.93 on windows build machines during each build. The correct attribute is "code" -- right now, this part of the recipe is a no-op, so new build machines do not install Ruby and eventually fail the build. Workaround is manual provisioning, which is not acceptable.

This fix changes the recipe to use the correct code attribute and has been tested on new build machines.
