### PR TITLE
[thor-16-17-support] Support Thor 0.16-0.17

### DIFF
--- a/lib/omnibus/cli/base.rb
+++ b/lib/omnibus/cli/base.rb
@@ -33,8 +33,9 @@ module Omnibus
         super(args, options, config)
         $stdout.sync = true
 
-        # Don't try to initialize the Omnibus project for help commands
-        return if config[:current_command].name == "help"
+        # Don't try to initialize the Omnibus project for help commands. current_task renamed to current_command in Thor 0.18.0
+        current_command = config[:current_command] ? config[:current_command].name : config[:current_task].name
+        return if current_command == "help"
 
         if path = @options[:path]
           if (config = @options[:config]) && File.exist?(@options[:config])


### PR DESCRIPTION
Currently in the gemspec anything > Thor 0.16.0 is allowed, however in Thor 0.18.0 current_task was renamed to current_command and omnibus is making use of current_command only so it was failing with a no method .name for nil class. This change makes it truly compatible with Thor 0.16-0.17, etc.
