### PR TITLE
Refactor how we handle loading dirs for software files.

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -154,6 +154,17 @@ module Omnibus
     ruby_files(File.join(project_root, Config.software_dir))
   end
 
+  # Return directories to search for {Omnibus::Software} DSL files.
+  #
+  # @return [Array<String>]
+  def self.software_dirs
+    @software_dirs ||= begin
+      software_dirs = [File.join(project_root, Config.software_dir)]
+      software_dirs << File.join(omnibus_software_root, 'config', 'software') if omnibus_software_root
+      software_dirs
+    end
+  end
+
   # Backward compat alias
   #
   # @todo print a deprecation message
@@ -288,9 +299,7 @@ module Omnibus
     dep_file = software_map[dependency_name]
 
     unless dep_file
-      raise MissingProjectDependency.new(dependency_name,
-                                         [File.join(project_root, Config.software_dir),
-                                          File.join(omnibus_software_root, 'config', 'software')])
+      raise MissingProjectDependency.new(dependency_name, software_dirs)
     end
 
     dep_software = Omnibus::Software.load(dep_file, project, overrides)

--- a/spec/software_dirs_spec.rb
+++ b/spec/software_dirs_spec.rb
@@ -1,0 +1,34 @@
+require 'omnibus'
+require 'spec_helper'
+
+describe Omnibus do
+
+  describe '#software_dirs' do
+
+    before :each do
+      # This is probably really silly, but it works
+      Omnibus.class_eval { @software_dirs = nil }
+    end
+
+    context 'omnibus_software_root not nil' do
+      before :each do
+        Omnibus.stub(:omnibus_software_root) { './data' }
+      end
+
+      it 'will include list of software from omnibus-software gem' do
+        Omnibus.software_dirs.length.should eq 2
+      end
+    end
+
+    context 'omnibus_software_root nil' do
+      before :each do
+        Omnibus.stub(:omnibus_software_root) { nil }
+      end
+
+      it 'will not include list of software from omnibus-software gem' do
+        Omnibus.software_dirs.length.should eq 1
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This came about because I found myself trying to debug and oddly placed `can't convert nil into String` exception, while attempting to build a project. 

Turns out I wasn't running omnibus in `bundler` context, so it couldn't load up the gem metadata. In this condition, the error happens when trying to evaluate line 293. `Omnibus.omnibus_software_root` was `nil`, hence the boom.

I felt that letting it fall through, like there was a problem with the places it looks for the software files, was a reasonable course of action here.

So, this addresses an edge case, and I threw in a silly test for good measure.
