### PR TITLE
Add libstdc++ to smartos whitelist libs

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -94,6 +94,7 @@ module Omnibus
                               /libmd.so/,
                               /libc.so/,
                               /libgcc_s.so/,
+                              /libstdc\+\+\.so/,
                               /libcrypt.so/
                              ]
 


### PR DESCRIPTION
title says it all. 
