### PR TITLE
allow access to Omnibus.project_root in software

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -38,6 +38,7 @@ module Omnibus
       def_delegator :@builder, :rake
       def_delegator :@builder, :block
       def_delegator :@builder, :name
+      def_delegator :@builder, :project_root
 
       def initialize(builder, software)
         @builder, @software = builder, software
@@ -170,6 +171,10 @@ module Omnibus
 
     def block(&rb_block)
       @build_commands << rb_block
+    end
+
+    def project_root
+      Omnibus.project_root
     end
 
     def project_dir


### PR DESCRIPTION
I find this to be pretty useful.
