### PR TITLE
Add support for pre-install scripts

### DIFF
--- a/lib/omnibus/cli/application.rb
+++ b/lib/omnibus/cli/application.rb
@@ -85,7 +85,7 @@ module Omnibus
         template(File.join("Vagrantfile.erb"), File.join(target, "Vagrantfile"), opts)
 
         # render out stub packge scripts
-        %w{ makeselfinst postinst postrm }.each do |package_script|
+        %w{ makeselfinst preinst postinst postrm }.each do |package_script|
           script_path = File.join(target, "package-scripts", name, package_script)
           template_path = File.join("package_scripts", "#{package_script}.erb")
           # render the package script

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -532,6 +532,10 @@ module Omnibus
                           "-m '#{maintainer}'",
                           "--description '#{description}'",
                           "--url #{homepage}"]
+      if File.exist?(File.join(package_scripts_path, "preinst"))
+        command_and_opts << "--before-install '#{File.join(package_scripts_path, "preinst")}'"
+      end
+
       if File.exist?("#{package_scripts_path}/postinst")
         command_and_opts << "--post-install '#{package_scripts_path}/postinst'"
       end

--- a/lib/omnibus/templates/package_scripts/preinst.erb
+++ b/lib/omnibus/templates/package_scripts/preinst.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Perform necessary <%= config[:name] %> setup steps
+# before package is installed.
+#
+
+echo "You're about to install <%= config[:name] %>!"


### PR DESCRIPTION
Handy for, say, making sure all omnibus-managed services have been shut down prior to an upgrade.

cc: @schisamo @jkeiser @danielsdeleo @sdelano @seth 
