### PR TITLE
Fix cache operations by checking if bucket exists

### DIFF
--- a/lib/omnibus/s3_cacher.rb
+++ b/lib/omnibus/s3_cacher.rb
@@ -122,11 +122,12 @@ module Omnibus
 
     def bucket
       @bucket ||= begin
-        b = UberS3::Bucket.new(@client, @client.bucket)
-        # creating the bucket is idempotent, make sure it's created:
-        @client.connection.put('/')
-        b
+        if !@client.exists?('/')
+          @client.connection.put('/')
+        end
+          @client.bucket
       end
     end
+
   end
 end


### PR DESCRIPTION
Bucket creation via uber-s3 may be broken. Running the previous existence check via attempt to create bucket code gives the following error:

```
Digest::Digest is deprecated; use Digest
UberS3::Error::SignatureDoesNotMatch: SignatureDoesNotMatch: The
request signature we calculated does not match the signature you
provided. Check your key and signing method.
```

With this patch, we safely determine if the bucket exists and only attempt creation if the bucket is missing. Further investigation is needed since bucket creation as coded here fails in the same way.
But at least that can be worked around by creating the bucket with an external tool.
