### PR TITLE
Add CoreServices to Mac whitelist for health check.

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -113,6 +113,7 @@ module Omnibus
       /libobjc\.A\.dylib/,
       /libSystem\.B\.dylib/,
       /CoreFoundation/,
+      /CoreServices/,
       /Tcl$/,
       /Cocoa$/,
       /Carbon$/,


### PR DESCRIPTION
Recent berkshelf updates caused a health check issue for chef-dk:

This is what we are fixing:

```
[health_check] Executing `find /opt/chefdk/ -type f | egrep '.(dylib|bundle)$' | xargs otool -L > otool.out 2>/dev/null`
[health_check] *** Health Check Failed, Summary follows:
[health_check] *** The following Omnibus-built libraries have unsafe or unmet dependencies:
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/extensions/x86_64-darwin-13/2.1.0/hitimes-1.2.1/hitimes/2.1/hitimes.bundle
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/gems/hitimes-1.2.1/ext/hitimes/c/hitimes.bundle
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/gems/hitimes-1.2.1/lib/hitimes/2.1/hitimes.bundle
[health_check] *** The following Omnibus-built binaries have unsafe or unmet dependencies:
[health_check] *** The following libraries cannot be guaranteed to be on target systems:
[health_check]     --> /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
[health_check] *** The precise failures were:
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/extensions/x86_64-darwin-13/2.1.0/hitimes-1.2.1/hitimes/2.1/hitimes.bundle
[health_check]     DEPENDS ON: CoreServices
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/gems/hitimes-1.2.1/ext/hitimes/c/hitimes.bundle
[health_check]     DEPENDS ON: CoreServices
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
[health_check]       FAILED BECAUSE: Unsafe dependency
[health_check]     --> /opt/chefdk//embedded/lib/ruby/gems/2.1.0/gems/hitimes-1.2.1/lib/hitimes/2.1/hitimes.bundle
[health_check]     DEPENDS ON: CoreServices
[health_check]       COUNT: 1
[health_check]       PROVIDED BY: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
[health_check]       FAILED BECAUSE: Unsafe dependency
Something went wrong...the Omnibus just ran off the road!
```

File looks pretty safe:

```
 ~$ pkgutil --file-info /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
volume: /
path: /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices

pkgid: com.apple.pkg.BaseSystemBinaries
pkg-version: 10.9.0.1.1.1306847324
install-time: 1385144063
uid: 0
gid: 0
mode: 755
```

/cc: @opscode/client-eng, @opscode/release-engineers 
