### PR TITLE
Add libc++.1.dylib to the healthcheck whitelist.

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -122,6 +122,7 @@ module Omnibus
       /libncurses\.5\.4\.dylib/,
       /libiconv/,
       /libstdc\+\+\.6\.dylib/,
+      /libc\+\+\.1\.dylib/,
     ]
 
     FREEBSD_WHITELIST_LIBS = [


### PR DESCRIPTION
This is a standard system package that gecode links to. From pkgutil:

```
$ pkgutil --file-info /usr/lib/libc++.1.dylib

volume: /
path: /usr/lib/libc++.1.dylib

pkgid: com.apple.pkg.BaseSystemBinaries
pkg-version: 10.9.0.1.1.1306847324
install-time: 1382478239
uid: 0
gid: 0
mode: 755
```

/cc @opscode/client-eng @opscode/release-engineers 
