### PR TITLE
Add support for a software.library_paths attribute

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -137,14 +137,14 @@ module Omnibus
       puts "[health_check] #{msg}"
     end
 
-    def self.run(install_dir, whitelist_files = [])
+    def self.run(install_dir, whitelist_files = [], library_paths = [])
       case OHAI.platform
       when "mac_os_x"
-        bad_libs = health_check_otool(install_dir, whitelist_files)
+        bad_libs = health_check_otool(install_dir, whitelist_files, library_paths)
       when "aix"
-        bad_libs = health_check_aix(install_dir, whitelist_files)
+        bad_libs = health_check_aix(install_dir, whitelist_files, library_paths)
       else
-        bad_libs = health_check_ldd(install_dir, whitelist_files)
+        bad_libs = health_check_ldd(install_dir, whitelist_files, library_paths)
       end
 
       unresolved = []
@@ -192,7 +192,7 @@ module Omnibus
       end
     end
 
-    def self.health_check_otool(install_dir, whitelist_files)
+    def self.health_check_otool(install_dir, whitelist_files, library_paths)
       otool_cmd = "find #{install_dir}/ -type f | egrep '\.(dylib|bundle)$' | xargs otool -L > otool.out 2>/dev/null"
       log "Executing `#{otool_cmd}`"
       shell = Mixlib::ShellOut.new(otool_cmd, :timeout => 3600)
@@ -210,7 +210,7 @@ module Omnibus
         when /^\s+(.+) \(.+\)$/
           linked = $1
           name = File.basename(linked)
-          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, library_paths, current_library, name, linked)
         end
       end
 
@@ -219,7 +219,7 @@ module Omnibus
       bad_libs
     end
 
-    def self.check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
+    def self.check_for_bad_library(install_dir, bad_libs, whitelist_files, library_paths, current_library, name, linked)
       safe = nil
 
       whitelist_libs = case OHAI.platform
@@ -245,6 +245,14 @@ module Omnibus
         safe ||= true if reg.match(current_library)
       end
 
+      linked_path = File.realpath(File.dirname(linked))
+      Dir.glob(library_paths, File::FNM_PATHNAME).each { |path|
+        if File.realpath(path) == linked_path
+          safe ||= true
+          break
+        end
+      }
+
       log "  --> Dependency: #{name}" if ARGV[0] == "verbose"
       log "  --> Provided by: #{linked}" if ARGV[0] == "verbose"
 
@@ -264,7 +272,7 @@ module Omnibus
       bad_libs
     end
 
-    def self.health_check_aix(install_dir, whitelist_files)
+    def self.health_check_aix(install_dir, whitelist_files, library_paths)
       #
       # ShellOut has GC turned off during execution, so when we're
       # executing extremely long commands with lots of output, we
@@ -290,7 +298,7 @@ module Omnibus
         when /^\s+(.+)$/
           name = $1
           linked = $1
-          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, library_paths, current_library, name, linked)
         when /File is not an executable XCOFF file/ # ignore non-executable files
         else
           log "*** Line did not match for #{current_library}\n#{line}"
@@ -301,7 +309,7 @@ module Omnibus
       bad_libs
     end
 
-    def self.health_check_ldd(install_dir, whitelist_files)
+    def self.health_check_ldd(install_dir, whitelist_files, library_paths)
       #
       # ShellOut has GC turned off during execution, so when we're
       # executing extremely long commands with lots of output, we
@@ -327,7 +335,7 @@ module Omnibus
         when /^\s+(.+) \=\>\s+(.+)( \(.+\))?$/
           name = $1
           linked = $2
-          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, library_paths, current_library, name, linked)
         when /^\s+(.+) \(.+\)$/
           next
         when /^\s+statically linked$/

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -702,7 +702,8 @@ module Omnibus
             else
               # build a list of all whitelist files from all project dependencies
               whitelist_files = library.components.map{|component| component.whitelist_files }.flatten
-              Omnibus::HealthCheck.run(install_path, whitelist_files)
+              library_paths = library.components.map{|component| component.library_paths }.flatten
+              Omnibus::HealthCheck.run(install_path, whitelist_files, library_paths)
             end
           end
         end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -52,6 +52,7 @@ module Omnibus
     attr_reader :given_version
     attr_reader :override_version
     attr_reader :whitelist_files
+    attr_reader :library_paths
 
     def self.load(filename, project, overrides={})
       new(IO.read(filename), filename, project, overrides)
@@ -87,6 +88,7 @@ module Omnibus
 
       @dependencies = Array.new
       @whitelist_files = Array.new
+      @library_paths = Array.new
       instance_eval(io, filename, 0)
 
       # Set override information after the DSL file has been consumed
@@ -162,6 +164,14 @@ module Omnibus
     def whitelist_file(file)
       file = Regexp.new(file) unless file.kind_of?(Regexp)
       @whitelist_files << file
+    end
+
+    # Add an alternate library path to check for dependencies
+    #
+    # @param path [String] a glob-style path to search in the healthcheck
+    # @return [void]
+    def library_path(path)
+      @library_paths << path
     end
 
     # Was this software version overridden externally, relative to the

--- a/spec/software_spec.rb
+++ b/spec/software_spec.rb
@@ -39,6 +39,15 @@ describe Omnibus::Software do
     end
   end
 
+  describe "#library_path" do
+
+    it "appends to the library_paths array" do
+      software.library_paths.size.should equal 0
+      software.library_path(/foo\/bar/)
+      software.library_paths.size.should equal 1
+    end
+  end
+
   context "testing version overrides" do
 
     context "without overrides" do


### PR DESCRIPTION
When using omnibus to build packages that are dependent upon other
packages in the same source base (ie. a "common" package that includes
all shared libraries for its dependents) it would be very handy to
provide a mechanism similar to LD_LIBRARY_PATH. In this case, it is
possible to provide a list of library search paths, instead of
explicitly whitelisting individual files/regexs. These search paths
support glob-style syntax in order to make this functionality as
flexible as possible.

All tests pass.
