### PR TITLE
Move clean disks after dmg_stage directory creation so that the command can run correctly.

### DIFF
--- a/lib/omnibus/packagers/mac_dmg.rb
+++ b/lib/omnibus/packagers/mac_dmg.rb
@@ -25,9 +25,9 @@ module Omnibus
     end
 
     setup do
-      clean_disks
       create_directory(dmg_stage)
       remove_file(writable_dmg)
+      clean_disks
     end
 
     build do


### PR DESCRIPTION
`clean_disks` is executing a system command which automatically sets the `staging_dir`. This command fails on newly provisioned machines when `dmg_stage` directory is not created before the first build.
