### PR TITLE
Stop the replaces insanity

### DIFF
--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -51,6 +51,27 @@ module Omnibus
     end
   end
 
+  class BadReplacesLine < RuntimeError
+    def to_s
+      """
+      The `replaces` project DSL statement should never equal the `package_name`
+      or `name` of a project.  The `replaces` option should only be used when
+      you have published an artifact under one name and then later renamed the
+      packages that you are publishing and you must obsolete the old package
+      name.  For example this is used, correctly, in chef-client builds:
+
+      name "chef"
+      replaces "chef-full"
+
+      The RPMs and debs which were originally published were named "chef-full" and
+      this was later renamed, and in order to upgrade the (very old) "chef-full"
+      packages the new "chef" packages needed to know to uninstall any "chef-full"
+      packages that were found.  Projects which have never been renamed, however, should
+      never use the replaces line.
+      """
+    end
+  end
+
   class NoPackageFile < RuntimeError
     def initialize(package_path)
       @package_path = package_path

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -143,6 +143,9 @@ module Omnibus
     # @return [void]
     def validate
       name && install_path && maintainer && homepage
+      if package_name == replaces
+        fail(BadReplacesLine.new)
+      end
     end
 
     # @!group DSL methods
@@ -270,11 +273,12 @@ module Omnibus
     # Ultimately used as the value for the `--replaces` flag in
     # {https://github.com/jordansissel/fpm fpm}.
     #
+    # This should only be used when renaming a package and obsoleting the old
+    # name of the package.  Setting this to the same name as package_name will
+    # cause RPM upgrades to fail.
+    #
     # @param val [String] the name of the package to replace
     # @return [String]
-    #
-    # @todo Consider having this default to {#package_name}; many uses of this
-    #   method effectively do this already.
     def replaces(val = NULL_ARG)
       @replaces = val unless val.equal?(NULL_ARG)
       @replaces


### PR DESCRIPTION
This DSL line was introduced only to deal with the renaming of the "chef-full" artifacts to "chef" back in the dark ages.  It has been copypasta'd around to other projects to the point where there
was a completely inaccurate @todo added to make replaces default to a broken configuration.  Very few projects should be using replaces and including a replaces line which is the same as the
package_name will break RPM upgrades.

Patch validates that replaces != package_name and yells at the user to knock if off if they're doing that.   Because ARRRRGGGHH.

Just delete the line.  Stop the copypasta errors.
