### PR TITLE
CC-49: Fix the name of the pkg artifact created by the pipeline.

### DIFF
--- a/lib/omnibus/packagers/mac_pkg.rb
+++ b/lib/omnibus/packagers/mac_pkg.rb
@@ -46,6 +46,10 @@ module Omnibus
       #   @return (see Project#build_version)
       def_delegator :@project, :build_version, :version
 
+      # !@method iteration
+      #   @return (see Project#iteration)
+      def_delegator :@project, :iteration, :iteration
+
       # !@method identifier
       #   @return (see Project#mac_pkg_identifier)
       def_delegator :@project, :mac_pkg_identifier, :identifier
@@ -171,7 +175,7 @@ module Omnibus
       #
       # @return [String] the basename of the package file
       def package_name
-        "#{name}.pkg"
+        "#{name}-#{version}-#{iteration}.pkg"
       end
 
       def identifier


### PR DESCRIPTION
Currently `mac_pkg` creates the artifact with name `chef.pkg` which is not compatible with the omnitruck release logic. 

This change is tested here: http://ci.opscode.us/job/chef-client-build/1340/build_os=mac_os_x_10_7,machine_architecture=x64,role=oss-builder/

Created a package with name: `chef-11.10.0.alpha.1-246-gc861b2d-1.mac_os_x.10.7.2.pkg`

/cc: @opscode/client-eng / @sethvargo / @schisamo 
