### PR TITLE
bump default cpus to get better throughput when ohai is wrong

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -262,7 +262,7 @@ module Omnibus
       if OHAI.cpu && OHAI.cpu[:total] && OHAI.cpu[:total].to_s =~ /^\d+$/
         OHAI.cpu[:total].to_i + 1
       else
-        2
+        3
       end
     end
 


### PR DESCRIPTION
This is going to be a no-op on linuxes, but on solaris and other OSen where we don't have good cpu detection in OHAI (which is admittedly a bug, but not one getting fixed particularly quickly) this will make compiles faster in the 2-[v]cpu case.  Users on single-core solaris boxes might get some increased contention.  Even our ancient v245s have 2 cores though.
