### PR TITLE
Vagrantfile.erb - removing V2 unsupported ssh options

### DIFF
--- a/lib/omnibus/templates/Vagrantfile.erb
+++ b/lib/omnibus/templates/Vagrantfile.erb
@@ -62,8 +62,6 @@ Vagrant.configure("2") do |config|
   # The path to the Berksfile to use with Vagrant Berkshelf
   config.berkshelf.berksfile_path = "./Berksfile"
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
   config.ssh.forward_agent = true
 
   host_project_path = File.expand_path("..", __FILE__)


### PR DESCRIPTION
Including these ssh options in Vagrantfile:

```
config.ssh.max_tries
config.ssh.timeout 
```

... causes vagrant (I'm running 1.3.5) to barf:

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

SSH:
* The following settings shouldn't exist: max_tries, timeout
```

And indeed, those options don't seem to exist in the v2 documentation:
http://docs.vagrantup.com/v2/vagrantfile/ssh_settings.html

I posit that a sane default Vagrantfile does not include these options.
