### PR TITLE
Fix the error message logged when omnibus failed to resolve refs to commits

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -164,7 +164,7 @@ E
       commit_ref
     rescue Exception => e
       if retries >= 3
-        ErrorReporter.new(e, self).explain("Failed to fetch git repository '#{@source[:git]}'")
+        ErrorReporter.new(e, self).explain("Failed to find any commits for the ref '#{ref}'")
         raise
       else
         # Deal with github failing all the time :(

--- a/spec/fetchers/git_fetcher_spec.rb
+++ b/spec/fetchers/git_fetcher_spec.rb
@@ -78,7 +78,7 @@ describe Omnibus::GitFetcher do
                }
              }
             Omnibus::Fetcher::ErrorReporter.any_instance
-              .should_receive(:explain).with(%q|Failed to fetch git repository 'git@example.com:test/project.git'|)
+              .should_receive(:explain).with(%q|Failed to find any commits for the ref '0.0.1'|)
             subject.should_receive(:log).with(%r|git ls-remote failed|).at_least(1).times
             subject.should_receive(:log).with(%r|git clone/fetch failed|).at_least(1).times
             # Prevent sleeping to run the spec fast


### PR DESCRIPTION
Hi, 

Thanks for sharing this!

I doubt that omnibus emits an incorrect message when it fails to resolve refs(typically specified via `version` in `config/software/foo.rb`) to commit IDs.

I get "Failed to fetch git repository '#{@source[:git]}'", but what I think better is something like "Failed to find any commits for the ref '#{ref}'", since in this case omnibus did succeed to fetch.

This PR will fix the message while adding specs to GitFetcher to ensure that it work before and after the fix.

Regards,
Yusuke
