### PR TITLE
Add libstdc++ to mac whitelist libs

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -96,7 +96,8 @@ module Omnibus
                           /libutil\.dylib/,
                           /libffi\.dylib/,
                           /libncurses\.5\.4\.dylib/,
-                          /libiconv/
+                          /libiconv/,
+                          /libstdc\+\+\.6\.dylib/
                          ]
 
     FREEBSD_WHITELIST_LIBS = [


### PR DESCRIPTION
...to make the health check pass when depending on C++ libs.
