### PR TITLE
Prevent the installation of the 7.* ohai gem

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "mixlib-shellout", "~> 1.3.0"
   gem.add_dependency "mixlib-config", "~> 2.1.0"
-  gem.add_dependency "ohai", "~> 0.6.12"
+  gem.add_dependency "ohai", "~> 6.12"
   gem.add_dependency "rake", ">= 0.9"
   gem.add_dependency "fpm", "~> 1.0.0"
   gem.add_dependency "uber-s3"


### PR DESCRIPTION
Prevents the installation of the 7.\* ohai gem as 7.0.0-rc is installed now by default and breaks (at least in RHEL) omnibus.'
