### PR TITLE
Allow setting the software name from constructor

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -55,7 +55,7 @@ module Omnibus
 
     attr_reader :source_config
 
-    def self.load(filename, project, repo_overrides = {}, name=nil)
+    def self.load(filename, project, repo_overrides = {}, name = nil)
       new(IO.read(filename), filename, project, repo_overrides, name)
     end
 
@@ -72,7 +72,7 @@ module Omnibus
     #   project, and override hash directly?  That is, why io AND a
     #   filename, if the filename can always get you the contents you
     #   need anyway?
-    def initialize(io, filename, project, repo_overrides = {}, name=nil)
+    def initialize(io, filename, project, repo_overrides = {}, name = nil)
       @version          = nil
       @overrides        = UNINITIALIZED
       @name             = name


### PR DESCRIPTION
There are scenarios where it could be advantageous to allow for
setting the software name from code. An example of this would be when
you are able to distill the configurations of many similar software
configurations into one. In particular, I have a number of Python
projects which will always be built the same way, the only difference
being that the source, version and name might be different. Overriding
the source and version are already easily managed. Overriding the name
is not as it is often referenced elsewhere in the config file.

Therefore, in order to allow developers to keep their configs as DRY as
possible, this change allows one to optionally set the software name at
object construction.
