### PR TITLE
add support for .tar.xz files

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -179,6 +179,8 @@ E
         "7z.exe x #{project_file} -o#{source_dir} -r -y"
       elsif project_file.end_with?(".zip")
         "unzip #{project_file} -d #{source_dir}"
+      elsif project_file.end_with?(".xz") || project_file.end_with?(".txz")
+        "xz -dc #{project_file} | ( cd #{source_dir} && tar -xf - )"
       else
         #if we don't recognize the extension, simply copy over the file
         Proc.new do

--- a/spec/fetchers/net_fetcher_spec.rb
+++ b/spec/fetchers/net_fetcher_spec.rb
@@ -13,4 +13,29 @@ describe Omnibus::NetFetcher do
     net_fetcher = Omnibus::NetFetcher.new software_mock
     net_fetcher.extract_cmd.should == 'unzip file.zip -d /tmp/out'
   end
+  it "should download and uncompress .tar.xz files" do
+    software_mock = stub 'software'
+    software_mock.stub :project_file => 'file.tar.xz',
+                       :name         => 'file',
+                       :source       => '/tmp/out',
+                       :checksum     => 'abc123',
+                       :source_uri   => 'http://example.com/file.tar.xz',
+                       :source_dir   => '/tmp/out',
+                       :project_dir  => '/tmp/project'
+    net_fetcher = Omnibus::NetFetcher.new software_mock
+    net_fetcher.extract_cmd.should == 'xz -dc file.tar.xz | ( cd /tmp/out && tar -xf - )'
+  end
+  it "should download and uncompress .txz files" do
+    software_mock = stub 'software'
+    software_mock.stub :project_file => 'file.txz',
+                       :name         => 'file',
+                       :source       => '/tmp/out',
+                       :checksum     => 'abc123',
+                       :source_uri   => 'http://example.com/file.txz',
+                       :source_dir   => '/tmp/out',
+                       :project_dir  => '/tmp/project'
+    net_fetcher = Omnibus::NetFetcher.new software_mock
+    net_fetcher.extract_cmd.should == 'xz -dc file.txz | ( cd /tmp/out && tar -xf - )'
+  end
 end
+


### PR DESCRIPTION
This adds support for .tar.xz and .txz files, because some authors feel the need to make my life miserable for the sake of a few bytes.
