### PR TITLE
Fixes Github Issue #140

### DIFF
--- a/lib/omnibus/library.rb
+++ b/lib/omnibus/library.rb
@@ -38,7 +38,7 @@ module Omnibus
       @components.each do |component|
         if head.length == 0
           head << component
-        elsif @project.dependencies.include?(component.name)
+        elsif @project.dependencies.include?(component.name) && @components.none? { |c| c.dependencies.include?(component.name) }
           tail << component
         else
           head << component


### PR DESCRIPTION
This issue happens when a software is both a transitive
dependency at the software level, and a top level project
dependency. We were blindly shifting all the project deps
to the end of the build order as an optimization, and failed
to check for the case where we actually _needed_ that software
in the right place.

This patch ensures that, if the software is a dependency of
any other software description, it does not get shifted to the
end.
