### PR TITLE
quiet git config warning messages when saving to cache

### DIFF
--- a/lib/omnibus/install_path_cache.rb
+++ b/lib/omnibus/install_path_cache.rb
@@ -65,6 +65,9 @@ module Omnibus
         end
       end
       dep_string = dep_list.map { |i| "#{i.name}-#{i.version}" }.join('-')
+      # digest the content of the software's config so that changes to
+      # build params invalidate cache.
+      dep_string = IO.read(@software.source_config) + dep_string
       digest = Digest::SHA256.hexdigest(dep_string)
       "#{name}-#{version}-#{digest}"
     end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -53,6 +53,8 @@ module Omnibus
 
     attr_reader :whitelist_files
 
+    attr_reader :source_config
+
     def self.load(filename, project, repo_overrides = {})
       new(IO.read(filename), filename, project, repo_overrides)
     end

--- a/spec/install_path_cache_spec.rb
+++ b/spec/install_path_cache_spec.rb
@@ -20,8 +20,12 @@ EOH
     project
   end
 
+  let(:fake_software_config_file) do
+    File.join(Omnibus::RSpec::SPEC_DATA, 'software', 'zlib.rb')
+  end
+
   let(:zlib) do
-    software = Omnibus::Software.new('', 'zlib.rb', project)
+    software = Omnibus::Software.new('', fake_software_config_file, project)
     software.name('zlib')
     software.default_version('1.7.2')
     software
@@ -64,11 +68,14 @@ EOH
   end
 
   describe '#tag' do
-    # 9664a7dd4f27909a38769faef7ec739a4d6934f1c2cf95d3112e064682f6a91a
+    # 13b3f7f2653e40b9d5b393659210775ac5b56f7e0009f82f85b83f5132409362
     #
-    # Is the sha256sum of 'preparation-1.0.0-snoopy-1.0.0'
+    # Is the sha256sum of:
+    # cat spec/data/software/zlib.rb > t
+    # echo -n 'preparation-1.0.0-snoopy-1.0.0' >> t
+    # sha256sum t
     it 'returns a tag with the softwares name, version, and hash of deps name+version' do
-      expect(ipc.tag).to eql('zlib-1.7.2-9664a7dd4f27909a38769faef7ec739a4d6934f1c2cf95d3112e064682f6a91a')
+      expect(ipc.tag).to eql('zlib-1.7.2-13b3f7f2653e40b9d5b393659210775ac5b56f7e0009f82f85b83f5132409362')
     end
 
     describe 'with no deps' do
@@ -76,8 +83,10 @@ EOH
         Omnibus::InstallPathCache.new(install_path, zlib)
       end
 
-      it 'uses the shasum of an empty string' do
-        expect(ipc.tag).to eql('zlib-1.7.2-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+      it 'uses the shasum of the software config file' do
+        # gsha256sum spec/data/software/zlib.rb
+        # 363e6cc2475fcdd6e18b2dc10f6022d1cab498b9961e8225d8a309d18ed3c94b  spec/data/software/zlib.rb
+        expect(ipc.tag).to eql('zlib-1.7.2-363e6cc2475fcdd6e18b2dc10f6022d1cab498b9961e8225d8a309d18ed3c94b')
       end
     end
   end


### PR DESCRIPTION
Enhancements to git caching

Use -q when calling git commit so prevent git from displaying warning about email/username not set in config.

Leverage `git tag -l $ARG` for cache key lookup. This prevents listing all tags to the log on each cache lookup.

Include the software config definition source file in data used to generate the tag. This way the cache key is invalidated if you edit the build config of a software item.

I've tested a build locally with this both building fresh and 2nd run using cache and it worked -- with less output during build.
