### PR TITLE
Whitelist libgcc_s.so.1 on Solaris

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -66,6 +66,7 @@ module Omnibus
       /libcrypto.so/,
       /libcurses\.so/,
       /libdoor\.so/,
+      /libgcc_s\.so\.1/,
       /libgen\.so/,
       /libmd5\.so/,
       /libmd\.so/,


### PR DESCRIPTION
libgcc_s.so.1 seems to be part of compiler which is linked to some files on Solaris in old CI pipelines:

https://www.opencsw.org/packages/CSWlibgcc-s1/

Issue: 

```
[health_check] *** Health Check Failed, Summary follows:
[health_check] *** The following Omnibus-built libraries have unsafe or unmet dependencies:
[health_check]     --> /opt/chef/embedded/lib/libgdbm.so.4.0.0
[health_check]     --> /opt/chef/embedded/lib/libgdbm_compat.so.4.0.0
[health_check]     --> /opt/chef/embedded/lib/ruby/1.9.1/i386-solaris2.10/gdbm.so
[health_check] *** The following Omnibus-built binaries have unsafe or unmet dependencies:
[health_check]     --> /opt/chef/embedded/bin/testgdbm
[health_check] *** The following libraries cannot be guaranteed to be on target systems:
[health_check]     --> /opt/csw/lib/libgcc_s.so.1
[health_check] *** The precise failures were:
[health_check]     --> /opt/chef/embedded/lib/libgdbm.so.4.0.0
[health_check]     DEPENDS ON: libgcc_s.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /opt/csw/lib/libgcc_s.so.1
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef/embedded/lib/libgdbm_compat.so.4.0.0
[health_check]     DEPENDS ON: libgcc_s.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /opt/csw/lib/libgcc_s.so.1
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef/embedded/lib/ruby/1.9.1/i386-solaris2.10/gdbm.so
[health_check]     DEPENDS ON: libgcc_s.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /opt/csw/lib/libgcc_s.so.1
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chef/embedded/bin/testgdbm
[health_check]     DEPENDS ON: libgcc_s.so.1
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /opt/csw/lib/libgcc_s.so.1
[health_check]       FAILED BECAUSE: Unsafe dependency
Something went wrong...the Omnibus just ran off the road!
```
