### PR TITLE
Lock Rubocop down at `~> 0.17.0`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-ClassAndModuleChildren:
-  Enabled: false
 ClassLength:
   Enabled: false
 CyclomaticComplexity:

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'thor',            '>= 0.16.0'
 
   gem.add_development_dependency 'rspec',   '~> 2.14'
-  gem.add_development_dependency 'rubocop', '~> 0.18'
+  gem.add_development_dependency 'rubocop', '~> 0.17.0'
   gem.add_development_dependency 'rake'
 
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
As much as I like playing whack-a-mole with style errors, this has to stop. The cops are varying wildly from minor version to minor version. This makes accepting PRs from the community very hard. We are locking to `0.17.0` as this was the last version that wasn't total BS.

/cc @opscode/release-engineers @opscode/engineering-leads @opscode/client-eng 
