### PR TITLE
CHEF-4171 - Include additional whitelist libs for freebsd 8.x

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -105,7 +105,8 @@ module Omnibus
                                /libm\.so/,
                                /librt\.so/,
                                /libthr\.so/,
-                               /libutil\.so/
+                               /libutil\.so/,
+                               /libexecinfo\.so/
                               ]
 
     WHITELIST_FILES = [


### PR DESCRIPTION
Include libexecinfo\* library whitelist for building freebsd 8.1 and 8.2 omnibus buils (probably 8.3 as well).
