### PR TITLE
Whitelist libnsl on Arch Linux.

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -44,6 +44,7 @@ module Omnibus
                            /libffi\.so/,
                            /libgdbm\.so/,
                            /libm\.so/,
+                           /libnsl\.so/,
                            /libpthread\.so/,
                            /librt\.so/,
                            /libutil\.so/


### PR DESCRIPTION
libnsl is part of glibc which is obviously part of the base install.  I missed this in my initial pull request creating the Arch-specific whitelist.  :(
