### PR TITLE
Detach all the disks with the project name before starting dmg packaging.

### DIFF
--- a/lib/omnibus/packagers/mac_dmg.rb
+++ b/lib/omnibus/packagers/mac_dmg.rb
@@ -59,6 +59,9 @@ module Omnibus
     # Cleans any previously left over mounted disks
     #
     def clean_disks
+      # We're trying to detach disks that look like below:
+      # /dev/disk1s1 on /Volumes/chef (hfs, local, nodev, nosuid, read-only, noowners, quarantine, mounted by serdar)
+      # /dev/disk2s1 on /Volumes/chef 1 (hfs, local, nodev, nosuid, read-only, noowners, quarantine, mounted by serdar)
       existing_disks = execute "mount | grep /Volumes/#{project.name} | awk '{print $1}'"
       existing_disks.stdout.lines.each do |existing_disk|
         existing_disk.chomp!


### PR DESCRIPTION
/cc: @opscode/client-eng, @opscode/release-engineers 

This resolves https://github.com/opscode/omnibus-ruby/issues/127.
