### PR TITLE
Add Chef Sugar

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -32,6 +32,7 @@ require 'omnibus/project'
 require 'omnibus/fetchers'
 require 'omnibus/health_check'
 require 'omnibus/build_version'
+require 'omnibus/sugar'
 require 'omnibus/overrides'
 require 'omnibus/version'
 

--- a/lib/omnibus/sugar.rb
+++ b/lib/omnibus/sugar.rb
@@ -1,0 +1,49 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/sugar/architecture'
+require 'chef/sugar/cloud'
+# NOTE: We cannot include the constraints library because of the conflicting
+# +version+ attribute would screw things up. You can still use the
+# +Chef::Sugar::Constraint.version('1.2.3') for comparing versions.
+#
+# require 'chef/sugar/constraints'
+require 'chef/sugar/ip'
+require 'chef/sugar/platform'
+require 'chef/sugar/platform_family'
+require 'chef/sugar/ruby'
+require 'chef/sugar/shell'
+require 'chef/sugar/vagrant'
+
+require 'omnibus/project'
+
+module Omnibus
+  class Project
+    private
+
+    # This method is used by Chef Sugar to easily add the DSL. By mimicing
+    # Chef's +node+ object, we can easily include the existing DSL into
+    # Omnibus project as if it were Chef. Otherwise, we would need to rewrite
+    # all the DSL methods.
+    def node
+      OHAI
+    end
+  end
+end
+
+# Include everything in Omnibus
+Omnibus::Project.send(:include, Chef::Sugar::DSL)
+Omnibus::Software.send(:include, Chef::Sugar::DSL)

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
+  gem.add_dependency 'chef-sugar',      '~> 1.2'
   gem.add_dependency 'mixlib-shellout', '~> 1.3'
   gem.add_dependency 'mixlib-config',   '~> 2.1'
   gem.add_dependency 'ohai',            '~> 6.12'

--- a/spec/sugar_spec.rb
+++ b/spec/sugar_spec.rb
@@ -1,0 +1,20 @@
+require 'omnibus/project'
+require 'omnibus/software'
+
+require 'spec_helper'
+
+describe Omnibus::Software do
+  it 'includes the Chef Sugar DSL methods' do
+    expect(described_class).to be_method_defined(:windows?)
+    expect(described_class).to be_method_defined(:vagrant?)
+    expect(described_class).to be_method_defined(:_64_bit?)
+  end
+end
+
+describe Omnibus::Project do
+  it 'includes the Chef Sugar DSL methods' do
+    expect(described_class).to be_method_defined(:windows?)
+    expect(described_class).to be_method_defined(:vagrant?)
+    expect(described_class).to be_method_defined(:_64_bit?)
+  end
+end


### PR DESCRIPTION
After seeing the PR at https://github.com/opscode/omnibus-software/pull/141/files, should we consider adding [Chef Sugar](https://github.com/sethvargo/chef-sugar) as a dependency on omnibus-ruby. Since Sugar works mostly off of Ohai data (with minimal exception), that PR could have leveraged the `freebsd?` matcher.

/cc @opscode/release-engineers @sersut @danielsdeleo @lamont-granquist 
