### PR TITLE
Raise an exception if a patch file is not found

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -16,6 +16,7 @@
 #
 
 require 'forwardable'
+require 'omnibus/exceptions'
 
 module Omnibus
   class Builder
@@ -132,6 +133,10 @@ module Omnibus
       end
 
       source = candidate_paths.find{|path| File.exists?(path) }
+
+      unless source
+        raise MissingPatch.new(args[:source], candidate_paths)
+      end
 
       plevel = args[:plevel] || 1
       if args[:target] 

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -110,4 +110,19 @@ module Omnibus
       """
     end
   end
+
+  class MissingPatch < RuntimeError
+    def initialize(patch_name, search_paths)
+      @patch_name, @search_paths = patch_name, search_paths
+    end
+
+    def to_s
+      """
+      Attempting to apply the patch #{@patch_name}, but it was not
+      found at any of the following locations:
+
+      #{@search_paths.join("\n      ")}
+      """
+    end
+  end
 end


### PR DESCRIPTION
Figuring out that a patch file wasn't found because you added some
string interpolation to a single-quoted string is a little trickier
otherwise :frowning: 
