### PR TITLE
Use local var from rescue rather than "English" global.

### DIFF
--- a/lib/omnibus/cli/application.rb
+++ b/lib/omnibus/cli/application.rb
@@ -118,7 +118,7 @@ module Omnibus
         super
       rescue => e
         error_msg = 'Something went wrong...the Omnibus just ran off the road!'
-        error_msg << "\n\nError raised was:\n\n\t#{$ERROR_INFO}"
+        error_msg << "\n\nError raised was:\n\n\t#{e}"
         error_msg << "\n\nBacktrace:\n\n\t#{e.backtrace.join("\n\t") }"
         if e.respond_to?(:original) && e.original
           error_msg << "\n\nOriginal Error:\n\n\t#{e.original}"


### PR DESCRIPTION
Apparently an Omnibus dependency was requiring "English"
http://www.ruby-doc.org/stdlib-2.0/libdoc/English/rdoc/English.html but
no longer does. That library must be loaded to use $ERROR_INFO. But
since $ERROR_INFO is just $!, the last exception raised, and we already
have a reference to it from `rescue => e`, we can just use the local
variable instead.

ping @schisamo @sethvargo 
