### PR TITLE
CHEF-4141: Fix md5 binary detection

### DIFF
--- a/bin/makeself.sh
+++ b/bin/makeself.sh
@@ -358,8 +358,8 @@ else
 	PATH=${GUESS_MD5_PATH:-"$OLD_PATH:/bin:/usr/bin:/sbin:/usr/local/ssl/bin:/usr/local/bin:/opt/openssl/bin"}
 	MD5_ARG=""
 	MD5_PATH=`exec <&- 2>&-; which md5sum || type md5sum`
-	test -x $MD5_PATH || MD5_PATH=`exec <&- 2>&-; which md5 || type md5`
-	test -x $MD5_PATH || MD5_PATH=`exec <&- 2>&-; which digest || type digest`
+	test -x "$MD5_PATH" || MD5_PATH=`exec <&- 2>&-; which md5 || type md5`
+	test -x "$MD5_PATH" || MD5_PATH=`exec <&- 2>&-; which digest || type digest`
 	PATH=$OLD_PATH
 	if test `basename $MD5_PATH` = digest; then
 		MD5_ARG="-a md5"


### PR DESCRIPTION
This change fixes a minor bash bug related to the interpretation of undefined variables.
