### PR TITLE
Support versioned dependencies

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -65,6 +65,7 @@ module Omnibus
       @description = nil
       @replaces = nil
 
+      @software_version_pinning = { }
       @exclusions = Array.new
       @conflicts = Array.new
       @config_files = Array.new
@@ -101,6 +102,12 @@ module Omnibus
       @name = val unless val.equal?(NULL_ARG)
       @name || raise(MissingProjectConfiguration.new("name", "my_project"))
     end
+
+    def software_version_pinning(val=NULL_ARG)
+      @software_version_pinning = val unless val.equal?(NULL_ARG)
+      @software_version_pinning
+    end
+
 
     # Set or retrieve the package name of the project.  Unless
     # explicitly set, the package name defaults to the project name
@@ -583,7 +590,7 @@ module Omnibus
       @exclusions.each do |pattern|
         command_and_opts << "--exclude '#{pattern}'"
       end
-      
+
       @config_files.each do |config_file|
         command_and_opts << "--config-files '#{config_file}'"
       end

--- a/lib/omnibus/software_definition.rb
+++ b/lib/omnibus/software_definition.rb
@@ -1,0 +1,63 @@
+#
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'rake'
+
+module Omnibus
+  class SoftwareDefinition
+    include Rake::DSL
+
+    NULL_ARG = Object.new
+
+    attr_reader :name
+    attr_reader :version
+    attr_reader :filename
+
+    def self.load(filename)
+      new(IO.read(filename), filename)
+    end
+
+    def initialize(io, filename)
+      @name = nil
+      @version = nil
+      @filename = filename
+
+      instance_eval(io, filename, 0)
+    end
+
+    def name(val=NULL_ARG)
+      @name = val unless val.equal?(NULL_ARG)
+      @name
+    end
+
+    def version(val=NULL_ARG)
+      @given_version = val unless val.equal?(NULL_ARG)
+      @override_version || @given_version
+    end
+
+    def placeholder_dsl_method(var1=nil, var2=nil, var3=nil)
+      # This is a placeholder method that does nothing.
+    end
+
+    # Define the methods of Omnibus::Software so that we can load a software as
+    # a SoftwareDefinition
+    dsl_methods = Omnibus::Software.instance_methods - Object.instance_methods - [:name, :version]
+    dsl_methods.each do |dsl_method|
+      define_method dsl_method, instance_method(:placeholder_dsl_method)
+    end
+  end
+end


### PR DESCRIPTION
:construction: 

Currently it's a pain if one wants to have different versions of softwares in different projects when using omnibus. This approach introduces a new DSL attribute on projects called `software_version_pinning` (looking for a better name) which can be used to pin the version of a software component at the project level. 

Example usage of it would be to update chef.rb and chef-dk.rb in omnibus-chef repo as below:

``` ruby
# chef.rb in omnibus-chef
software_version_pinning = {
   "ruby" => "1.9.3-p484"
}

# chef-dk.rb in omnibus-chef
software_version_pinning = {
   "ruby" => "2.1.0-p121"
}
```

We've considered achieving this goal by introducing different software configurations with different names but it took us to dependency hell because of inter-software dependencies. 

This PR aims to vet this approach and make sure we agree before moving further into it. 

Note that this will likely be a breaking change because it changes the keys in the `software_map` from file names to the names specified in the software definitions. We will most likely couple this with another breaking change coming from @danielsdeleo about producing dmg files by default on Mac.

@lamont-granquist / @schisamo thoughts? 

One question for you @schisamo: How would this impact the build speed improvements that we're bringing in?
