### PR TITLE
must run mkinstallp as root

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -506,7 +506,7 @@ module Omnibus
     end
 
     def bff_command
-      bff_command = ["mkinstallp -d / -T /tmp/bff/gen.template"]
+      bff_command = ["sudo /usr/sbin/mkinstallp -d / -T /tmp/bff/gen.template"]
       [bff_command.join(" "), {:returns => [0]}]
     end
 
@@ -610,7 +610,7 @@ module Omnibus
     end
 
     def run_bff
-      FileUtils.rm_rf "/.info"
+      FileUtils.rm_rf "/.info/*"
       FileUtils.rm_rf "/tmp/bff"
       FileUtils.mkdir "/tmp/bff"
 


### PR DESCRIPTION
- tired of fighting with AIX's mkinstallp, they really want it to
  run as root, so its now a requirement to allow sudo access to
  mkinstallp to create bff files on AIX.
