### PR TITLE
Issue #150 test case

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  Excludes:
+    - spec/data/**/*
 ClassLength:
   Enabled: false
 CyclomaticComplexity:

--- a/spec/data/complicated/config/patches/bzip2/makefile_take_env_vars.patch
+++ b/spec/data/complicated/config/patches/bzip2/makefile_take_env_vars.patch
@@ -1,0 +1,15 @@
+--- bzip2-1.0.6/Makefile-orig	2010-09-10 17:46:02.000000000 -0500
++++ bzip2-1.0.6/Makefile	2013-11-21 13:55:11.000000000 -0600
+@@ -18,10 +18,10 @@
+ CC=gcc
+ AR=ar
+ RANLIB=ranlib
+-LDFLAGS=
++LDFLAGS+=
+ 
+ BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++CFLAGS+=-Wall -Winline -O2 -g $(BIGFILES)
+ 
+ # Where you want it installed when you do 'make install'
+ PREFIX=/usr/local

--- a/spec/data/complicated/config/patches/couchdb/patch_for_couchjs_stack.patch
+++ b/spec/data/complicated/config/patches/couchdb/patch_for_couchjs_stack.patch
@@ -1,0 +1,20 @@
+diff -r -u apache-couchdb-1.0.3/src/couchdb/priv/couch_js/main.c apache-couchdb-1.0.3-couchjs-stack-patch/src/couchdb/priv/couch_js/main.c
+--- apache-couchdb-1.0.3/src/couchdb/priv/couch_js/main.c	2012-07-17 16:09:32.000000000 -0700
++++ apache-couchdb-1.0.3-couchjs-stack-patch/src/couchdb/priv/couch_js/main.c	2012-07-17 16:11:35.000000000 -0700
+@@ -57,6 +57,8 @@
+         return JS_FALSE;
+     }
+ 
++    JS_SetScriptStackQuota(subcx, 0x20000000);
++
+     SETUP_REQUEST(subcx);
+ 
+     src = JS_GetStringChars(str);
+@@ -286,6 +288,7 @@
+     cx = JS_NewContext(rt, 8L * 1024L);
+     if (!cx) return 1;
+ 
++    JS_SetScriptStackQuota(cx, 0x20000000);
+     JS_SetErrorReporter(cx, printerror);
+     JS_ToggleOptions(cx, JSOPTION_XML);
+     

--- a/spec/data/complicated/config/patches/gd/gd-2.0.33-configure-libpng.patch
+++ b/spec/data/complicated/config/patches/gd/gd-2.0.33-configure-libpng.patch
@@ -1,0 +1,100 @@
+diff -ur libgd-gd-libgd-5551f61978e3/src/configure libgd-gd-libgd-5551f61978e3.fixed/src/configure
+--- libgd-gd-libgd-5551f61978e3/src/configure	2006-04-05 08:56:57.000000000 -0700
++++ libgd-gd-libgd-5551f61978e3.fixed/src/configure	2012-04-06 16:38:27.000000000 -0700
+@@ -10953,95 +10953,8 @@
+ # authors decide to do this AGAIN. Which I really hope they won't. TBB
+ 
+ if test "$withval" != no; then
+-  # Extract the first word of "libpng12-config", so it can be a program name with args.
+-set dummy libpng12-config; ac_word=$2
+-echo "$as_me:$LINENO: checking for $ac_word" >&5
+-echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6
+-if test "${ac_cv_path_LIBPNG12_CONFIG+set}" = set; then
+-  echo $ECHO_N "(cached) $ECHO_C" >&6
+-else
+-  case $LIBPNG12_CONFIG in
+-  [\\/]* | ?:[\\/]*)
+-  ac_cv_path_LIBPNG12_CONFIG="$LIBPNG12_CONFIG" # Let the user override the test with a path.
+-  ;;
+-  *)
+-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-  for ac_exec_ext in '' $ac_executable_extensions; do
+-  if $as_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_LIBPNG12_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+-    echo "$as_me:$LINENO: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-done
+-
+-  ;;
+-esac
+-fi
+-LIBPNG12_CONFIG=$ac_cv_path_LIBPNG12_CONFIG
+-
+-if test -n "$LIBPNG12_CONFIG"; then
+-  echo "$as_me:$LINENO: result: $LIBPNG12_CONFIG" >&5
+-echo "${ECHO_T}$LIBPNG12_CONFIG" >&6
+-else
+-  echo "$as_me:$LINENO: result: no" >&5
+-echo "${ECHO_T}no" >&6
+-fi
+-
+-  # Extract the first word of "libpng-config", so it can be a program name with args.
+-set dummy libpng-config; ac_word=$2
+-echo "$as_me:$LINENO: checking for $ac_word" >&5
+-echo $ECHO_N "checking for $ac_word... $ECHO_C" >&6
+-if test "${ac_cv_path_LIBPNG_CONFIG+set}" = set; then
+-  echo $ECHO_N "(cached) $ECHO_C" >&6
+-else
+-  case $LIBPNG_CONFIG in
+-  [\\/]* | ?:[\\/]*)
+-  ac_cv_path_LIBPNG_CONFIG="$LIBPNG_CONFIG" # Let the user override the test with a path.
+-  ;;
+-  *)
+-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-  for ac_exec_ext in '' $ac_executable_extensions; do
+-  if $as_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_path_LIBPNG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+-    echo "$as_me:$LINENO: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-done
+-
+-  ;;
+-esac
+-fi
+-LIBPNG_CONFIG=$ac_cv_path_LIBPNG_CONFIG
+ 
+-if test -n "$LIBPNG_CONFIG"; then
+-  echo "$as_me:$LINENO: result: $LIBPNG_CONFIG" >&5
+-echo "${ECHO_T}$LIBPNG_CONFIG" >&6
+-else
+-  echo "$as_me:$LINENO: result: no" >&5
+-echo "${ECHO_T}no" >&6
+-fi
+-
+-  if test -n "$LIBPNG12_CONFIG"; then
+-    libpng_CPPFLAGS=`libpng12-config --cflags`
+-    # should be --ldopts, but it's currently broken
+-    libpng_LDFLAGS=`libpng12-config --ldflags`
+-    libpng_LDFLAGS=`echo " $libpng_LDFLAGS" | sed 's/ -l[^ ][^ ]*//g'`
+-  elif test -n "$LIBPNG_CONFIG"; then
+-    libpng_CPPFLAGS=`libpng-config --cflags`
+-    # should be --ldopts, but it's currently broken
+-    libpng_LDFLAGS=`libpng-config --ldflags`
+-    libpng_LDFLAGS=`echo " $libpng_LDFLAGS" | sed 's/ -l[^ ][^ ]*//g'`
+-  elif test -d "$withval"; then
++  if test -d "$withval"; then
+     libpng_CPPFLAGS="-I$withval/include"
+     libpng_LDFLAGS="-L$withval/lib"
+   fi

--- a/spec/data/complicated/config/patches/keepalived/keepalived-1.2.9_opscode_centos_5.patch
+++ b/spec/data/complicated/config/patches/keepalived/keepalived-1.2.9_opscode_centos_5.patch
@@ -1,0 +1,15 @@
+diff --git keepalived-1.2.9/vrrp/vrrp_ipaddress.c keepalived-1.2.9_centos5/vrrp/vrrp_ipaddress.c
+index 130014f..1900327 100644
+--- a/keepalived/vrrp/vrrp_ipaddress.c
++++ b/keepalived/vrrp/vrrp_ipaddress.c
+@@ -76,7 +76,9 @@ netlink_ipaddress(ip_address_t *ipaddress, int cmd)
+ 		 *     without service. HA/VRRP setups have their own "DAD"-like
+ 		 *     functionality, so it's not really needed from the IPv6 stack.
+ 		 */
+-		req.ifa.ifa_flags |= IFA_F_NODAD;
++		#ifdef IFA_F_NODAD
++			req.ifa.ifa_flags |= IFA_F_NODAD;
++		#endif
+ 
+ 		addattr_l(&req.n, sizeof(req), IFA_LOCAL,
+ 			  &ipaddress->u.sin6_addr, sizeof(ipaddress->u.sin6_addr));

--- a/spec/data/complicated/config/patches/libedit/freebsd-vi-fix.patch
+++ b/spec/data/complicated/config/patches/libedit/freebsd-vi-fix.patch
@@ -1,0 +1,24 @@
+diff -ruN libedit-20120601-3.0/src/vi.c libedit-20120601-3.0.fixed/src/vi.c
+--- libedit-20120601-3.0/src/vi.c	2012-03-11 09:54:58.000000000 +0000
++++ libedit-20120601-3.0.fixed/src/vi.c	2013-02-08 05:22:16.338954507 +0000
+@@ -918,17 +918,15 @@
+  * NB: posix implies that we should enter insert mode, however
+  * this is against historical precedent...
+  */
+-#ifdef __weak_reference
+-__weakref_visible char *my_get_alias_text(const char *)
+-    __weak_reference(get_alias_text);
+-#endif
+ protected el_action_t
+ /*ARGSUSED*/
+ vi_alias(EditLine *el, Int c __attribute__((__unused__)))
+ {
+-#ifdef __weak_reference
++#ifdef __weak_extern
+ 	char alias_name[3];
+ 	char *alias_text;
++	extern __weakref_visible char *my_get_alias_text(const char *);
++	__weak_extern(get_alias_text);
+ 
+ 	if (my_get_alias_text == 0) {
+ 		return CC_ERROR;

--- a/spec/data/complicated/config/patches/libiconv/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
+++ b/spec/data/complicated/config/patches/libiconv/libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch
@@ -1,0 +1,30 @@
+diff -r -u libiconv-1.14/srclib/stdio.in.h.orig libiconv-1.14/srclib/stdio.in.h
+--- libiconv-1.14/srclib/stdio.in.h.orig	2013-02-22 13:52:46.336327969 -0600
++++ libiconv-1.14/srclib/stdio.in.h	2013-02-22 13:54:27.948207059 -0600
+@@ -679,22 +679,11 @@
+ # endif
+ #endif
+ 
+-#if @GNULIB_GETS@
+-# if @REPLACE_STDIO_READ_FUNCS@ && @GNULIB_STDIO_H_NONBLOCKING@
+-#  if !(defined __cplusplus && defined GNULIB_NAMESPACE)
+-#   undef gets
+-#   define gets rpl_gets
+-#  endif
+-_GL_FUNCDECL_RPL (gets, char *, (char *s) _GL_ARG_NONNULL ((1)));
+-_GL_CXXALIAS_RPL (gets, char *, (char *s));
+-# else
+-_GL_CXXALIAS_SYS (gets, char *, (char *s));
+-#  undef gets
+-# endif
+-_GL_CXXALIASWARN (gets);
+ /* It is very rare that the developer ever has full control of stdin,
+-   so any use of gets warrants an unconditional warning.  Assume it is
+-   always declared, since it is required by C89.  */
++   so any use of gets warrants an unconditional warning; besides, C11
++   removed it.  */
++#undef gets
++#if HAVE_RAW_DECL_GETS
+ _GL_WARN_ON_USE (gets, "gets is a security hole - use fgets instead");
+ #endif
+ 

--- a/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-makefile-dest-fix.patch
+++ b/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-makefile-dest-fix.patch
@@ -1,0 +1,35 @@
+diff -ur tcp_wrappers_7.6/Makefile tcp_wrappers_7.6.fixed/Makefile
+--- tcp_wrappers_7.6/Makefile	2012-04-10 11:45:38.000000000 -0700
++++ tcp_wrappers_7.6.fixed/Makefile	2012-04-10 14:11:58.000000000 -0700
+@@ -768,9 +768,9 @@
+ install: install-lib install-bin install-dev
+ 
+ install-lib:
+-	install -o root -g root -m 0755 $(SHLIB) ${DESTDIR}/usr/lib/
+-	ln -sf $(notdir $(SHLIB)) ${DESTDIR}/usr/lib/$(notdir $(SHLIBSOMAJ))
+-	ln -sf $(notdir $(SHLIBSOMAJ)) ${DESTDIR}/usr/lib/$(notdir $(SHLIBSO))
++	install -m 0755 $(SHLIB) ${DESTDIR}/lib/
++	ln -sf $(notdir $(SHLIB)) ${DESTDIR}/lib/$(notdir $(SHLIBSOMAJ))
++	ln -sf $(notdir $(SHLIBSOMAJ)) ${DESTDIR}/lib/$(notdir $(SHLIBSO))
+ 
+ install-bin:
+ 	install -o root -g root -m 0755 tcpd ${DESTDIR}/usr/sbin/
+@@ -787,12 +787,12 @@
+ 	install -o root -g root -m 0644 hosts_options.5 ${DESTDIR}/usr/share/man/man5/
+ 
+ install-dev:
+-	install -o root -g root -m 0644 hosts_access.3 ${DESTDIR}/usr/share/man/man3/
+-	install -o root -g root -m 0644 tcpd.h ${DESTDIR}/usr/include/
+-	install -o root -g root -m 0644 $(LIB) ${DESTDIR}/usr/lib/
+-	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/hosts_ctl.3
+-	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/request_init.3
+-	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/request_set.3
++	install -m 0644 hosts_access.3 ${DESTDIR}/share/man/man3/
++	install -m 0644 tcpd.h ${DESTDIR}/include/
++	install -m 0644 $(LIB) ${DESTDIR}/lib/
++	ln -sf hosts_access.3 ${DESTDIR}/share/man/man3/hosts_ctl.3
++	ln -sf hosts_access.3 ${DESTDIR}/share/man/man3/request_init.3
++	ln -sf hosts_access.3 ${DESTDIR}/share/man/man3/request_set.3
+ 
+ shar:	$(KIT)
+ 	@shar $(KIT)

--- a/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-malloc-fix.patch
+++ b/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-malloc-fix.patch
@@ -1,0 +1,13 @@
+diff -ur tcp_wrappers_7.6/scaffold.c tcp_wrappers_7.6.fixed/scaffold.c
+--- tcp_wrappers_7.6/scaffold.c	2012-04-10 11:45:38.000000000 -0700
++++ tcp_wrappers_7.6.fixed/scaffold.c	2012-04-10 12:48:14.000000000 -0700
+@@ -25,7 +25,7 @@
+ #define	INADDR_NONE	(-1)		/* XXX should be 0xffffffff */
+ #endif
+ 
+-extern char *malloc();
++/* extern char *malloc(); */
+ 
+ /* Application-specific. */
+ 
+Only in tcp_wrappers_7.6.fixed: scaffold.c-e

--- a/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-shared_lib_plus_plus-1.patch
+++ b/spec/data/complicated/config/patches/libwrap/tcp_wrappers-7.6-shared_lib_plus_plus-1.patch
@@ -1,0 +1,1035 @@
+Submitted By: Tushar Teredesai <tushar@linuxfromscratch.org>
+Date: 2003-10-04
+Initial Package Version: 7.6
+Origin: http://archives.linuxfromscratch.org/mail-archives/blfs-dev/2003-January/001960.html
+Description: The patch was created from the tcp_wrappers modified package by Mark Heerdink.
+This patch provides the following improvements:
+    * Install libwrap.so along with libwrap.a.
+    * Create an install target for tcp_wrappers.
+    * Compilation and security fixes.
+    * Documentation fixes.
+diff -Naur tcp_wrappers_7.6/Makefile tcp_wrappers_7.6.gimli/Makefile
+--- tcp_wrappers_7.6/Makefile	1997-03-21 12:27:21.000000000 -0600
++++ tcp_wrappers_7.6.gimli/Makefile	2002-07-15 16:07:21.000000000 -0500
+@@ -1,5 +1,10 @@
++GLIBC=$(shell grep -s -c __GLIBC__ /usr/include/features.h)
++
+ # @(#) Makefile 1.23 97/03/21 19:27:20
+ 
++# unset the HOSTNAME environment variable
++HOSTNAME =
++
+ what:
+ 	@echo
+ 	@echo "Usage: edit the REAL_DAEMON_DIR definition in the Makefile then:"
+@@ -19,7 +24,7 @@
+ 	@echo "	generic (most bsd-ish systems with sys5 compatibility)"
+ 	@echo "	386bsd aix alpha apollo bsdos convex-ultranet dell-gcc dgux dgux543"
+ 	@echo "	dynix epix esix freebsd hpux irix4 irix5 irix6 isc iunix"
+-	@echo "	linux machten mips(untested) ncrsvr4 netbsd next osf power_unix_211"
++	@echo "	linux gnu machten mips(untested) ncrsvr4 netbsd next osf power_unix_211"
+ 	@echo "	ptx-2.x ptx-generic pyramid sco sco-nis sco-od2 sco-os5 sinix sunos4"
+ 	@echo "	sunos40 sunos5 sysv4 tandem ultrix unicos7 unicos8 unixware1 unixware2"
+ 	@echo "	uts215 uxp"
+@@ -43,8 +48,8 @@
+ # Ultrix 4.x SunOS 4.x ConvexOS 10.x Dynix/ptx
+ #REAL_DAEMON_DIR=/usr/etc
+ #
+-# SysV.4 Solaris 2.x OSF AIX
+-#REAL_DAEMON_DIR=/usr/sbin
++# SysV.4 Solaris 2.x OSF AIX Linux
++REAL_DAEMON_DIR=/usr/sbin
+ #
+ # BSD 4.4
+ #REAL_DAEMON_DIR=/usr/libexec
+@@ -141,10 +146,21 @@
+ 	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ= NETGROUP= TLI= \
+ 	EXTRA_CFLAGS=-DSYS_ERRLIST_DEFINED VSYSLOG= all
+ 
++ifneq ($(GLIBC),0)
++MYLIB=-lnsl
++endif
++
+ linux:
+ 	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
+-	LIBS= RANLIB=ranlib ARFLAGS=rv AUX_OBJ=setenv.o \
+-	NETGROUP= TLI= EXTRA_CFLAGS="-DBROKEN_SO_LINGER" all
++	LIBS=$(MYLIB) RANLIB=ranlib ARFLAGS=rv AUX_OBJ=weak_symbols.o \
++	NETGROUP=-DNETGROUP TLI= VSYSLOG= BUGS= all \
++	EXTRA_CFLAGS="-DSYS_ERRLIST_DEFINED -DHAVE_WEAKSYMS -D_REENTRANT"
++
++gnu:
++	@make REAL_DAEMON_DIR=$(REAL_DAEMON_DIR) STYLE=$(STYLE) \
++	LIBS=$(MYLIB) RANLIB=ranlib ARFLAGS=rv AUX_OBJ=weak_symbols.o \
++	NETGROUP=-DNETGROUP TLI= VSYSLOG= BUGS= all \
++	EXTRA_CFLAGS="-DHAVE_STRERROR -DHAVE_WEAKSYMS -D_REENTRANT"
+ 
+ # This is good for many SYSV+BSD hybrids with NIS, probably also for HP-UX 7.x.
+ hpux hpux8 hpux9 hpux10:
+@@ -391,7 +407,7 @@
+ # the ones provided with this source distribution. The environ.c module
+ # implements setenv(), getenv(), and putenv().
+ 
+-AUX_OBJ= setenv.o
++#AUX_OBJ= setenv.o
+ #AUX_OBJ= environ.o
+ #AUX_OBJ= environ.o strcasecmp.o
+ 
+@@ -454,7 +470,8 @@
+ # host name aliases. Compile with -DSOLARIS_24_GETHOSTBYNAME_BUG to work
+ # around this. The workaround does no harm on other Solaris versions.
+ 
+-BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DLIBC_CALLS_STRTOK
++BUGS =
++#BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DLIBC_CALLS_STRTOK
+ #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DINET_ADDR_BUG
+ #BUGS = -DGETPEERNAME_BUG -DBROKEN_FGETS -DSOLARIS_24_GETHOSTBYNAME_BUG
+ 
+@@ -464,7 +481,7 @@
+ # If your system supports NIS or YP-style netgroups, enable the following
+ # macro definition. Netgroups are used only for host access control.
+ #
+-#NETGROUP= -DNETGROUP
++NETGROUP= -DNETGROUP
+ 
+ ###############################################################
+ # System dependencies: whether or not your system has vsyslog()
+@@ -491,7 +508,7 @@
+ # Uncomment the next definition to turn on the language extensions
+ # (examples: allow, deny, banners, twist and spawn).
+ # 
+-#STYLE	= -DPROCESS_OPTIONS	# Enable language extensions.
++STYLE	= -DPROCESS_OPTIONS	# Enable language extensions.
+ 
+ ################################################################
+ # Optional: Changing the default disposition of logfile records
+@@ -514,7 +531,7 @@
+ #
+ # The LOG_XXX names below are taken from the /usr/include/syslog.h file.
+ 
+-FACILITY= LOG_MAIL	# LOG_MAIL is what most sendmail daemons use
++FACILITY= LOG_DAEMON	# LOG_MAIL is what most sendmail daemons use
+ 
+ # The syslog priority at which successful connections are logged.
+ 
+@@ -610,7 +627,7 @@
+ # Paranoid mode implies hostname lookup. In order to disable hostname
+ # lookups altogether, see the next section.
+ 
+-PARANOID= -DPARANOID
++#PARANOID= -DPARANOID
+ 
+ ########################################
+ # Optional: turning off hostname lookups
+@@ -623,7 +640,7 @@
+ # In order to perform selective hostname lookups, disable paranoid
+ # mode (see previous section) and comment out the following definition.
+ 
+-HOSTNAME= -DALWAYS_HOSTNAME
++#HOSTNAME= -DALWAYS_HOSTNAME
+ 
+ #############################################
+ # Optional: Turning on host ADDRESS checking
+@@ -649,28 +666,46 @@
+ # source-routed traffic in the kernel. Examples: 4.4BSD derivatives,
+ # Solaris 2.x, and Linux. See your system documentation for details.
+ #
+-# KILL_OPT= -DKILL_IP_OPTIONS
++KILL_OPT= -DKILL_IP_OPTIONS
+ 
+ ## End configuration options
+ ############################
+ 
+ # Protection against weird shells or weird make programs.
+ 
++CC	= gcc
+ SHELL	= /bin/sh
+-.c.o:;	$(CC) $(CFLAGS) -c $*.c
++.c.o:;	$(CC) $(CFLAGS) -o $*.o -c $*.c
++
++SOMAJOR = 0
++SOMINOR = 7.6
++
++LIB	= libwrap.a
++SHLIB	= shared/libwrap.so.$(SOMAJOR).$(SOMINOR)
++SHLIBSOMAJ= shared/libwrap.so.$(SOMAJOR)
++SHLIBSO	= shared/libwrap.so
++SHLIBFLAGS = -Lshared -lwrap
+ 
+-CFLAGS	= -O -DFACILITY=$(FACILITY) $(ACCESS) $(PARANOID) $(NETGROUP) \
++shared/%.o: %.c
++	$(CC) $(CFLAGS) $(SHCFLAGS) -c $< -o $@
++
++CFLAGS	= -O2 -DFACILITY=$(FACILITY) $(ACCESS) $(PARANOID) $(NETGROUP) \
+ 	$(BUGS) $(SYSTYPE) $(AUTH) $(UMASK) \
+ 	-DREAL_DAEMON_DIR=\"$(REAL_DAEMON_DIR)\" $(STYLE) $(KILL_OPT) \
+ 	-DSEVERITY=$(SEVERITY) -DRFC931_TIMEOUT=$(RFC931_TIMEOUT) \
+ 	$(UCHAR) $(TABLES) $(STRINGS) $(TLI) $(EXTRA_CFLAGS) $(DOT) \
+ 	$(VSYSLOG) $(HOSTNAME)
+ 
++SHLINKFLAGS = -shared -Xlinker -soname -Xlinker libwrap.so.$(SOMAJOR) -lc $(LIBS)
++SHCFLAGS = -fPIC -shared -D_REENTRANT
++
+ LIB_OBJ= hosts_access.o options.o shell_cmd.o rfc931.o eval.o \
+ 	hosts_ctl.o refuse.o percent_x.o clean_exit.o $(AUX_OBJ) \
+ 	$(FROM_OBJ) fix_options.o socket.o tli.o workarounds.o \
+ 	update.o misc.o diag.o percent_m.o myvsyslog.o
+ 
++SHLIB_OBJ= $(addprefix shared/, $(LIB_OBJ));
++
+ FROM_OBJ= fromhost.o
+ 
+ KIT	= README miscd.c tcpd.c fromhost.c hosts_access.c shell_cmd.c \
+@@ -684,46 +719,80 @@
+ 	refuse.c tcpdchk.8 setenv.c inetcf.c inetcf.h scaffold.c \
+ 	scaffold.h tcpdmatch.8 README.NIS
+ 
+-LIB	= libwrap.a
+-
+-all other: config-check tcpd tcpdmatch try-from safe_finger tcpdchk
++all other: config-check tcpd tcpdmatch try-from safe_finger tcpdchk $(LIB)
+ 
+ # Invalidate all object files when the compiler options (CFLAGS) have changed.
+ 
+ config-check:
+ 	@set +e; test -n "$(REAL_DAEMON_DIR)" || { make; exit 1; }
+-	@set +e; echo $(CFLAGS) >/tmp/cflags.$$$$ ; \
+-	if cmp cflags /tmp/cflags.$$$$ ; \
+-	then rm /tmp/cflags.$$$$ ; \
+-	else mv /tmp/cflags.$$$$ cflags ; \
++	@set +e; echo $(CFLAGS) >cflags.new ; \
++	if cmp cflags cflags.new ; \
++	then rm cflags.new ; \
++	else mv cflags.new cflags ; \
+ 	fi >/dev/null 2>/dev/null
++	@if [ ! -d shared ]; then mkdir shared; fi
+ 
+ $(LIB):	$(LIB_OBJ)
+ 	rm -f $(LIB)
+ 	$(AR) $(ARFLAGS) $(LIB) $(LIB_OBJ)
+ 	-$(RANLIB) $(LIB)
+ 
+-tcpd:	tcpd.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ tcpd.o $(LIB) $(LIBS)
++$(SHLIB): $(SHLIB_OBJ)
++	rm -f $(SHLIB)
++	$(CC) -o $(SHLIB) $(SHLINKFLAGS) $(SHLIB_OBJ)
++	ln -s $(notdir $(SHLIB)) $(SHLIBSOMAJ)
++	ln -s $(notdir $(SHLIBSOMAJ)) $(SHLIBSO)
++
++tcpd:	tcpd.o $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ tcpd.o $(SHLIBFLAGS)
+ 
+-miscd:	miscd.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ miscd.o $(LIB) $(LIBS)
++miscd:	miscd.o $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ miscd.o $(SHLIBFLAGS)
+ 
+-safe_finger: safe_finger.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ safe_finger.o $(LIB) $(LIBS)
++safe_finger: safe_finger.o $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ safe_finger.o $(SHLIBFLAGS)
+ 
+ TCPDMATCH_OBJ = tcpdmatch.o fakelog.o inetcf.o scaffold.o
+ 
+-tcpdmatch: $(TCPDMATCH_OBJ) $(LIB)
+-	$(CC) $(CFLAGS) -o $@ $(TCPDMATCH_OBJ) $(LIB) $(LIBS)
++tcpdmatch: $(TCPDMATCH_OBJ) $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ $(TCPDMATCH_OBJ) $(SHLIBFLAGS)
+ 
+-try-from: try-from.o fakelog.o $(LIB)
+-	$(CC) $(CFLAGS) -o $@ try-from.o fakelog.o $(LIB) $(LIBS)
++try-from: try-from.o fakelog.o $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ try-from.o fakelog.o $(SHLIBFLAGS)
+ 
+ TCPDCHK_OBJ = tcpdchk.o fakelog.o inetcf.o scaffold.o
+ 
+-tcpdchk: $(TCPDCHK_OBJ) $(LIB)
+-	$(CC) $(CFLAGS) -o $@ $(TCPDCHK_OBJ) $(LIB) $(LIBS)
++tcpdchk: $(TCPDCHK_OBJ) $(SHLIB)
++	$(CC) $(CFLAGS) -o $@ $(TCPDCHK_OBJ) $(SHLIBFLAGS)
++
++install: install-lib install-bin install-dev
++
++install-lib:
++	install -o root -g root -m 0755 $(SHLIB) ${DESTDIR}/usr/lib/
++	ln -sf $(notdir $(SHLIB)) ${DESTDIR}/usr/lib/$(notdir $(SHLIBSOMAJ))
++	ln -sf $(notdir $(SHLIBSOMAJ)) ${DESTDIR}/usr/lib/$(notdir $(SHLIBSO))
++
++install-bin:
++	install -o root -g root -m 0755 tcpd ${DESTDIR}/usr/sbin/
++	install -o root -g root -m 0755 tcpdchk ${DESTDIR}/usr/sbin/
++	install -o root -g root -m 0755 tcpdmatch ${DESTDIR}/usr/sbin/
++	install -o root -g root -m 0755 try-from ${DESTDIR}/usr/sbin/
++	install -o root -g root -m 0755 safe_finger ${DESTDIR}/usr/sbin/
++	install -o root -g root -m 0644 tcpd.8 ${DESTDIR}/usr/share/man/man8/
++	install -o root -g root -m 0644 tcpdchk.8 ${DESTDIR}/usr/share/man/man8/
++	install -o root -g root -m 0644 try-from.8 ${DESTDIR}/usr/share/man/man8/
++	install -o root -g root -m 0644 tcpdmatch.8 ${DESTDIR}/usr/share/man/man8/
++	install -o root -g root -m 0644 safe_finger.8 ${DESTDIR}/usr/share/man/man8/
++	install -o root -g root -m 0644 hosts_access.5 ${DESTDIR}/usr/share/man/man5/
++	install -o root -g root -m 0644 hosts_options.5 ${DESTDIR}/usr/share/man/man5/
++
++install-dev:
++	install -o root -g root -m 0644 hosts_access.3 ${DESTDIR}/usr/share/man/man3/
++	install -o root -g root -m 0644 tcpd.h ${DESTDIR}/usr/include/
++	install -o root -g root -m 0644 $(LIB) ${DESTDIR}/usr/lib/
++	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/hosts_ctl.3
++	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/request_init.3
++	ln -sf hosts_access.3 ${DESTDIR}/usr/share/man/man3/request_set.3
+ 
+ shar:	$(KIT)
+ 	@shar $(KIT)
+@@ -739,7 +808,8 @@
+ 
+ clean:
+ 	rm -f tcpd miscd safe_finger tcpdmatch tcpdchk try-from *.[oa] core \
+-	cflags
++	cflags libwrap*.so*
++	rm -rf shared
+ 
+ tidy:	clean
+ 	chmod -R a+r .
+@@ -885,5 +955,6 @@
+ update.o: mystdarg.h
+ update.o: tcpd.h
+ vfprintf.o: cflags
++weak_symbols.o: tcpd.h
+ workarounds.o: cflags
+ workarounds.o: tcpd.h
+diff -Naur tcp_wrappers_7.6/fix_options.c tcp_wrappers_7.6.gimli/fix_options.c
+--- tcp_wrappers_7.6/fix_options.c	1997-04-07 19:29:19.000000000 -0500
++++ tcp_wrappers_7.6.gimli/fix_options.c	2002-01-07 08:50:19.000000000 -0600
+@@ -35,7 +35,12 @@
+ #ifdef IP_OPTIONS
+     unsigned char optbuf[BUFFER_SIZE / 3], *cp;
+     char    lbuf[BUFFER_SIZE], *lp;
++#if !defined(__GLIBC__)
+     int     optsize = sizeof(optbuf), ipproto;
++#else /* __GLIBC__ */
++    size_t  optsize = sizeof(optbuf);
++    int     ipproto;
++#endif /* __GLIBC__ */
+     struct protoent *ip;
+     int     fd = request->fd;
+     unsigned int opt;
+diff -Naur tcp_wrappers_7.6/hosts_access.3 tcp_wrappers_7.6.gimli/hosts_access.3
+--- tcp_wrappers_7.6/hosts_access.3	1996-02-11 10:01:27.000000000 -0600
++++ tcp_wrappers_7.6.gimli/hosts_access.3	2002-01-07 08:50:19.000000000 -0600
+@@ -3,7 +3,7 @@
+ hosts_access, hosts_ctl, request_init, request_set \- access control library
+ .SH SYNOPSIS
+ .nf
+-#include "tcpd.h"
++#include <tcpd.h>
+ 
+ extern int allow_severity;
+ extern int deny_severity;
+diff -Naur tcp_wrappers_7.6/hosts_access.5 tcp_wrappers_7.6.gimli/hosts_access.5
+--- tcp_wrappers_7.6/hosts_access.5	1995-01-30 12:51:47.000000000 -0600
++++ tcp_wrappers_7.6.gimli/hosts_access.5	2002-01-07 08:50:19.000000000 -0600
+@@ -8,9 +8,9 @@
+ impatient reader is encouraged to skip to the EXAMPLES section for a
+ quick introduction.
+ .PP
+-An extended version of the access control language is described in the
+-\fIhosts_options\fR(5) document. The extensions are turned on at
+-program build time by building with -DPROCESS_OPTIONS.
++The extended version of the access control language is described in the
++\fIhosts_options\fR(5) document. \fBNote that this language supersedes
++the meaning of \fIshell_command\fB as documented below.\fR
+ .PP
+ In the following text, \fIdaemon\fR is the the process name of a
+ network daemon process, and \fIclient\fR is the name and/or address of
+@@ -40,7 +40,7 @@
+ character. This permits you to break up long lines so that they are
+ easier to edit.
+ .IP \(bu
+-Blank lines or lines that begin with a `#\' character are ignored.
++Blank lines or lines that begin with a `#' character are ignored.
+ This permits you to insert comments and whitespace so that the tables
+ are easier to read.
+ .IP \(bu
+@@ -69,26 +69,33 @@
+ .SH PATTERNS
+ The access control language implements the following patterns:
+ .IP \(bu
+-A string that begins with a `.\' character. A host name is matched if
++A string that begins with a `.' character. A host name is matched if
+ the last components of its name match the specified pattern.  For
+-example, the pattern `.tue.nl\' matches the host name
+-`wzv.win.tue.nl\'.
++example, the pattern `.tue.nl' matches the host name
++`wzv.win.tue.nl'.
+ .IP \(bu
+-A string that ends with a `.\' character. A host address is matched if
++A string that ends with a `.' character. A host address is matched if
+ its first numeric fields match the given string.  For example, the
+-pattern `131.155.\' matches the address of (almost) every host on the
++pattern `131.155.' matches the address of (almost) every host on the
+ Eind\%hoven University network (131.155.x.x).
+ .IP \(bu
+-A string that begins with an `@\' character is treated as an NIS
++A string that begins with an `@' character is treated as an NIS
+ (formerly YP) netgroup name. A host name is matched if it is a host
+ member of the specified netgroup. Netgroup matches are not supported
+ for daemon process names or for client user names.
+ .IP \(bu
+-An expression of the form `n.n.n.n/m.m.m.m\' is interpreted as a
+-`net/mask\' pair. A host address is matched if `net\' is equal to the
+-bitwise AND of the address and the `mask\'. For example, the net/mask
+-pattern `131.155.72.0/255.255.254.0\' matches every address in the
+-range `131.155.72.0\' through `131.155.73.255\'.
++An expression of the form `n.n.n.n/m.m.m.m' is interpreted as a
++`net/mask' pair. A host address is matched if `net' is equal to the
++bitwise AND of the address and the `mask'. For example, the net/mask
++pattern `131.155.72.0/255.255.254.0' matches every address in the
++range `131.155.72.0' through `131.155.73.255'.
++.IP \(bu
++A string that begins with a `/' character is treated as a file
++name. A host name or address is matched if it matches any host name
++or address pattern listed in the named file. The file format is
++zero or more lines with zero or more host name or address patterns
++separated by whitespace.  A file name pattern can be used anywhere
++a host name or address pattern can be used.
+ .SH WILDCARDS
+ The access control language supports explicit wildcards:
+ .IP ALL
+@@ -115,19 +122,19 @@
+ .ne 6
+ .SH OPERATORS
+ .IP EXCEPT
+-Intended use is of the form: `list_1 EXCEPT list_2\'; this construct
++Intended use is of the form: `list_1 EXCEPT list_2'; this construct
+ matches anything that matches \fIlist_1\fR unless it matches
+ \fIlist_2\fR.  The EXCEPT operator can be used in daemon_lists and in
+ client_lists. The EXCEPT operator can be nested: if the control
+-language would permit the use of parentheses, `a EXCEPT b EXCEPT c\'
+-would parse as `(a EXCEPT (b EXCEPT c))\'.
++language would permit the use of parentheses, `a EXCEPT b EXCEPT c'
++would parse as `(a EXCEPT (b EXCEPT c))'.
+ .br
+ .ne 6
+ .SH SHELL COMMANDS
+ If the first-matched access control rule contains a shell command, that
+ command is subjected to %<letter> substitutions (see next section).
+ The result is executed by a \fI/bin/sh\fR child process with standard
+-input, output and error connected to \fI/dev/null\fR.  Specify an `&\'
++input, output and error connected to \fI/dev/null\fR.  Specify an `&'
+ at the end of the command if you do not want to wait until it has
+ completed.
+ .PP
+@@ -159,7 +166,7 @@
+ .IP %u
+ The client user name (or "unknown").
+ .IP %%
+-Expands to a single `%\' character.
++Expands to a single `%' character.
+ .PP
+ Characters in % expansions that may confuse the shell are replaced by
+ underscores.
+@@ -243,9 +250,9 @@
+ less trustworthy. It is possible for an intruder to spoof both the
+ client connection and the IDENT lookup, although doing so is much
+ harder than spoofing just a client connection. It may also be that
+-the client\'s IDENT server is lying.
++the client's IDENT server is lying.
+ .PP
+-Note: IDENT lookups don\'t work with UDP services. 
++Note: IDENT lookups don't work with UDP services. 
+ .SH EXAMPLES
+ The language is flexible enough that different types of access control
+ policy can be expressed with a minimum of fuss. Although the language
+@@ -285,7 +292,7 @@
+ .br
+ ALL: .foobar.edu EXCEPT terminalserver.foobar.edu
+ .PP
+-The first rule permits access from hosts in the local domain (no `.\'
++The first rule permits access from hosts in the local domain (no `.'
+ in the host name) and from members of the \fIsome_netgroup\fP
+ netgroup.  The second rule permits access from all hosts in the
+ \fIfoobar.edu\fP domain (notice the leading dot), with the exception of
+@@ -322,8 +329,8 @@
+ /etc/hosts.deny:
+ .in +3
+ .nf
+-in.tftpd: ALL: (/some/where/safe_finger -l @%h | \\
+-	/usr/ucb/mail -s %d-%h root) &
++in.tftpd: ALL: (/usr/sbin/safe_finger -l @%h | \\
++	/usr/bin/mail -s %d-%h root) &
+ .fi
+ .PP
+ The safe_finger command comes with the tcpd wrapper and should be
+@@ -349,7 +356,7 @@
+ capacity of an internal buffer; when an access control rule is not
+ terminated by a newline character; when the result of %<letter>
+ expansion would overflow an internal buffer; when a system call fails
+-that shouldn\'t.  All problems are reported via the syslog daemon.
++that shouldn't.  All problems are reported via the syslog daemon.
+ .SH FILES
+ .na
+ .nf
+diff -Naur tcp_wrappers_7.6/hosts_access.c tcp_wrappers_7.6.gimli/hosts_access.c
+--- tcp_wrappers_7.6/hosts_access.c	1997-02-11 19:13:23.000000000 -0600
++++ tcp_wrappers_7.6.gimli/hosts_access.c	2002-01-07 08:50:19.000000000 -0600
+@@ -240,6 +240,26 @@
+     }
+ }
+ 
++/* hostfile_match - look up host patterns from file */
++
++static int hostfile_match(path, host)
++char   *path;
++struct hosts_info *host;
++{
++    char    tok[BUFSIZ];
++    int     match = NO;
++    FILE   *fp;
++
++    if ((fp = fopen(path, "r")) != 0) {
++        while (fscanf(fp, "%s", tok) == 1 && !(match = host_match(tok, host)))
++            /* void */ ;
++        fclose(fp);
++    } else if (errno != ENOENT) {
++        tcpd_warn("open %s: %m", path);
++    }
++    return (match);
++}
++
+ /* host_match - match host name and/or address against pattern */
+ 
+ static int host_match(tok, host)
+@@ -267,6 +287,8 @@
+ 	tcpd_warn("netgroup support is disabled");	/* not tcpd_jump() */
+ 	return (NO);
+ #endif
++    } else if (tok[0] == '/') {                         /* /file hack */
++        return (hostfile_match(tok, host));
+     } else if (STR_EQ(tok, "KNOWN")) {		/* check address and name */
+ 	char   *name = eval_hostname(host);
+ 	return (STR_NE(eval_hostaddr(host), unknown) && HOSTNAME_KNOWN(name));
+diff -Naur tcp_wrappers_7.6/hosts_options.5 tcp_wrappers_7.6.gimli/hosts_options.5
+--- tcp_wrappers_7.6/hosts_options.5	1994-12-28 10:42:29.000000000 -0600
++++ tcp_wrappers_7.6.gimli/hosts_options.5	2002-01-07 08:50:19.000000000 -0600
+@@ -58,12 +58,12 @@
+ Execute, in a child process, the specified shell command, after
+ performing the %<letter> expansions described in the hosts_access(5)
+ manual page.  The command is executed with stdin, stdout and stderr
+-connected to the null device, so that it won\'t mess up the
++connected to the null device, so that it won't mess up the
+ conversation with the client host. Example:
+ .sp
+ .nf
+ .ti +3
+-spawn (/some/where/safe_finger -l @%h | /usr/ucb/mail root) &
++spawn (/usr/sbin/safe_finger -l @%h | /usr/bin/mail root) &
+ .fi
+ .sp
+ executes, in a background child process, the shell command "safe_finger
+diff -Naur tcp_wrappers_7.6/options.c tcp_wrappers_7.6.gimli/options.c
+--- tcp_wrappers_7.6/options.c	1996-02-11 10:01:32.000000000 -0600
++++ tcp_wrappers_7.6.gimli/options.c	2002-01-07 08:50:19.000000000 -0600
+@@ -473,6 +473,9 @@
+ #ifdef LOG_CRON
+     "cron", LOG_CRON,
+ #endif
++#ifdef LOG_FTP
++    "ftp", LOG_FTP,
++#endif
+ #ifdef LOG_LOCAL0
+     "local0", LOG_LOCAL0,
+ #endif
+diff -Naur tcp_wrappers_7.6/percent_m.c tcp_wrappers_7.6.gimli/percent_m.c
+--- tcp_wrappers_7.6/percent_m.c	1994-12-28 10:42:37.000000000 -0600
++++ tcp_wrappers_7.6.gimli/percent_m.c	2002-01-07 08:50:19.000000000 -0600
+@@ -13,7 +13,7 @@
+ #include <string.h>
+ 
+ extern int errno;
+-#ifndef SYS_ERRLIST_DEFINED
++#if !defined(SYS_ERRLIST_DEFINED) && !defined(HAVE_STRERROR)
+ extern char *sys_errlist[];
+ extern int sys_nerr;
+ #endif
+@@ -29,11 +29,15 @@
+ 
+     while (*bp = *cp)
+ 	if (*cp == '%' && cp[1] == 'm') {
++#ifdef HAVE_STRERROR
++            strcpy(bp, strerror(errno));
++#else
+ 	    if (errno < sys_nerr && errno > 0) {
+ 		strcpy(bp, sys_errlist[errno]);
+ 	    } else {
+ 		sprintf(bp, "Unknown error %d", errno);
+ 	    }
++#endif
+ 	    bp += strlen(bp);
+ 	    cp += 2;
+ 	} else {
+diff -Naur tcp_wrappers_7.6/rfc931.c tcp_wrappers_7.6.gimli/rfc931.c
+--- tcp_wrappers_7.6/rfc931.c	1995-01-02 09:11:34.000000000 -0600
++++ tcp_wrappers_7.6.gimli/rfc931.c	2002-01-07 08:50:19.000000000 -0600
+@@ -33,7 +33,7 @@
+ 
+ int     rfc931_timeout = RFC931_TIMEOUT;/* Global so it can be changed */
+ 
+-static jmp_buf timebuf;
++static sigjmp_buf timebuf;
+ 
+ /* fsocket - open stdio stream on top of socket */
+ 
+@@ -62,7 +62,7 @@
+ static void timeout(sig)
+ int     sig;
+ {
+-    longjmp(timebuf, sig);
++    siglongjmp(timebuf, sig);
+ }
+ 
+ /* rfc931 - return remote user name, given socket structures */
+@@ -99,7 +99,7 @@
+ 	 * Set up a timer so we won't get stuck while waiting for the server.
+ 	 */
+ 
+-	if (setjmp(timebuf) == 0) {
++	if (sigsetjmp(timebuf,1) == 0) {
+ 	    signal(SIGALRM, timeout);
+ 	    alarm(rfc931_timeout);
+ 
+diff -Naur tcp_wrappers_7.6/safe_finger.8 tcp_wrappers_7.6.gimli/safe_finger.8
+--- tcp_wrappers_7.6/safe_finger.8	1969-12-31 18:00:00.000000000 -0600
++++ tcp_wrappers_7.6.gimli/safe_finger.8	2002-01-07 08:50:19.000000000 -0600
+@@ -0,0 +1,34 @@
++.TH SAFE_FINGER 8 "21th June 1997" Linux "Linux Programmer's Manual"
++.SH NAME
++safe_finger \- finger client wrapper that protects against nasty stuff
++from finger servers
++.SH SYNOPSIS
++.B safe_finger [finger_options]
++.SH DESCRIPTION
++The
++.B safe_finger
++command protects against nasty stuff from finger servers. Use this
++program for automatic reverse finger probes from the
++.B tcp_wrapper
++.B (tcpd)
++, not the raw finger command. The
++.B safe_finger
++command makes sure that the finger client is not run with root
++privileges. It also runs the finger client with a defined PATH
++environment.
++.B safe_finger
++will also protect you from problems caused by the output of some
++finger servers. The problem: some programs may react to stuff in
++the first column. Other programs may get upset by thrash anywhere
++on a line. File systems may fill up as the finger server keeps
++sending data. Text editors may bomb out on extremely long lines.
++The finger server may take forever because it is somehow wedged.
++.B safe_finger
++takes care of all this badness.
++.SH SEE ALSO
++.BR hosts_access (5),
++.BR hosts_options (5),
++.BR tcpd (8)
++.SH AUTHOR
++Wietse Venema, Eindhoven University of Technology, The Netherlands.
++
+diff -Naur tcp_wrappers_7.6/safe_finger.c tcp_wrappers_7.6.gimli/safe_finger.c
+--- tcp_wrappers_7.6/safe_finger.c	1994-12-28 10:42:42.000000000 -0600
++++ tcp_wrappers_7.6.gimli/safe_finger.c	2002-01-07 08:50:19.000000000 -0600
+@@ -26,21 +26,24 @@
+ #include <stdio.h>
+ #include <ctype.h>
+ #include <pwd.h>
++#include <syslog.h>
+ 
+ extern void exit();
+ 
+ /* Local stuff */
+ 
+-char    path[] = "PATH=/bin:/usr/bin:/usr/ucb:/usr/bsd:/etc:/usr/etc:/usr/sbin";
++char    path[] = "PATH=/bin:/usr/bin:/sbin:/usr/sbin";
+ 
+ #define	TIME_LIMIT	60		/* Do not keep listinging forever */
+ #define	INPUT_LENGTH	100000		/* Do not keep listinging forever */
+ #define	LINE_LENGTH	128		/* Editors can choke on long lines */
+ #define	FINGER_PROGRAM	"finger"	/* Most, if not all, UNIX systems */
+ #define	UNPRIV_NAME	"nobody"	/* Preferred privilege level */
+-#define	UNPRIV_UGID	32767		/* Default uid and gid */
++#define	UNPRIV_UGID	65534		/* Default uid and gid */
+ 
+ int     finger_pid;
++int	allow_severity = SEVERITY;
++int	deny_severity = LOG_WARNING;
+ 
+ void    cleanup(sig)
+ int     sig;
+diff -Naur tcp_wrappers_7.6/scaffold.c tcp_wrappers_7.6.gimli/scaffold.c
+--- tcp_wrappers_7.6/scaffold.c	1997-03-21 12:27:24.000000000 -0600
++++ tcp_wrappers_7.6.gimli/scaffold.c	2002-01-07 08:50:19.000000000 -0600
+@@ -180,10 +180,12 @@
+ 
+ /* ARGSUSED */
+ 
+-void    rfc931(request)
+-struct request_info *request;
++void    rfc931(rmt_sin, our_sin, dest)
++struct sockaddr_in *rmt_sin;
++struct sockaddr_in *our_sin;
++char   *dest;
+ {
+-    strcpy(request->user, unknown);
++    strcpy(dest, unknown);
+ }
+ 
+ /* check_path - examine accessibility */
+diff -Naur tcp_wrappers_7.6/socket.c tcp_wrappers_7.6.gimli/socket.c
+--- tcp_wrappers_7.6/socket.c	1997-03-21 12:27:25.000000000 -0600
++++ tcp_wrappers_7.6.gimli/socket.c	2002-01-07 08:50:19.000000000 -0600
+@@ -76,7 +76,11 @@
+ {
+     static struct sockaddr_in client;
+     static struct sockaddr_in server;
++#if !defined (__GLIBC__)
+     int     len;
++#else /* __GLIBC__ */
++    size_t  len;
++#endif /* __GLIBC__ */
+     char    buf[BUFSIZ];
+     int     fd = request->fd;
+ 
+@@ -224,7 +228,11 @@
+ {
+     char    buf[BUFSIZ];
+     struct sockaddr_in sin;
++#if !defined(__GLIBC__)
+     int     size = sizeof(sin);
++#else /* __GLIBC__ */
++    size_t  size = sizeof(sin);
++#endif /* __GLIBC__ */
+ 
+     /*
+      * Eat up the not-yet received datagram. Some systems insist on a
+diff -Naur tcp_wrappers_7.6/tcpd.8 tcp_wrappers_7.6.gimli/tcpd.8
+--- tcp_wrappers_7.6/tcpd.8	1996-02-21 09:39:16.000000000 -0600
++++ tcp_wrappers_7.6.gimli/tcpd.8	2002-01-07 08:50:19.000000000 -0600
+@@ -94,7 +94,7 @@
+ .PP
+ The example assumes that the network daemons live in /usr/etc. On some
+ systems, network daemons live in /usr/sbin or in /usr/libexec, or have
+-no `in.\' prefix to their name.
++no `in.' prefix to their name.
+ .SH EXAMPLE 2
+ This example applies when \fItcpd\fR expects that the network daemons
+ are left in their original place.
+@@ -110,26 +110,26 @@
+ becomes:
+ .sp
+ .ti +5
+-finger  stream  tcp  nowait  nobody  /some/where/tcpd     in.fingerd
++finger  stream  tcp  nowait  nobody  /usr/sbin/tcpd       in.fingerd
+ .sp
+ .fi
+ .PP
+ The example assumes that the network daemons live in /usr/etc. On some
+ systems, network daemons live in /usr/sbin or in /usr/libexec, the
+-daemons have no `in.\' prefix to their name, or there is no userid
++daemons have no `in.' prefix to their name, or there is no userid
+ field in the inetd configuration file.
+ .PP
+ Similar changes will be needed for the other services that are to be
+-covered by \fItcpd\fR.  Send a `kill -HUP\' to the \fIinetd\fR(8)
++covered by \fItcpd\fR.  Send a `kill -HUP' to the \fIinetd\fR(8)
+ process to make the changes effective. AIX users may also have to
+-execute the `inetimp\' command.
++execute the `inetimp' command.
+ .SH EXAMPLE 3
+ In the case of daemons that do not live in a common directory ("secret"
+ or otherwise), edit the \fIinetd\fR configuration file so that it
+ specifies an absolute path name for the process name field. For example:
+ .nf
+ .sp
+-    ntalk  dgram  udp  wait  root  /some/where/tcpd  /usr/local/lib/ntalkd
++    ntalk  dgram  udp  wait  root  /usr/sbin/tcpd  /usr/sbin/in.ntalkd
+ .sp
+ .fi
+ .PP
+diff -Naur tcp_wrappers_7.6/tcpd.h tcp_wrappers_7.6.gimli/tcpd.h
+--- tcp_wrappers_7.6/tcpd.h	1996-03-19 09:22:25.000000000 -0600
++++ tcp_wrappers_7.6.gimli/tcpd.h	2002-01-07 08:50:19.000000000 -0600
+@@ -4,6 +4,25 @@
+   * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
+   */
+ 
++#ifndef _TCPWRAPPERS_TCPD_H
++#define _TCPWRAPPERS_TCPD_H
++
++/* someone else may have defined this */
++#undef  __P
++
++/* use prototypes if we have an ANSI C compiler or are using C++ */
++#if defined(__STDC__) || defined(__cplusplus)
++#define __P(args)       args
++#else
++#define __P(args)       ()
++#endif
++
++/* Need definitions of struct sockaddr_in and FILE. */
++#include <netinet/in.h>
++#include <stdio.h>
++
++__BEGIN_DECLS
++
+ /* Structure to describe one communications endpoint. */
+ 
+ #define STRING_LENGTH	128		/* hosts, users, processes */
+@@ -25,10 +44,10 @@
+     char    pid[10];			/* access via eval_pid(request) */
+     struct host_info client[1];		/* client endpoint info */
+     struct host_info server[1];		/* server endpoint info */
+-    void  (*sink) ();			/* datagram sink function or 0 */
+-    void  (*hostname) ();		/* address to printable hostname */
+-    void  (*hostaddr) ();		/* address to printable address */
+-    void  (*cleanup) ();		/* cleanup function or 0 */
++    void  (*sink) __P((int));		/* datagram sink function or 0 */
++    void  (*hostname) __P((struct host_info *)); /* address to printable hostname */
++    void  (*hostaddr) __P((struct host_info *)); /* address to printable address */
++    void  (*cleanup) __P((struct request_info *)); /* cleanup function or 0 */
+     struct netconfig *config;		/* netdir handle */
+ };
+ 
+@@ -61,25 +80,30 @@
+ /* Global functions. */
+ 
+ #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
+-extern void fromhost();			/* get/validate client host info */
++extern void fromhost __P((struct request_info *));	/* get/validate client host info */
+ #else
+ #define fromhost sock_host		/* no TLI support needed */
+ #endif
+ 
+-extern int hosts_access();		/* access control */
+-extern void shell_cmd();		/* execute shell command */
+-extern char *percent_x();		/* do %<char> expansion */
+-extern void rfc931();			/* client name from RFC 931 daemon */
+-extern void clean_exit();		/* clean up and exit */
+-extern void refuse();			/* clean up and exit */
+-extern char *xgets();			/* fgets() on steroids */
+-extern char *split_at();		/* strchr() and split */
+-extern unsigned long dot_quad_addr();	/* restricted inet_addr() */
++extern void shell_cmd __P((char *));	/* execute shell command */
++extern char *percent_x __P((char *, int, char *, struct request_info *)); /* do %<char> expansion */
++extern void rfc931 __P((struct sockaddr_in *, struct sockaddr_in *, char *)); /* client name from RFC 931 daemon */
++extern void clean_exit __P((struct request_info *)); /* clean up and exit */
++extern void refuse __P((struct request_info *));	/* clean up and exit */
++extern char *xgets __P((char *, int, FILE *));	/* fgets() on steroids */
++extern char *split_at __P((char *, int));	/* strchr() and split */
++extern unsigned long dot_quad_addr __P((char *)); /* restricted inet_addr() */
+ 
+ /* Global variables. */
+ 
++#ifdef HAVE_WEAKSYMS
++extern int allow_severity __attribute__ ((weak)); /* for connection logging */
++extern int deny_severity __attribute__ ((weak)); /* for connection logging */
++#else
+ extern int allow_severity;		/* for connection logging */
+ extern int deny_severity;		/* for connection logging */
++#endif
++
+ extern char *hosts_allow_table;		/* for verification mode redirection */
+ extern char *hosts_deny_table;		/* for verification mode redirection */
+ extern int hosts_access_verbose;	/* for verbose matching mode */
+@@ -92,9 +116,14 @@
+   */
+ 
+ #ifdef __STDC__
++extern int hosts_access(struct request_info *request);
++extern int hosts_ctl(char *daemon, char *client_name, char *client_addr, 
++                     char *client_user);
+ extern struct request_info *request_init(struct request_info *,...);
+ extern struct request_info *request_set(struct request_info *,...);
+ #else
++extern int hosts_access();
++extern int hosts_ctl();
+ extern struct request_info *request_init();	/* initialize request */
+ extern struct request_info *request_set();	/* update request structure */
+ #endif
+@@ -117,27 +146,31 @@
+   * host_info structures serve as caches for the lookup results.
+   */
+ 
+-extern char *eval_user();		/* client user */
+-extern char *eval_hostname();		/* printable hostname */
+-extern char *eval_hostaddr();		/* printable host address */
+-extern char *eval_hostinfo();		/* host name or address */
+-extern char *eval_client();		/* whatever is available */
+-extern char *eval_server();		/* whatever is available */
++extern char *eval_user __P((struct request_info *));	/* client user */
++extern char *eval_hostname __P((struct host_info *));	/* printable hostname */
++extern char *eval_hostaddr __P((struct host_info *));	/* printable host address */
++extern char *eval_hostinfo __P((struct host_info *));	/* host name or address */
++extern char *eval_client __P((struct request_info *));	/* whatever is available */
++extern char *eval_server __P((struct request_info *));	/* whatever is available */
+ #define eval_daemon(r)	((r)->daemon)	/* daemon process name */
+ #define eval_pid(r)	((r)->pid)	/* process id */
+ 
+ /* Socket-specific methods, including DNS hostname lookups. */
+ 
+-extern void sock_host();		/* look up endpoint addresses */
+-extern void sock_hostname();		/* translate address to hostname */
+-extern void sock_hostaddr();		/* address to printable address */
++/* look up endpoint addresses */
++extern void sock_host __P((struct request_info *));
++/* translate address to hostname */
++extern void sock_hostname __P((struct host_info *));
++/* address to printable address */
++extern void sock_hostaddr __P((struct host_info *));
++
+ #define sock_methods(r) \
+ 	{ (r)->hostname = sock_hostname; (r)->hostaddr = sock_hostaddr; }
+ 
+ /* The System V Transport-Level Interface (TLI) interface. */
+ 
+ #if defined(TLI) || defined(PTX) || defined(TLI_SEQUENT)
+-extern void tli_host();			/* look up endpoint addresses etc. */
++extern void tli_host __P((struct request_info *));	/* look up endpoint addresses etc. */
+ #endif
+ 
+  /*
+@@ -178,7 +211,7 @@
+   * behavior.
+   */
+ 
+-extern void process_options();		/* execute options */
++extern void process_options __P((char *, struct request_info *)); /* execute options */
+ extern int dry_run;			/* verification flag */
+ 
+ /* Bug workarounds. */
+@@ -217,3 +250,7 @@
+ #define strtok	my_strtok
+ extern char *my_strtok();
+ #endif
++
++__END_DECLS
++
++#endif /* tcpd.h */
+diff -Naur tcp_wrappers_7.6/tcpdchk.c tcp_wrappers_7.6.gimli/tcpdchk.c
+--- tcp_wrappers_7.6/tcpdchk.c	1997-02-11 19:13:25.000000000 -0600
++++ tcp_wrappers_7.6.gimli/tcpdchk.c	2002-01-07 08:50:19.000000000 -0600
+@@ -350,6 +350,8 @@
+ {
+     if (pat[0] == '@') {
+ 	tcpd_warn("%s: daemon name begins with \"@\"", pat);
++    } else if (pat[0] == '/') {
++        tcpd_warn("%s: daemon name begins with \"/\"", pat);
+     } else if (pat[0] == '.') {
+ 	tcpd_warn("%s: daemon name begins with dot", pat);
+     } else if (pat[strlen(pat) - 1] == '.') {
+@@ -382,6 +384,8 @@
+ {
+     if (pat[0] == '@') {			/* @netgroup */
+ 	tcpd_warn("%s: user name begins with \"@\"", pat);
++    } else if (pat[0] == '/') {
++        tcpd_warn("%s: user name begins with \"/\"", pat);
+     } else if (pat[0] == '.') {
+ 	tcpd_warn("%s: user name begins with dot", pat);
+     } else if (pat[strlen(pat) - 1] == '.') {
+@@ -402,8 +406,13 @@
+ static int check_host(pat)
+ char   *pat;
+ {
++    char    buf[BUFSIZ];
+     char   *mask;
+     int     addr_count = 1;
++    FILE   *fp;
++    struct tcpd_context saved_context;
++    char   *cp;
++    char   *wsp = " \t\r\n";
+ 
+     if (pat[0] == '@') {			/* @netgroup */
+ #ifdef NO_NETGRENT
+@@ -422,6 +431,21 @@
+ 	tcpd_warn("netgroup support disabled");
+ #endif
+ #endif
++    } else if (pat[0] == '/') {                 /* /path/name */
++        if ((fp = fopen(pat, "r")) != 0) {
++            saved_context = tcpd_context;
++            tcpd_context.file = pat;
++            tcpd_context.line = 0;
++            while (fgets(buf, sizeof(buf), fp)) {
++                tcpd_context.line++;
++                for (cp = strtok(buf, wsp); cp; cp = strtok((char *) 0, wsp))
++                    check_host(cp);
++            }
++            tcpd_context = saved_context;
++            fclose(fp);
++        } else if (errno != ENOENT) {
++            tcpd_warn("open %s: %m", pat);
++        }
+     } else if (mask = split_at(pat, '/')) {	/* network/netmask */
+ 	if (dot_quad_addr(pat) == INADDR_NONE
+ 	    || dot_quad_addr(mask) == INADDR_NONE)
+diff -Naur tcp_wrappers_7.6/try-from.8 tcp_wrappers_7.6.gimli/try-from.8
+--- tcp_wrappers_7.6/try-from.8	1969-12-31 18:00:00.000000000 -0600
++++ tcp_wrappers_7.6.gimli/try-from.8	2002-01-07 08:50:19.000000000 -0600
+@@ -0,0 +1,28 @@
++.TH TRY-FROM 8 "21th June 1997" Linux "Linux Programmer's Manual"
++.SH NAME
++try-from \- test program for the tcp_wrapper
++.SH SYNOPSIS
++.B try-from
++.SH DESCRIPTION
++The
++.B try-from
++command can be called via a remote shell command to find out
++if the hostname and address are properly recognized
++by the
++.B tcp_wrapper
++library, if username lookup works, and (SysV only) if the TLI
++on top of IP heuristics work. Diagnostics are reported through
++.BR syslog (3)
++and redirected to stderr.
++
++Example:
++
++rsh host /some/where/try-from
++
++.SH SEE ALSO
++.BR hosts_access (5),
++.BR hosts_options (5),
++.BR tcpd (8)
++.SH AUTHOR
++Wietse Venema, Eindhoven University of Technology, The Netherlands.
++
+diff -Naur tcp_wrappers_7.6/weak_symbols.c tcp_wrappers_7.6.gimli/weak_symbols.c
+--- tcp_wrappers_7.6/weak_symbols.c	1969-12-31 18:00:00.000000000 -0600
++++ tcp_wrappers_7.6.gimli/weak_symbols.c	2002-01-07 08:50:19.000000000 -0600
+@@ -0,0 +1,11 @@
++ /*
++  * @(#) weak_symbols.h 1.5 99/12/29 23:50
++  * 
++  * Author: Anthony Towns <ajt@debian.org>
++  */
++
++#ifdef HAVE_WEAKSYMS
++#include <syslog.h>
++int deny_severity = LOG_WARNING;
++int allow_severity = SEVERITY; 
++#endif
+diff -Naur tcp_wrappers_7.6/workarounds.c tcp_wrappers_7.6.gimli/workarounds.c
+--- tcp_wrappers_7.6/workarounds.c	1996-03-19 09:22:26.000000000 -0600
++++ tcp_wrappers_7.6.gimli/workarounds.c	2002-01-07 08:50:19.000000000 -0600
+@@ -163,7 +163,11 @@
+ int     fix_getpeername(sock, sa, len)
+ int     sock;
+ struct sockaddr *sa;
++#if !defined(__GLIBC__)
+ int    *len;
++#else /* __GLIBC__ */
++size_t *len;
++#endif /* __GLIBC__ */
+ {
+     int     ret;
+     struct sockaddr_in *sin = (struct sockaddr_in *) sa;

--- a/spec/data/complicated/config/patches/logrotate/logrotate_basedir_override.patch
+++ b/spec/data/complicated/config/patches/logrotate/logrotate_basedir_override.patch
@@ -1,0 +1,12 @@
+--- Makefile  2013-06-10 08:02:36.000000000 -0400
++++ Makefile  2013-07-01 15:26:41.000000000 -0400
+@@ -90,6 +90,10 @@
+     CFLAGS += -DSTATEFILE=\"$(STATEFILE)\"
+ endif
+
++ifneq ($(BASEDIR),)
++    BASEDIR = $BASEDIR
++endif
++
+ BINDIR = $(BASEDIR)/sbin
+ MANDIR ?= $(BASEDIR)/man

--- a/spec/data/complicated/config/patches/ncurses/ncurses-5.9-solaris-xopen_source_extended-detection.patch
+++ b/spec/data/complicated/config/patches/ncurses/ncurses-5.9-solaris-xopen_source_extended-detection.patch
@@ -1,0 +1,11 @@
+--- configure.after.pkgin.patches	2012-12-17 01:06:16.964187316 +0000
++++ configure	2012-12-17 01:07:17.046932230 +0000
+@@ -7864,7 +7864,7 @@
+ else
+   echo "$as_me: failed program was:" >&5
+ cat conftest.$ac_ext >&5
+-cf_result=yes
++cf_result=no
+ fi
+ rm -f conftest.$ac_objext conftest.$ac_ext
+ echo "$as_me:7863: result: $cf_result" >&5

--- a/spec/data/complicated/config/patches/ncurses/ncurses-clang.patch
+++ b/spec/data/complicated/config/patches/ncurses/ncurses-clang.patch
@@ -1,0 +1,43 @@
+diff -ruNp ncurses-5.9.orig/c++/cursesf.h ncurses-5.9/c++/cursesf.h
+--- ncurses-5.9.orig/c++/cursesf.h	2005-08-13 21:08:24.000000000 +0300
++++ ncurses-5.9/c++/cursesf.h	2011-04-03 18:29:29.000000000 +0300
+@@ -681,7 +681,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, with_frame, autoDelete_Fields) {
++    : NCursesForm (&Fields, with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -694,7 +694,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, nlines, ncols, begin_y, begin_x,
++    : NCursesForm (&Fields, nlines, ncols, begin_y, begin_x,
+ 		   with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+diff -ruNp ncurses-5.9.orig/c++/cursesm.h ncurses-5.9/c++/cursesm.h
+--- ncurses-5.9.orig/c++/cursesm.h	2005-08-13 21:10:36.000000000 +0300
++++ ncurses-5.9/c++/cursesm.h	2011-04-03 18:31:42.000000000 +0300
+@@ -639,7 +639,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+-    : NCursesMenu (Items, with_frame, autoDelete_Items) {
++    : NCursesMenu (&Items, with_frame, autoDelete_Items) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -651,7 +651,7 @@ public:
+ 		   int begin_x = 0,
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE)
+-    : NCursesMenu (Items, nlines, ncols, begin_y, begin_x, with_frame) {
++    : NCursesMenu (&Items, nlines, ncols, begin_y, begin_x, with_frame) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+

--- a/spec/data/complicated/config/patches/ncurses/patch-aa
+++ b/spec/data/complicated/config/patches/ncurses/patch-aa
@@ -1,0 +1,23 @@
+$NetBSD: patch-aa,v 1.16 2011/02/28 11:02:46 adam Exp $
+
+--- misc/run_tic.in.orig	2006-10-28 21:43:30.000000000 +0200
++++ misc/run_tic.in
+@@ -122,7 +122,7 @@ TICDIR=`echo $TERMINFO | sed -e 's%/shar
+ # would generate a lot of confusing error messages if we tried to overwrite it.
+ # We explicitly remove its contents rather than the directory itself, in case
+ # the directory is actually a symbolic link.
+-( test -d "$TERMINFO" && cd $TERMINFO && rm -fr ? 2>/dev/null )
++#( test -d "$TERMINFO" && cd $TERMINFO && rm -fr ? 2>/dev/null )
+ 
+ if test "$ext_funcs" = 1 ; then
+ cat <<EOF
+@@ -164,6 +164,9 @@ else
+ fi
+ fi
+ 
++# For NetBSD pkgsrc, don't bother with setting a symbolic link.
++exit 0
++
+ # Make a symbolic link to provide compatibility with applications that expect
+ # to find terminfo under /usr/lib.  That is, we'll _try_ to do that.  Not
+ # all systems support symbolic links, and those that do provide a variety

--- a/spec/data/complicated/config/patches/ncurses/patch-ab
+++ b/spec/data/complicated/config/patches/ncurses/patch-ab
@@ -1,0 +1,44 @@
+$NetBSD: patch-ab,v 1.16 2011/02/28 11:02:46 adam Exp $
+
+--- mk-1st.awk.orig	2010-08-07 20:42:30.000000000 +0000
++++ mk-1st.awk
+@@ -396,11 +396,11 @@ END	{
+ 				end_name = lib_name;
+ 				printf "../lib/%s : $(%s_OBJS)\n", lib_name, OBJS
+ 				if ( is_ticlib() ) {
+-					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:$o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(TICS_LIST)\n", compile, lib_name, OBJS, libtool_version
++					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:.o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(TICS_LIST)\n", compile, lib_name, OBJS, libtool_version
+ 				} else if ( is_termlib() ) {
+-					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:$o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(TINFO_LIST)\n", compile, lib_name, OBJS, libtool_version
++					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:.o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(TINFO_LIST)\n", compile, lib_name, OBJS, libtool_version
+ 				} else {
+-					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:$o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(SHLIB_LIST)\n", compile, lib_name, OBJS, libtool_version
++					printf "\tcd ../lib && $(LIBTOOL_LINK) $(%s) -o %s $(%s_OBJS:.o=.lo) -rpath $(DESTDIR)$(libdir) %s $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(SHLIB_LIST)\n", compile, lib_name, OBJS, libtool_version
+ 				}
+ 				print  ""
+ 				print  "install \\"
+@@ -469,7 +469,7 @@ END	{
+ 			print "mostlyclean::"
+ 			printf "\t-rm -f $(%s_OBJS)\n", OBJS
+ 			if ( MODEL == "LIBTOOL" ) {
+-				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:$o=.lo)\n", OBJS
++				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:.o=.lo)\n", OBJS
+ 			}
+ 		}
+ 		else if ( found == 2 )
+@@ -478,13 +478,13 @@ END	{
+ 			print "mostlyclean::"
+ 			printf "\t-rm -f $(%s_OBJS)\n", OBJS
+ 			if ( MODEL == "LIBTOOL" ) {
+-				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:$o=.lo)\n", OBJS
++				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:.o=.lo)\n", OBJS
+ 			}
+ 			print ""
+ 			print "clean ::"
+ 			printf "\t-rm -f $(%s_OBJS)\n", OBJS
+ 			if ( MODEL == "LIBTOOL" ) {
+-				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:$o=.lo)\n", OBJS
++				printf "\t-$(LIBTOOL_CLEAN) rm -f $(%s_OBJS:.o=.lo)\n", OBJS
+ 			}
+ 		}
+ 	}

--- a/spec/data/complicated/config/patches/ncurses/patch-ac
+++ b/spec/data/complicated/config/patches/ncurses/patch-ac
@@ -1,0 +1,40 @@
+$NetBSD: patch-ac,v 1.18 2011/11/01 14:47:46 hans Exp $
+
+--- configure.orig	2011-02-21 01:40:36.000000000 +0000
++++ configure
+@@ -7096,6 +7096,13 @@ sco*) #(vi
+ 	# setting _XOPEN_SOURCE breaks Lynx on SCO Unix / OpenServer
+ 	;;
+ solaris2.1[0-9]) #(vi
++	case "$GCC_VERSION" in 
++		4.[67].*)
++			cf_XOPEN_SOURCE=600
++			cf_add_cflags=-std=c99
++			CPPFLAGS="$CPPFLAGS -std=c99"
++			;;
++	esac
+ 	cf_xopen_source="-D__EXTENSIONS__ -D_XOPEN_SOURCE=$cf_XOPEN_SOURCE"
+ 	;;
+ solaris2.[1-9]) #(vi
+@@ -9640,12 +9647,7 @@ case ".$MANPAGE_RENAMES" in #(vi
+ .no) #(vi
+   ;;
+ .|.yes)
+-  # Debian 'man' program?
+-  if test -f /etc/debian_version ; then
+-    MANPAGE_RENAMES=`cd $srcdir && pwd`/man/man_db.renames
+-  else
+     MANPAGE_RENAMES=no
+-  fi
+   ;;
+ esac
+ 
+@@ -18449,7 +18444,7 @@ echo "${ECHO_T}$LIB_SUBSETS" >&6
+ 
+ ### Construct the list of include-directories to be generated
+ 
+-CPPFLAGS="$CPPFLAGS -I. -I../include"
++CPPFLAGS="-I. -I../include $CPPFLAGS"
+ if test "$srcdir" != "."; then
+ 	CPPFLAGS="$CPPFLAGS -I\${srcdir}/../include"
+ fi

--- a/spec/data/complicated/config/patches/ncurses/patch-ad
+++ b/spec/data/complicated/config/patches/ncurses/patch-ad
@@ -1,0 +1,13 @@
+$NetBSD: patch-ad,v 1.11 2011/02/28 11:02:46 adam Exp $
+
+--- c++/Makefile.in.orig	2010-11-27 21:45:27.000000000 +0000
++++ c++/Makefile.in
+@@ -167,7 +167,7 @@ LIB_OBJS = \
+ 
+ ../lib/$(LIBNAME_LIBTOOL) : $(LIB_OBJS)
+ 	cd ../lib && $(LIBTOOL_LINK) $(CXX) $(CXXFLAGS) \
+-		-o $(LIBNAME) $(LIB_OBJS:$o=.lo) \
++		-o $(LIBNAME) $(LIB_OBJS:.o=.lo) \
+ 		-rpath $(INSTALL_PREFIX)$(libdir) \
+ 		$(LIBTOOL_VERSION) $(NCURSES_MAJOR):$(NCURSES_MINOR) $(LT_UNDEF) $(SHLIB_LIST)
+ 

--- a/spec/data/complicated/config/patches/ncurses/patch-aix-configure
+++ b/spec/data/complicated/config/patches/ncurses/patch-aix-configure
@@ -1,0 +1,23 @@
+--- configure~	2011-03-31 18:35:51 -0500
++++ configure	2013-05-16 22:50:24 -0500
+@@ -5559,6 +5559,9 @@
+ 		if test "$GCC" = yes; then
+ 			CC_SHARED_OPTS=
+ 			MK_SHARED_LIB='$(CC) -shared'
++		else
++			CC_SHARED_OPTS=
++			MK_SHARED_LIB='$(CC) -qmkshrobj -o $@'
+ 		fi
+ 		;;
+ 	beos*) #(vi
+--- mk-1st.awk~	2010-08-07 15:42:30 -0500
++++ mk-1st.awk	2013-05-16 22:50:24 -0500
+@@ -180,7 +180,7 @@
+ function shlib_build(directory) {
+ 		dst_libs = sprintf("%s/%s", directory, end_name);
+ 		printf "%s : \\\n", dst_libs
+-		printf "\t\t%s \\\n", directory
++#		printf "\t\t%s \\\n", directory
+ 		if (subset ~ /^base/ || subset == "ticlib" ) {
+ 			save_suffix = suffix
+ 			sub(/^[^.]\./,".",suffix)

--- a/spec/data/complicated/config/patches/ncurses/patch-cxx_cursesf.h
+++ b/spec/data/complicated/config/patches/ncurses/patch-cxx_cursesf.h
@@ -1,0 +1,22 @@
+$NetBSD: patch-cxx_cursesf.h,v 1.1 2011/02/28 11:02:46 adam Exp $
+
+--- c++/cursesf.h.orig	2011-02-28 09:23:33.000000000 +0000
++++ c++/cursesf.h
+@@ -677,7 +677,7 @@ protected:
+   }
+ 
+ public:
+-  NCursesUserForm (NCursesFormField Fields[],
++  NCursesUserForm (NCursesFormField *Fields[],
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+@@ -686,7 +686,7 @@ public:
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+ 
+-  NCursesUserForm (NCursesFormField Fields[],
++  NCursesUserForm (NCursesFormField *Fields[],
+ 		   int nlines,
+ 		   int ncols,
+ 		   int begin_y = 0,

--- a/spec/data/complicated/config/patches/ncurses/patch-cxx_cursesm.h
+++ b/spec/data/complicated/config/patches/ncurses/patch-cxx_cursesm.h
@@ -1,0 +1,22 @@
+$NetBSD: patch-cxx_cursesm.h,v 1.1 2011/02/28 11:02:46 adam Exp $
+
+--- c++/cursesm.h.orig	2011-02-28 09:25:22.000000000 +0000
++++ c++/cursesm.h
+@@ -635,7 +635,7 @@ protected:
+   }
+ 
+ public:
+-  NCursesUserMenu (NCursesMenuItem Items[],
++  NCursesUserMenu (NCursesMenuItem *Items[],
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+@@ -644,7 +644,7 @@ public:
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+ 
+-  NCursesUserMenu (NCursesMenuItem Items[],
++  NCursesUserMenu (NCursesMenuItem *Items[],
+ 		   int nlines,
+ 		   int ncols,
+ 		   int begin_y = 0,

--- a/spec/data/complicated/config/patches/nrpe/fix_for_runit.patch
+++ b/spec/data/complicated/config/patches/nrpe/fix_for_runit.patch
@@ -1,0 +1,65 @@
+--- ./nrpe-2.13/src/nrpe.c	2011-11-11 10:45:49.000000000 -0800
++++ ./nrpe-2.13-runit/src/nrpe.c	2012-01-12 17:48:31.511472215 -0800
+@@ -85,6 +85,7 @@
+ int     show_version=FALSE;
+ int     use_inetd=TRUE;
+ int     debug=FALSE;
++int     stay_in_foreground=FALSE;
+ 
+ 
+ 
+@@ -273,26 +274,9 @@
+ 		/* handle the connection */
+ 		handle_connection(0);
+ 	        }
+-
+ 	/* else daemonize and start listening for requests... */
+-	else if(fork()==0){
++	else if(1){
+ 		
+-		/* we're a daemon - set up a new process group */
+-		setsid();
+-
+-		/* close standard file descriptors */
+-		close(0);
+-		close(1);
+-		close(2);
+-
+-		/* redirect standard descriptors to /dev/null */
+-		open("/dev/null",O_RDONLY);
+-		open("/dev/null",O_WRONLY);
+-		open("/dev/null",O_WRONLY);
+-
+-		chdir("/");
+-		/*umask(0);*/
+-
+ 		/* handle signals */
+ 		signal(SIGQUIT,sighandler);
+ 		signal(SIGTERM,sighandler);
+@@ -301,16 +285,6 @@
+ 		/* log info to syslog facility */
+ 		syslog(LOG_NOTICE,"Starting up daemon");
+ 
+-		/* write pid file */
+-		if(write_pid_file()==ERROR)
+-			return STATE_CRITICAL;
+-		
+-		/* drop privileges */
+-		drop_privileges(nrpe_user,nrpe_group);
+-
+-		/* make sure we're not root */
+-		check_privileges();
+-
+ 		do{
+ 
+ 			/* reset flags */
+@@ -337,9 +311,6 @@
+ 	
+ 		        }while(sigrestart==TRUE && sigshutdown==FALSE);
+ 
+-		/* remove pid file */
+-		remove_pid_file();
+-
+ 		syslog(LOG_NOTICE,"Daemon shutdown\n");
+ 	        }
+ 

--- a/spec/data/complicated/config/patches/openssl/openssl-1.0.1f-do-not-build-docs.patch
+++ b/spec/data/complicated/config/patches/openssl/openssl-1.0.1f-do-not-build-docs.patch
@@ -1,0 +1,101 @@
+--- openssl-1.0.1f/Makefile.org.orig	2014-01-08 10:58:40.000000000 -0800
++++ openssl-1.0.1f/Makefile.org	2014-01-08 11:06:29.000000000 -0800
+@@ -167,7 +167,7 @@
+ 
+ TOP=    .
+ ONEDIRS=out tmp
+-EDIRS=  times doc bugs util include certs ms shlib mt demos perl sf dep VMS
++EDIRS=  times bugs util include certs ms shlib mt demos perl sf dep VMS
+ WDIRS=  windows
+ LIBS=   libcrypto.a libssl.a
+ SHARED_CRYPTO=libcrypto$(SHLIB_EXT)
+@@ -538,7 +538,7 @@
+ dist_pem_h:
+ 	(cd crypto/pem; $(MAKE) -e $(BUILDENV) pem.h; $(MAKE) clean)
+ 
+-install: all install_docs install_sw
++install: all install_sw
+ 
+ install_sw:
+ 	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
+@@ -603,7 +603,6 @@
+ 			echo 'OpenSSL shared libraries have been installed in:'; \
+ 			echo '  $(INSTALLTOP)'; \
+ 			echo ''; \
+-			sed -e '1,/^$$/d' doc/openssl-shared.txt; \
+ 		fi; \
+ 	fi
+ 	cp libcrypto.pc $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig
+@@ -613,72 +612,4 @@
+ 	cp openssl.pc $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig
+ 	chmod 644 $(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/pkgconfig/openssl.pc
+ 
+-install_html_docs:
+-	here="`pwd`"; \
+-	for subdir in apps crypto ssl; do \
+-		mkdir -p $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir; \
+-		for i in doc/$$subdir/*.pod; do \
+-			fn=`basename $$i .pod`; \
+-			echo "installing html/$$fn.$(HTMLSUFFIX)"; \
+-			cat $$i \
+-			| sed -r 's/L<([^)]*)(\([0-9]\))?\|([^)]*)(\([0-9]\))?>/L<\1|\3>/g' \
+-			| pod2html --podroot=doc --htmlroot=.. --podpath=apps:crypto:ssl \
+-			| sed -r 's/<!DOCTYPE.*//g' \
+-			> $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir/$$fn.$(HTMLSUFFIX); \
+-			$(PERL) util/extract-names.pl < $$i | \
+-				grep -v $$filecase "^$$fn\$$" | \
+-				(cd $(INSTALL_PREFIX)$(HTMLDIR)/$$subdir; \
+-				 while read n; do \
+-					PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$(HTMLSUFFIX) "$$n".$(HTMLSUFFIX); \
+-				 done); \
+-		done; \
+-	done
+-
+-install_docs:
+-	@$(PERL) $(TOP)/util/mkdir-p.pl \
+-		$(INSTALL_PREFIX)$(MANDIR)/man1 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man3 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man5 \
+-		$(INSTALL_PREFIX)$(MANDIR)/man7
+-	@pod2man="`cd ./util; ./pod2mantest $(PERL)`"; \
+-	here="`pwd`"; \
+-	filecase=; \
+-	if [ "$(PLATFORM)" = "DJGPP" -o "$(PLATFORM)" = "Cygwin" -o "$(PLATFORM)" = "mingw" ]; then \
+-		filecase=-i; \
+-	fi; \
+-	set -e; for i in doc/apps/*.pod; do \
+-		fn=`basename $$i .pod`; \
+-		sec=`$(PERL) util/extract-section.pl 1 < $$i`; \
+-		echo "installing man$$sec/$$fn.$${sec}$(MANSUFFIX)"; \
+-		(cd `$(PERL) util/dirname.pl $$i`; \
+-		sh -c "$$pod2man \
+-			--section=$$sec --center=OpenSSL \
+-			--release=$(VERSION) `basename $$i`") \
+-			>  $(INSTALL_PREFIX)$(MANDIR)/man$$sec/$$fn.$${sec}$(MANSUFFIX); \
+-		$(PERL) util/extract-names.pl < $$i | \
+-			(grep -v $$filecase "^$$fn\$$"; true) | \
+-			(grep -v "[	]"; true) | \
+-			(cd $(INSTALL_PREFIX)$(MANDIR)/man$$sec/; \
+-			 while read n; do \
+-				PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$${sec}$(MANSUFFIX) "$$n".$${sec}$(MANSUFFIX); \
+-			 done); \
+-	done; \
+-	set -e; for i in doc/crypto/*.pod doc/ssl/*.pod; do \
+-		fn=`basename $$i .pod`; \
+-		sec=`$(PERL) util/extract-section.pl 3 < $$i`; \
+-		echo "installing man$$sec/$$fn.$${sec}$(MANSUFFIX)"; \
+-		(cd `$(PERL) util/dirname.pl $$i`; \
+-		sh -c "$$pod2man \
+-			--section=$$sec --center=OpenSSL \
+-			--release=$(VERSION) `basename $$i`") \
+-			>  $(INSTALL_PREFIX)$(MANDIR)/man$$sec/$$fn.$${sec}$(MANSUFFIX); \
+-		$(PERL) util/extract-names.pl < $$i | \
+-			(grep -v $$filecase "^$$fn\$$"; true) | \
+-			(grep -v "[	]"; true) | \
+-			(cd $(INSTALL_PREFIX)$(MANDIR)/man$$sec/; \
+-			 while read n; do \
+-				PLATFORM=$(PLATFORM) $$here/util/point.sh $$fn.$${sec}$(MANSUFFIX) "$$n".$${sec}$(MANSUFFIX); \
+-			 done); \
+-	done
+-
+ # DO NOT DELETE THIS LINE -- make depend depends on it.

--- a/spec/data/complicated/config/patches/postgresql/postgresql-9.1.2-configure-ncurses-fix.patch
+++ b/spec/data/complicated/config/patches/postgresql/postgresql-9.1.2-configure-ncurses-fix.patch
@@ -1,0 +1,12 @@
+diff -ur postgresql-9.1.2/configure postgresql-9.1.2.fixed/configure
+--- postgresql-9.1.2/configure	2011-12-01 13:47:20.000000000 -0800
++++ postgresql-9.1.2.fixed/configure	2012-04-09 16:10:15.000000000 -0700
+@@ -8330,7 +8330,7 @@
+ else	READLINE_ORDER="-ledit -lreadline"
+ fi
+ for pgac_rllib in $READLINE_ORDER ; do
+-  for pgac_lib in "" " -ltermcap" " -lncurses" " -lcurses" ; do
++  for pgac_lib in "" " -lncurses" " -lcurses" ; do
+     LIBS="${pgac_rllib}${pgac_lib} $pgac_save_LIBS"
+     cat >conftest.$ac_ext <<_ACEOF
+ /* confdefs.h.  */

--- a/spec/data/complicated/config/patches/ruby/patch-configure
+++ b/spec/data/complicated/config/patches/ruby/patch-configure
@@ -1,0 +1,103 @@
+$NetBSD: patch-configure,v 1.4 2012/10/12 14:51:31 taca Exp $
+
+* Adding Interix and MirBSD support.
+* Ignore doxygen.
+
+--- configure.orig	2012-10-12 09:23:46.000000000 +0000
++++ configure
+@@ -10654,6 +10654,9 @@ esac
+   superux*) :
+     	ac_cv_func_setitimer=no
+ 		 ;; #(
++  interix*)	LIBS="-lm $LIBS"
++	ac_cv_func_getpgrp_void=yes
++		 ;; #(
+   *) :
+     	LIBS="-lm $LIBS" ;;
+ esac
+@@ -11980,6 +11983,9 @@ fi
+ ac_fn_c_check_type "$LINENO" "struct timespec" "ac_cv_type_struct_timespec" "#ifdef HAVE_TIME_H
+ #include <time.h>
+ #endif
++#ifdef HAVE_SYS_TIME_H
++# include <sys/time.h>
++#endif
+ "
+ if test "x$ac_cv_type_struct_timespec" = xyes; then :
+ 
+@@ -15790,7 +15796,7 @@ done
+     MAINLIBS="-pthread $MAINLIBS" ;; #(
+   *) :
+     case "$target_os" in #(
+-  openbsd*) :
++  openbsd*|mirbsd*) :
+     LIBS="-pthread $LIBS" ;; #(
+   *) :
+     LIBS="-l$pthread_lib $LIBS" ;;
+@@ -16239,8 +16245,12 @@ esac ;; #(
+ 			rb_cv_dlopen=yes ;; #(
+   interix*) :
+     	: ${LDSHARED='$(CC) -shared'}
++			LDFLAGS="$LDFLAGS -Wl,-E"
+ 			XLDFLAGS="$XLDFLAGS -Wl,-E"
++			# use special random-slot linkage in 0x[56]XXXXXXX
+ 			LIBPATHFLAG=" -L%1\$-s"
++			DLDFLAGS="$DLDFLAGS "'-Wl,-h,$(.TARGET) -Wl,--image-base,$$(($$RANDOM %4096/2*262144+1342177280))'
++			RPATHFLAG=' -Wl,-R%1$-s'
+ 			rb_cv_dlopen=yes ;; #(
+   freebsd*|dragonfly*) :
+ 
+@@ -16252,7 +16262,7 @@ esac ;; #(
+ 			  test "$GCC" = yes && test "$rb_cv_prog_gnu_ld" = yes || LDSHARED="ld -Bshareable"
+ 			fi
+ 			rb_cv_dlopen=yes ;; #(
+-  openbsd*) :
++  openbsd*|mirbsd*) :
+     	: ${LDSHARED='$(CC) -shared ${CCDLFLAGS}'}
+ 			if test "$rb_cv_binary_elf" = yes; then
+ 			    LDFLAGS="$LDFLAGS -Wl,-E"
+@@ -16781,7 +16791,7 @@ _ACEOF
+   freebsd*|dragonfly*) :
+ 
+ 	SOLIBS='$(LIBS)'
+-	LIBRUBY_SO='lib$(RUBY_SO_NAME).so.$(MAJOR)$(MINOR)'
++	LIBRUBY_SO='lib$(RUBY_SO_NAME).so.$(MAJOR)$(MINOR)$(TEENY)'
+ 	if test "$rb_cv_binary_elf" != "yes" ; then
+ 	    LIBRUBY_SO="$LIBRUBY_SO.\$(TEENY)"
+ 	    LIBRUBY_ALIASES=''
+@@ -16798,7 +16808,7 @@ _ACEOF
+ 	   LIBRUBY_ALIASES=""
+ 	fi
+ 	 ;; #(
+-  openbsd*) :
++  openbsd*|mirbsd*) :
+ 
+ 	SOLIBS='$(LIBS)'
+ 	LIBRUBY_SO='lib$(RUBY_SO_NAME).so.$(MAJOR).'`expr ${MINOR} \* 10 + ${TEENY}`
+@@ -16859,7 +16869,12 @@ esac
+ 	 ;; #(
+   interix*) :
+ 
+-	LIBRUBYARG_SHARED='-L. -L${libdir} -l$(RUBY_SO_NAME)'
++	SOLIBS='$(LIBS)'
++	LIBRUBY_SO='lib$(RUBY_SO_NAME).so.$(MAJOR)$(MINOR).$(TEENY)'
++	# link explicitly to 0x48000000
++	LIBRUBY_DLDFLAGS='-Wl,-h,lib$(RUBY_SO_NAME).so.$(MAJOR)$(MINOR) -Wl,--image-base,1207959552'
++	LIBRUBYARG_SHARED='-Wl,-R -Wl,${libdir} -L${libdir} -L. -l$(RUBY_SO_NAME)'
++	LIBRUBY_ALIASES='lib$(RUBY_SO_NAME).so.$(MAJOR)$(MINOR) lib$(RUBY_SO_NAME).so'
+ 	 ;; #(
+   *) :
+      ;;
+@@ -16922,11 +16937,7 @@ if test "$install_doc" != no; then
+     else
+ 	RDOCTARGET="nodoc"
+     fi
+-    if test "$install_capi" != no -a -n "$DOXYGEN"; then
+-	CAPITARGET="capi"
+-    else
+-	CAPITARGET="nodoc"
+-    fi
++    CAPITARGET="nodoc"
+ else
+     RDOCTARGET="nodoc"
+     CAPITARGET="nodoc"

--- a/spec/data/complicated/config/patches/ruby/ruby-aix-configure.patch
+++ b/spec/data/complicated/config/patches/ruby/ruby-aix-configure.patch
@@ -1,0 +1,10 @@
+--- a/configure	2013-05-14 11:42:05 -0500
++++ b/configure	2013-05-22 14:49:01 -0500
+@@ -16314,6 +16314,7 @@
+   aix*) :
+     	: ${LDSHARED='$(CC)'}
+ 			LDSHARED="$LDSHARED ${linker_flag}-G"
++			DLDFLAGS='-eInit_$(TARGET)'
+ 			EXTDLDFLAGS='-e$(TARGET_ENTRY)'
+ 			XLDFLAGS="${linker_flag}"'-bE:$(ARCHFILE)'" ${linker_flag}-brtl"
+ 			XLDFLAGS="$XLDFLAGS ${linker_flag}-blibpath:${prefix}/lib:${LIBPATH:-/usr/lib:/lib}"

--- a/spec/data/complicated/config/patches/ruby/ruby-openssl-1.0.1c.patch
+++ b/spec/data/complicated/config/patches/ruby/ruby-openssl-1.0.1c.patch
@@ -1,0 +1,42 @@
+diff -Naur ruby-1.9.3-p286.pristine/ext/openssl/openssl_missing.c ruby-1.9.3-p286/ext/openssl/openssl_missing.c
+--- ruby-1.9.3-p286.pristine/ext/openssl/openssl_missing.c	2011-06-26 01:32:03.000000000 +0000
++++ ruby-1.9.3-p286/ext/openssl/openssl_missing.c	2013-01-28 05:08:38.192083253 +0000
+@@ -22,7 +22,7 @@
+ #include "openssl_missing.h"
+ 
+ #if !defined(HAVE_HMAC_CTX_COPY)
+-void
++int
+ HMAC_CTX_copy(HMAC_CTX *out, HMAC_CTX *in)
+ {
+     if (!out || !in) return;
+@@ -118,7 +118,7 @@
+  * tested on 0.9.7d.
+  */
+ int
+-EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, EVP_CIPHER_CTX *in)
++EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, const EVP_CIPHER_CTX *in)
+ {
+     memcpy(out, in, sizeof(EVP_CIPHER_CTX));
+ 
+diff -Naur ruby-1.9.3-p286.pristine/ext/openssl/openssl_missing.h ruby-1.9.3-p286/ext/openssl/openssl_missing.h
+--- ruby-1.9.3-p286.pristine/ext/openssl/openssl_missing.h	2011-06-26 01:32:03.000000000 +0000
++++ ruby-1.9.3-p286/ext/openssl/openssl_missing.h	2013-01-28 05:08:38.192500215 +0000
+@@ -68,7 +68,7 @@
+ #endif
+ 
+ #if !defined(HAVE_HMAC_CTX_COPY)
+-void HMAC_CTX_copy(HMAC_CTX *out, HMAC_CTX *in);
++int HMAC_CTX_copy(HMAC_CTX *out, HMAC_CTX *in);
+ #endif
+ 
+ #if !defined(HAVE_HMAC_CTX_CLEANUP)
+@@ -92,7 +92,7 @@
+ #endif
+ 
+ #if !defined(HAVE_EVP_CIPHER_CTX_COPY)
+-int EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, EVP_CIPHER_CTX *in);
++int EVP_CIPHER_CTX_copy(EVP_CIPHER_CTX *out, const EVP_CIPHER_CTX *in);
+ #endif
+ 
+ #if !defined(HAVE_EVP_DIGESTINIT_EX)

--- a/spec/data/complicated/config/patches/ruby/ruby_aix_1_9_3_448_ssl_EAGAIN.patch
+++ b/spec/data/complicated/config/patches/ruby/ruby_aix_1_9_3_448_ssl_EAGAIN.patch
@@ -1,0 +1,58 @@
+diff --git a/ext/openssl/lib/openssl/ssl-internal.rb b/ext/openssl/lib/openssl/ssl-internal.rb
+index 356d4e8..89a7a42 100644
+--- a/ext/openssl/lib/openssl/ssl-internal.rb
++++ b/ext/openssl/lib/openssl/ssl-internal.rb
+@@ -169,7 +169,15 @@ module OpenSSL
+         begin
+           ssl = OpenSSL::SSL::SSLSocket.new(sock, @ctx)
+           ssl.sync_close = true
+-          ssl.accept if @start_immediately
++          if @start_immediately
++            # Retry on EAGAIN (may be due to underlying inprogress for TLS handshake or renegotiation requested.)
++            # Any other error is rescued further.
++            begin
++              ssl.accept
++            rescue Errno::EAGAIN
++              retry
++            end
++          end
+           ssl
+         rescue SSLError => ex
+           sock.close
+diff --git a/lib/net/http.rb b/lib/net/http.rb
+index 9e4fe6a..41a9c75 100644
+--- a/lib/net/http.rb
++++ b/lib/net/http.rb
+@@ -797,7 +797,14 @@ module Net   #:nodoc:
+           end
+           # Server Name Indication (SNI) RFC 3546
+           s.hostname = @address if s.respond_to? :hostname=
+-          timeout(@open_timeout) { s.connect }
++          timeout(@open_timeout) {
++            # Retry on EAGAIN (may be due to underlying inprogress for TLS handshake or renegotiation requested.)
++            begin
++             s.connect
++            rescue Errno::EAGAIN
++             retry
++            end
++          }
+           if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+             s.post_connection_check(@address)
+           end
+diff --git a/lib/net/protocol.rb b/lib/net/protocol.rb
+index f374466..b6f9f17 100644
+--- a/lib/net/protocol.rb
++++ b/lib/net/protocol.rb
+@@ -153,6 +153,12 @@ module Net # :nodoc:
+         else
+           raise Timeout::Error
+         end
++      rescue Errno::EAGAIN
++        # read_nonblock calls underlying SSL_read. openssl doc states that data can be processed only when SSL/TLS
++        # record has been received completely. Also data that was not retrieved at the last call of SSL_read() 
++        # can still be buffered inside the SSL layer and will be retrieved on the next call to SSL_read.
++        # http://www.openssl.org/docs/ssl/SSL_read.html
++        retry
+       end
+     end
+ 

--- a/spec/data/complicated/config/patches/ruby/rvm-cflags.patch
+++ b/spec/data/complicated/config/patches/ruby/rvm-cflags.patch
@@ -1,0 +1,27 @@
+--- a/configure.in
++++ b/configure.in
+@@ -267,11 +267,9 @@
+     cflagspat="$cflagspat;s|"`eval echo '"'"${debugflags}"'"' | sed 's/[[][|.*]]/\\&/g;s/^ */ /;s/ *$/ /'`'| |g'
+ test -z "warnflags" ||
+     cflagspat="$cflagspat;s|"`eval echo '"'"${warnflags}"'"' | sed 's/[[][|.*]]/\\&/g;s/^ */ /;s/ *$/ /'`'| |g'
+-if test -z "${CFLAGS+set}"; then
+-    cflags=`echo " $cflags " | sed "$cflagspat;s/^ *//;s/ *$//"`
+-    orig_cflags="$cflags"
+-    cflags="$cflags "'${optflags} ${debugflags} ${warnflags}'
+-fi
++cflags=`echo " $cflags " | sed "$cflagspat;s/^ *//;s/ *$//"`
++orig_cflags="$cflags"
++cflags="$cflags "'${optflags} ${debugflags} ${warnflags}'
+ if test -z "${CXXFLAGS+set}"; then
+     cxxflags=`echo " $cxxflags " | sed "$cflagspat;s/^ *//;s/ *$//"`
+     orig_cxxflags="$cxxflags"
+@@ -511,7 +509,8 @@
+     ])
+ fi
+
+-test -z "${ac_env_CFLAGS_set}" -a -n "${cflags+set}" && eval CFLAGS="\"$cflags $ARCH_FLAG\""
++test -z "${ac_env_CFLAGS_set}" && CFLAGS="$ARCH_FLAG"
++test -n "${cflags:+set}" && eval CFLAGS="\"$cflags\${CFLAGS:+ $CFLAGS}\""
+ test -z "${ac_env_CXXFLAGS_set}" -a -n "${cxxflags+set}" && eval CXXFLAGS="\"$cxxflags $ARCH_FLAG\""
+
+ dnl check for large file stuff

--- a/spec/data/complicated/config/projects/angrychef.rb
+++ b/spec/data/complicated/config/projects/angrychef.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is a clone of chef that we can install on build and test machines
+# without interfering with the regular build/test.
+
+name "angrychef"
+maintainer "Opscode, Inc."
+homepage "http://www.opscode.com"
+
+replaces        "angrychef"
+install_path    "/opt/angrychef"
+build_version   '1.0.0'
+build_iteration 4
+
+dependency "preparation"
+dependency "chef"
+dependency "version-manifest"

--- a/spec/data/complicated/config/projects/chef-windows.rb
+++ b/spec/data/complicated/config/projects/chef-windows.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-windows"
+maintainer "Opscode, Inc."
+homepage "http://www.opscode.com"
+
+# NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
+#       Native gems will use gcc which will barf on files with spaces,
+#       which is only fixable if everyone in the world fixes their Makefiles
+install_path    "c:\\opscode\\chef"
+build_version   '1.0.0'
+build_iteration 4
+package_name    "chef-client"
+
+dependency "preparation"
+dependency "chef-windows"
+dependency "chef-client-msi"

--- a/spec/data/complicated/config/projects/chef.rb
+++ b/spec/data/complicated/config/projects/chef.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef"
+friendly_name "Chef Client"
+maintainer "Opscode, Inc."
+homepage "http://www.opscode.com"
+
+replaces        "chef-full"
+install_path    "/opt/chef"
+build_version   '1.0.0'
+build_iteration 4
+mac_pkg_identifier "com.getchef.pkg.chef"
+resources_path File.join(files_path, name)
+
+dependency "preparation"
+dependency "chef"
+dependency "version-manifest"

--- a/spec/data/complicated/config/projects/chefdk-windows.rb
+++ b/spec/data/complicated/config/projects/chefdk-windows.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chefdk-windows"
+maintainer "Opscode, Inc."
+homepage "http://www.opscode.com"
+
+# NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
+#       Native gems will use gcc which will barf on files with spaces,
+#       which is only fixable if everyone in the world fixes their Makefiles
+install_path    "c:\\opscode\\chefdk"
+build_version   '1.0.0'
+build_iteration 1
+
+package_name    "chef-dk"
+
+override :berkshelf, version: "3.0.0.beta6"
+override :bundler,   version: "1.5.2"
+override :nokogiri,  version: "1.6.1"
+
+dependency "preparation"
+dependency "ruby-windows"
+dependency "libyaml-windows"
+dependency "ruby-windows-devkit"
+dependency "chef-windows"
+dependency "chefdk"
+dependency "chef-client-msi"

--- a/spec/data/complicated/config/projects/chefdk.rb
+++ b/spec/data/complicated/config/projects/chefdk.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name       "chefdk"
+friendly_name "Chef DK"
+maintainer "Opscode, Inc."
+homepage   "http://www.opscode.com"
+
+install_path    "/opt/chefdk"
+build_version   '1.0.0'
+build_iteration 1
+mac_pkg_identifier "com.getchef.pkg.chefdk"
+resources_path File.join(files_path, name)
+
+override :berkshelf, version: "master"
+override :bundler,   version: "1.5.2"
+override :libedit,   version: "20130712-3.1"
+override :libtool,   version: "2.4.2"
+override :libxml2,   version: "2.9.1"
+override :libxslt,   version: "1.1.28"
+override :nokogiri,  version: "1.6.1"
+override :ruby,      version: "2.1.1"
+override :rubygems,  version: "2.2.1"
+override :yajl,      version: "1.2.0"
+override :zlib,      version: "1.2.8"
+
+dependency "preparation"
+dependency "chefdk"
+dependency "rubygems-customization"
+dependency "version-manifest"

--- a/spec/data/complicated/config/software/appbundler.rb
+++ b/spec/data/complicated/config/software/appbundler.rb
@@ -1,0 +1,25 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "appbundler"
+default_version "0.1.0.beta.0"
+
+dependency "bundler"
+
+build do
+  gem "install appbundler --no-rdoc --no-ri -v '#{version}'"
+end

--- a/spec/data/complicated/config/software/autoconf.rb
+++ b/spec/data/complicated/config/software/autoconf.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "autoconf"
+default_version "2.68"
+
+source :url => "http://ftp.gnu.org/gnu/autoconf/autoconf-2.68.tar.gz",
+       :md5 => "c3b5247592ce694f7097873aa07d66fe"
+
+relative_path "autoconf-2.68"
+
+env = {
+  "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+}
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
+  command "make -j #{max_build_jobs}"
+  command "make install"
+end

--- a/spec/data/complicated/config/software/automake.rb
+++ b/spec/data/complicated/config/software/automake.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "automake"
+default_version "1.11.2"
+
+dependency "autoconf"
+
+source :url => "http://ftp.gnu.org/gnu/automake/automake-1.11.2.tar.gz",
+       :md5 => "79ad64a9f6e83ea98d6964cef8d8a0bc"
+
+relative_path "automake-1.11.2"
+
+configure_env = {
+  "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
+}
+
+build do
+  command "./bootstrap", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}"
+  command "make install"
+end

--- a/spec/data/complicated/config/software/berkshelf.rb
+++ b/spec/data/complicated/config/software/berkshelf.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "berkshelf"
+default_version "master"
+always_build true
+
+source :git => "git://github.com/berkshelf/berkshelf"
+
+relative_path "berkshelf"
+
+if platform == 'windows'
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "libffi"
+  dependency "ruby"
+  dependency "rubygems"
+  dependency "libarchive"
+end
+dependency "nokogiri"
+
+dependency "bundler"
+
+build do
+  bundle "install --without guard", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  bundle "exec thor gem:build", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  gem ["install pkg/berkshelf-*.gem",
+       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+end

--- a/spec/data/complicated/config/software/bundler.rb
+++ b/spec/data/complicated/config/software/bundler.rb
@@ -1,0 +1,25 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "bundler"
+default_version "1.5.3"
+
+dependency "rubygems" unless platform == 'windows'
+
+build do
+  gem "install bundler --no-rdoc --no-ri -v '#{version}'"
+end

--- a/spec/data/complicated/config/software/bzip2.rb
+++ b/spec/data/complicated/config/software/bzip2.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Install bzip2 and its shared library, libbz2.so
+# This library object is required for building Python with the bz2 module,
+# and should be picked up automatically when building Python.
+
+name "bzip2"
+default_version "1.0.6"
+
+dependency "zlib"
+dependency "openssl"
+
+source :url => "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
+       :md5 => "00b516f4704d4a7cb50a1d97e6e8e15b"
+
+relative_path "#{name}-#{version}"
+
+prefix="#{install_dir}/embedded"
+libdir="#{prefix}/lib"
+
+env = {
+  "LDFLAGS" => "-L#{libdir} -I#{prefix}/include",
+  "CFLAGS" => "-L#{libdir} -I#{prefix}/include -fPIC",
+  "LD_RUN_PATH" => libdir
+}
+
+build do
+  patch :source => 'makefile_take_env_vars.patch'
+  command "make PREFIX=#{prefix} VERSION=#{version}", :env => env
+  command "make PREFIX=#{prefix} VERSION=#{version} -f Makefile-libbz2_so", :env => env
+  command "make install VERSION=#{version} PREFIX=#{prefix}", :env => env
+end

--- a/spec/data/complicated/config/software/cacerts.rb
+++ b/spec/data/complicated/config/software/cacerts.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "cacerts"
+default_version "2014.04.22"  # date of the file is in a comment at the start, or in the changelog
+
+source :url => "http://curl.haxx.se/ca/cacert.pem",
+       :md5 => "9f92a0d9f605e227ae068e605f4c86fa"
+
+relative_path "cacerts-#{version}"
+
+build do
+  block do
+    FileUtils.mkdir_p(File.expand_path("embedded/ssl/certs", install_dir))
+
+    # There is a bug in omnibus-ruby that may or may not have been fixed. Since the source url
+    # does not point to an archive, omnibus-ruby tries to copy cacert.pem into the project working
+    # directory. However, it fails and copies to '/var/cache/omnibus/src/cacerts-2012.12.19\' instead
+    # There is supposed to be a fix in omnibus-ruby, but under further testing, it was unsure if the
+    # fix worked. Rather than trying to fix this now, we're filing a bug and copying the cacert.pem
+    # directly from the cache instead.
+
+    FileUtils.cp(File.expand_path("cacert.pem", Omnibus.config.cache_dir),
+                 File.expand_path("embedded/ssl/certs/cacert.pem", install_dir))
+  end
+
+  unless platform == 'windows'
+    command "ln -sf #{install_dir}/embedded/ssl/certs/cacert.pem #{install_dir}/embedded/ssl/cert.pem"
+  end
+end

--- a/spec/data/complicated/config/software/chef-client-msi.rb
+++ b/spec/data/complicated/config/software/chef-client-msi.rb
@@ -1,0 +1,88 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-client-msi"
+
+source :path => File.expand_path("files/msi", Omnibus.project_root)
+
+build do
+  # harvest with heat.exe
+  # recursively generate fragment for chef-client directory
+  block do
+    src_dir = self.project_dir
+
+    shell = Mixlib::ShellOut.new("heat.exe dir \"#{install_dir}\" -nologo -srd -gg -cg ChefClientDir -dr CHEFLOCATION -var var.ChefClientSourceDir -out chef-client-Files.wxs", :cwd => src_dir)
+    shell.run_command
+    shell.error!
+  end
+
+  # Prepare the include file which contains the version numbers
+  block do
+    require 'erb'
+
+    File.open("#{project_dir}\\templates\\chef-client-Config.wxi.erb") { |file|
+      # build_version looks something like this:
+      # dev builds => 0.10.8-299-g360818f
+      # rel builds => 0.10.8-299
+      versions = build_version.split("-").first.split(".")
+      @major_version = versions[0]
+      @minor_version = versions[1]
+      @micro_version = versions[2]
+      @build_version = build_version.split("-")[1] || self.project.build_iteration
+
+      # Find path in which chef gem is installed to.
+      # Note that install_dir is something like: c:\\opscode\\chef
+      chef_path_regex = "#{install_dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR)}/**/gems/chef-[0-9]*"
+      chef_gem_paths = Dir[chef_path_regex].select{ |path| File.directory?(path) }
+      raise "Expected one but found #{chef_gem_paths.length} installation directories for chef gem using: #{chef_path_regex}. Found paths: #{chef_gem_paths.inspect}." unless chef_gem_paths.length == 1
+      @chef_gem_path = chef_gem_paths.first
+
+      # Convert the chef gem path to a relative path based on install_dir
+      # We are going to use this path in the startup command of chef
+      # service. So we need to change file seperators to make windows
+      # happy.
+      @chef_gem_path.gsub!(File::SEPARATOR, File::ALT_SEPARATOR)
+      @chef_gem_path.slice!(install_dir.gsub(File::SEPARATOR, File::ALT_SEPARATOR) + File::ALT_SEPARATOR)
+
+      @guid = "D607A85C-BDFA-4F08-83ED-2ECB4DCD6BC5"
+
+      erb = ERB.new(file.read)
+      File.open("#{project_dir}\\ChefClient-Config.wxi", "w") { |out|
+        out.write(erb.result(binding))
+      }
+    }
+  end
+
+  # Create temporary directory to store the files required for msi
+  # packaging.
+  command "IF exist #{install_dir}\\msi-tmp (echo msi-tmp is found on the system) ELSE (mkdir #{install_dir}\\msi-tmp && echo msi-tmp directory is created.) "
+
+  # Copy the localization file into the temporary file directory for packaging
+  command "xcopy chef-client-en-us.wxl #{install_dir}\\msi-tmp /Y", :cwd => source[:path]
+
+  # Copy the asset files into the temporary file directory for packaging
+  command "xcopy assets #{install_dir}\\msi-tmp\\assets /I /Y", :cwd => source[:path]
+
+  # compile with candle.exe
+  block do
+    src_dir = self.project_dir
+
+    shell = Mixlib::ShellOut.new("candle.exe -nologo -out #{install_dir}\\msi-tmp\\ -dChefClientSourceDir=\"#{install_dir}\" chef-client-Files.wxs chef-client.wxs", :cwd => src_dir)
+    shell.run_command
+    shell.error!
+  end
+end

--- a/spec/data/complicated/config/software/chef-gem.rb
+++ b/spec/data/complicated/config/software/chef-gem.rb
@@ -1,0 +1,26 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-gem"
+default_version "11.12.2"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  gem "install chef -n #{install_dir}/embedded/bin --no-rdoc --no-ri -v #{version}"
+end

--- a/spec/data/complicated/config/software/chef-vault.rb
+++ b/spec/data/complicated/config/software/chef-vault.rb
@@ -1,0 +1,43 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name 'chef-vault'
+default_version 'v2.2.1'
+
+source :git => 'git://github.com/Nordstrom/chef-vault.git'
+
+relative_path 'chef-vault'
+
+if platform == 'windows'
+  dependency 'ruby-windows'
+  dependency 'ruby-windows-devkit'
+  dependency 'chef-windows'
+else
+  dependency 'ruby'
+  dependency 'rubygems'
+  dependency 'chef'
+end
+
+
+build_env = {'PATH' => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+
+build do
+  bundle 'install --no-cache', :env => build_env
+  gem 'build chef-vault.gemspec', :env => build_env
+  gem ['install chef-vault-*.gem',
+       '--no-rdoc --no-ri'].join(' '), :env => build_env
+end

--- a/spec/data/complicated/config/software/chef-windows.rb
+++ b/spec/data/complicated/config/software/chef-windows.rb
@@ -1,0 +1,158 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef-windows"
+
+dependency "ruby-windows" #includes rubygems
+dependency "libyaml-windows"
+dependency "ruby-windows-devkit"
+dependency "bundler"
+dependency "cacerts"
+
+default_version "master"
+
+source :git => "git://github.com/opscode/chef"
+
+relative_path "chef"
+
+build do
+  #####################################################################
+  #
+  # nasty nasty nasty hack for setting artifact version
+  #
+  #####################################################################
+  #
+  # since omnibus-ruby is not architected to intentionally let the
+  # software definitions define the #build_version and
+  # #build_iteration of the package artifact, we're going to implement
+  # a temporary hack here that lets us do so. this type of use case
+  # will become a feature of omnibus-ruby in the future, but in order
+  # to get things shipped, we'll hack it up here.
+  #
+  # <3 Stephen
+  #
+  #####################################################################
+  block do
+    project = self.project
+    if project.name == "chef-windows"
+      git_cmd = "git describe --tags"
+      src_dir = self.project_dir
+      shell = Mixlib::ShellOut.new(git_cmd,
+                                   :cwd => src_dir)
+      shell.run_command
+      shell.error!
+      build_version = shell.stdout.chomp
+
+      project.build_version   build_version
+      project.build_iteration ENV["CHEF_PACKAGE_ITERATION"].to_i || 1
+    end
+  end
+
+  # COMPAT HACK :( - Chef 11 finally has the core Chef code in the root of the
+  # project repo. Since the Chef Client pipeline needs to build/test Chef 10.x
+  # and 11 releases our software definition need to handle both cases
+  # gracefully.
+  block do
+    build_commands = self.builder.build_commands
+    chef_root = File.join(self.project_dir, "chef")
+    if File.exists?(chef_root)
+      build_commands.each_index do |i|
+        cmd = build_commands[i].dup
+        if cmd.is_a? Array
+          if cmd.last.is_a? Hash
+            cmd_opts = cmd.pop.dup
+            cmd_opts[:cwd] = chef_root
+            cmd << cmd_opts
+          else
+            cmd << {:cwd => chef_root}
+          end
+          build_commands[i] = cmd
+        end
+      end
+    end
+  end
+
+  # Normally we would symlink the required unix tools.
+  # However with the introduction of git-cache to speed up omnibus builds,
+  # we can't do that anymore since git on windows doesn't support symlinks.
+  # https://groups.google.com/forum/#!topic/msysgit/arTTH5GmHRk
+  # Therefore we copy the tools to the necessary places.
+  # We need tar for 'knife cookbook site install' to function correctly
+  {"tar.exe" => "bsdtar.exe",
+    "libarchive-2.dll" => "libarchive-2.dll",
+    "libexpat-1.dll" => "libexpat-1.dll",
+    "liblzma-1.dll" => "liblzma-1.dll",
+    "libbz2-2.dll" => "libbz2-2.dll",
+    "libz-1.dll" => "libz-1.dll"
+  }.each do |target, to|
+    source = File.expand_path(File.join(install_dir, "embedded", "mingw", "bin", to)).gsub(/\//, "\\")
+    target = File.expand_path(File.join(install_dir, "bin", target)).gsub(/\//, "\\")
+    command "cp #{source}  #{target}"
+  end
+
+  rake "gem"
+
+  gem ["install pkg/chef*mingw32.gem",
+       "-n #{install_dir}/bin",
+       "--no-rdoc --no-ri"].join(" ")
+
+  # XXX: doing a normal bundle_bust here results in gems installed into the outer bundle...
+  command "bundle install", :env => { "PATH" => "#{install_dir}/embedded/bin;#{install_dir}/embedded/mingw/bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem", "BUNDLE_BIN_PATH" => "#{install_dir}/embedded/bin/bundle" , "BUNDLE_GEMFILE" => nil, "GEM_HOME" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "GEM_PATH" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "RUBYOPT" => nil }
+
+  # render batch files
+  #
+  # TODO:
+  #  I'd love to move this out to a top-level 'template' operation in omnibus, but it currently
+  #  requires pretty deep inspection of the Rubygems structure of the installed chef and ohai
+  #  gems
+  #
+  block do
+    require 'erb'
+    require 'rubygems/format'
+
+    batch_template = ERB.new <<EOBATCH
+@ECHO OFF
+IF NOT "%~f0" == "~f0" GOTO :WinNT
+@"%~dp0\\..\\embedded\\bin\\ruby.exe" "%~dp0/<%= @bin %>" %1 %2 %3 %4 %5 %6 %7 %8 %9
+GOTO :EOF
+:WinNT
+@"%~dp0\\..\\embedded\\bin\\ruby.exe" "%~dpn0" %*
+EOBATCH
+
+    gem_executables = []
+    %w{chef}.each do |gem|
+      puts "#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"
+      require 'pp'
+      pp Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"]
+      gem_file = Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"].first
+      gem_executables << Gem::Format.from_file_by_path(gem_file).spec.executables
+    end
+
+    # XXX: need to fix ohai to use own gemspec as well and eliminate copypasta
+    %w{ohai}.each do |gem|
+      gem_file = Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*.gem"].first
+      gem_executables << Gem::Format.from_file_by_path(gem_file).spec.executables
+    end
+
+    gem_executables.flatten.each do |bin|
+      @bin = bin
+      File.open("#{install_dir}/bin/#{@bin}.bat", "w") do |f|
+        f.puts batch_template.result(binding)
+      end
+    end
+  end
+end

--- a/spec/data/complicated/config/software/chef.rb
+++ b/spec/data/complicated/config/software/chef.rb
@@ -1,0 +1,170 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chef"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "yajl"
+dependency "bundler"
+
+default_version "master"
+
+source :git => "git://github.com/opscode/chef"
+
+relative_path "chef"
+
+always_build (self.project.name == "chef")
+
+env =
+  case platform
+  when "solaris2"
+    {
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
+    }
+  when "aix"
+    {
+      "LDFLAGS" => "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+      "CFLAGS" => "-I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  end
+
+build do
+  #####################################################################
+  #
+  # nasty nasty nasty hack for setting artifact version
+  #
+  #####################################################################
+  #
+  # since omnibus-ruby is not architected to intentionally let the
+  # software definitions define the #build_version and
+  # #build_iteration of the package artifact, we're going to implement
+  # a temporary hack here that lets us do so. this type of use case
+  # will become a feature of omnibus-ruby in the future, but in order
+  # to get things shipped, we'll hack it up here.
+  #
+  # <3 Stephen
+  #
+  #####################################################################
+  block do
+    project = self.project
+    if project.name == "chef"
+      git_cmd = "git describe --tags"
+      src_dir = self.project_dir
+      shell = Mixlib::ShellOut.new(git_cmd,
+                                   :cwd => src_dir)
+      shell.run_command
+      shell.error!
+      build_version = shell.stdout.chomp
+
+      project.build_version   build_version
+      project.build_iteration ENV["CHEF_PACKAGE_ITERATION"].to_i || 1
+    end
+  end
+
+  # COMPAT HACK :( - Chef 11 finally has the core Chef code in the root of the
+  # project repo. Since the Chef Client pipeline needs to build/test Chef 10.x
+  # and 11 releases our software definition need to handle both cases
+  # gracefully.
+  block do
+    build_commands = self.builder.build_commands
+    chef_root = File.join(self.project_dir, "chef")
+    if File.exists?(chef_root)
+      build_commands.each_index do |i|
+        cmd = build_commands[i].dup
+        if cmd.is_a? Array
+          if cmd.last.is_a? Hash
+            cmd_opts = cmd.pop.dup
+            cmd_opts[:cwd] = chef_root
+            cmd << cmd_opts
+          else
+            cmd << {:cwd => chef_root}
+          end
+          build_commands[i] = cmd
+        end
+      end
+    end
+  end
+
+  # The way we install chef is different between chefdk and chef projects
+  # due to the fact that chefdk project has appbundler enabled.
+  # Two differences are:
+  #   1-) Order of bundle install & rake gem
+  #   2-) "-n #{install_dir}/bin" option for gem install
+  # We don't expect any side effects from (1) other than not creating
+  # link to erubis binary (which is not needed other than ruby 1.8.7 due to
+  # change that switched the template syntax checking to native ruby code.
+  # Not having (2) does not create symlinks for binaries under
+  # #{install_dir}/bin which gets created by appbundler later on.
+  if project.name == "chef"
+    # install chef first so that ohai gets installed into /opt/chef/bin/ohai
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    command "rm -f pkg/chef-*-x86-mingw32.gem"
+
+    gem ["install pkg/chef-*.gem",
+      "-n #{install_dir}/bin",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    # install the whole bundle, so that we get dev gems (like rspec) and can later test in CI
+    # against all the exact gems that we ship (we will run rspec unbundled in the test phase).
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  else
+    # install the whole bundle first
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+    command "rm -f pkg/chef-*-x86-mingw32.gem"
+
+    # Don't use -n #{install_dir}/bin. Appbundler will take care of them later
+    gem ["install pkg/chef-*.gem",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+  end
+
+  auxiliary_gems = []
+  auxiliary_gems << "ruby-shadow" unless platform == "aix"
+
+  gem ["install",
+       auxiliary_gems.join(" "),
+       "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+  #
+  # TODO: the "clean up" section below was cargo-culted from the
+  # clojure version of omnibus that depended on the build order of the
+  # tasks and not dependencies. if we really need to clean stuff up,
+  # we should probably stick the clean up steps somewhere else
+  #
+
+  # clean up
+  ["docs",
+   "share/man",
+   "share/doc",
+   "share/gtk-doc",
+   "ssl/man",
+   "man",
+   "info"].each do |dir|
+    command "rm -rf #{install_dir}/embedded/#{dir}"
+  end
+end

--- a/spec/data/complicated/config/software/chefdk.rb
+++ b/spec/data/complicated/config/software/chefdk.rb
@@ -1,0 +1,103 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "chefdk"
+default_version "master"
+
+source :git => "git://github.com/opscode/chef-dk"
+
+relative_path "chef-dk"
+
+always_build (self.project.name == "chefdk")
+
+if platform == 'windows'
+  dependency "chef-windows"
+else
+  dependency "chef"
+end
+
+dependency "test-kitchen"
+dependency "appbundler"
+dependency "berkshelf"
+dependency "chef-vault"
+
+sep = File::PATH_SEPARATOR || ":"
+path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
+
+env = {
+  # rubocop pulls in nokogiri 1.5.11, so needs PKG_CONFIG_PATH and
+  # NOKOGIRI_USE_SYSTEM_LIBRARIES until rubocop stops doing that
+  "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+  "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
+  "PATH" => path
+}
+
+build do
+  # Nasty hack to set the artifact version until this gets fixed:
+  # https://github.com/opscode/omnibus-ruby/issues/134
+  block do
+    project = self.project
+    if project.name == "chefdk"
+      project.build_version Omnibus::BuildVersion.new(self.project_dir).semver
+    end
+  end
+
+  def appbuilder(app_path, bin_path)
+    sep = File::PATH_SEPARATOR || ":"
+    path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
+
+    gemfile = File.join(app_path, "Gemfile.lock")
+    command("#{install_dir}/embedded/bin/appbundler #{app_path} #{bin_path}",
+            :env => {
+      'RUBYOPT'         => nil,
+      'BUNDLE_BIN_PATH' => nil,
+      'BUNDLE_GEMFILE'  => gemfile,
+      'GEM_PATH'        => nil,
+      'GEM_HOME'        => nil,
+      'PATH'            => path
+    })
+  end
+
+  bundle "install", :env => {"PATH" => path}
+  rake "build", :env => env.merge({"PATH" => path})
+
+  gem ["install pkg/chef-dk*.gem",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => path})
+
+  auxiliary_gems = []
+
+  auxiliary_gems << {name: 'foodcritic',  version: '3.0.3'}
+  auxiliary_gems << {name: 'chefspec',    version: '3.4.0'}
+  auxiliary_gems << {name: 'rubocop',     version: '0.18.1'}
+  auxiliary_gems << {name: 'knife-spork', version: '1.3.2'}
+  auxiliary_gems << {name: 'kitchen-vagrant', version: '0.15.0'}
+  # strainer build is hosed on windows
+  # auxiliary_gems << {name: 'strainer',    version: '3.3.0'}
+
+  # do multiple gem installs to better isolate/debug failures
+  auxiliary_gems.each do |g|
+    gem "install #{g[:name]} -v #{g[:version]} -n #{install_dir}/bin --no-rdoc --no-ri --verbose", :env => env
+  end
+
+  block { FileUtils.mkdir_p("#{install_dir}/embedded/apps") }
+
+  appbundler_apps = %w[chef berkshelf test-kitchen chef-dk chef-vault]
+  appbundler_apps.each do |app_name|
+    block { FileUtils.cp_r("#{source_dir}/#{app_name}", "#{install_dir}/embedded/apps/") }
+    appbuilder("#{install_dir}/embedded/apps/#{app_name}", "#{install_dir}/bin")
+  end
+end

--- a/spec/data/complicated/config/software/couchdb.rb
+++ b/spec/data/complicated/config/software/couchdb.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "couchdb"
+default_version "1.0.3"
+
+dependency "spidermonkey"
+dependency "icu"
+dependency "curl"
+dependency "erlang"
+
+source :url => "http://archive.apache.org/dist/couchdb/#{version}/apache-couchdb-#{version}.tar.gz",
+       :md5 => "cfdc2ab751bf18049c5ef7866602d8ed"
+
+relative_path "apache-couchdb-#{version}"
+
+build_env = {
+  "RPATH" => "#{install_dir}/embedded/lib",
+  "CURL_CONFIG" => "#{install_dir}/embedded/bin/curl-config",
+  "ICU_CONFIG" => "#{install_dir}/embedded/bin/icu-config",
+  "ERL" => "#{install_dir}/embedded/bin/erl",
+  "ERLC" => "#{install_dir}/embedded/bin/erlc",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+#  command "./bootstrap", :env => build_env
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--disable-init",
+           "--disable-launchd",
+           "--with-erlang=#{install_dir}/embedded/lib/erlang/usr/include",
+           "--with-js-include=#{install_dir}/embedded/include",
+           "--with-js-lib=#{install_dir}/embedded/lib"].join(" "), :env => build_env
+  command "make -j #{max_build_jobs}", :env => build_env
+  command "make install", :env => build_env
+end

--- a/spec/data/complicated/config/software/curl.rb
+++ b/spec/data/complicated/config/software/curl.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "curl"
+default_version "7.36.0"
+
+dependency "zlib"
+dependency "openssl"
+
+source :url => "http://curl.haxx.se/download/curl-#{version}.tar.gz",
+       :md5 => "643a7030b27449e76413d501d4b8eb57"
+
+relative_path "curl-#{version}"
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--disable-debug",
+           "--enable-optimize",
+           "--disable-ldap",
+           "--disable-ldaps",
+           "--disable-rtsp",
+           "--enable-proxy",
+           "--disable-dependency-tracking",
+           "--enable-ipv6",
+           "--without-libidn",
+           "--without-gnutls",
+           "--without-librtmp",
+           "--with-ssl=#{install_dir}/embedded",
+           "--with-zlib=#{install_dir}/embedded"].join(" ")
+
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/erlang.rb
+++ b/spec/data/complicated/config/software/erlang.rb
@@ -1,0 +1,65 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "erlang"
+default_version "R15B03-1"
+
+dependency "zlib"
+dependency "openssl"
+dependency "ncurses"
+
+version "R15B03-1" do
+  source :md5 => 'eccd1e6dda6132993555e088005019f2'
+  relative_path "otp_src_R15B03"
+end
+
+version "R16B03-1" do
+  source md5: 'e5ece977375197338c1b93b3d88514f8'
+  relative_path "otp_src_#{version}"
+end
+
+source :url => "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
+
+env = {
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
+  "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include"
+}
+
+build do
+  # set up the erlang include dir
+  command "mkdir -p #{install_dir}/embedded/erlang/include"
+  %w{ncurses openssl zlib.h zconf.h}.each do |link|
+    command "ln -fs #{install_dir}/embedded/include/#{link} #{install_dir}/embedded/erlang/include/#{link}"
+  end
+
+  # TODO: build cross-platform. this is for linux
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--enable-threads",
+           "--enable-smp-support",
+           "--enable-kernel-poll",
+           "--enable-dynamic-ssl-lib",
+           "--enable-shared-zlib",
+           "--enable-hipe",
+           "--without-javac",
+           "--with-ssl=#{install_dir}/embedded",
+           "--disable-debug"].join(" "),
+          :env => env)
+
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/expat.rb
+++ b/spec/data/complicated/config/software/expat.rb
@@ -1,0 +1,21 @@
+name "expat"
+default_version "2.1.0"
+
+relative_path "expat-2.1.0"
+
+source :url => "http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fexpat%2F&ts=1374730265&use_mirror=iweb",
+       :md5 => "dd7dab7a5fea97d2a6a43f511449b7cd"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded"].join(" "), :env => env
+
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/fcgi.rb
+++ b/spec/data/complicated/config/software/fcgi.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "fcgi"
+default_version "2.4.0"
+
+dependency "autoconf"
+dependency "automake"
+dependency "libtool"
+
+source :url => "http://fastcgi.com/dist/fcgi-2.4.0.tar.gz",
+       :md5 => "d15060a813b91383a9f3c66faf84867e"
+
+relative_path "fcgi-2.4.0"
+
+reconf_env = {"PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"}
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -L/lib -L/usr/lib",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  # patch and touch files so it builds
+  diff = <<D
+24a25
+> #include <cstdio>
+D
+  command "echo '#{diff}' | patch libfcgi/fcgio.cpp"
+  command "touch COPYING ChangeLog AUTHORS NEWS"
+
+  # autoreconf
+  command "autoreconf -i -f", :env => reconf_env
+  command "libtoolize", :env => reconf_env
+
+  # configure and build
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/fcgiwrap.rb
+++ b/spec/data/complicated/config/software/fcgiwrap.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "fcgiwrap"
+default_version "1.0.3"
+
+dependency "autoconf"
+dependency "fcgi"
+
+# TODO: deploy from the 1.0.3 tag / SHA
+source :git => "git://github.com/gnosek/fcgiwrap"
+
+relative_path "fcgiwrap"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  command "autoreconf -i", :env => env
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/gd.rb
+++ b/spec/data/complicated/config/software/gd.rb
@@ -1,0 +1,56 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gd"
+default_version "2.0.33"
+
+dependency "libiconv"
+dependency "zlib"
+dependency "libjpeg"
+dependency "libpng"
+
+# TODO: make sure that this is where we want to download libgd from
+source :url => "https://bitbucket.org/libgd/gd-libgd/get/GD_2_0_33.tar.gz",
+       :md5 => "a028f1642586e611fa39c39175478721"
+
+relative_path "libgd-gd-libgd-486e81dea984"
+
+source_dir = "#{project_dir}/src"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "LIBS" => "-liconv"
+}
+
+build do
+  patch :source => 'gd-2.0.33-configure-libpng.patch'
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-libiconv-prefix=#{install_dir}/embedded",
+           "--with-jpeg=#{install_dir}/embedded",
+           "--with-png=#{install_dir}/embedded",
+           "--without-x", "--without-freetype",
+           "--without-fontconfig",
+           "--without-xpm"].join(" "),
+          :env => configure_env,
+          :cwd => source_dir)
+
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin", "LIBS" => "-liconv"}, :cwd => source_dir
+  command "make install", :cwd => source_dir
+end

--- a/spec/data/complicated/config/software/gdbm.rb
+++ b/spec/data/complicated/config/software/gdbm.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gdbm"
+default_version "1.9.1"
+
+dependency "libgcc"
+
+source :url => "http://ftp.gnu.org/gnu/gdbm/gdbm-1.9.1.tar.gz",
+       :md5 => "59f6e4c4193cb875964ffbe8aa384b58"
+
+relative_path "gdbm-1.9.1"
+
+build do
+  configure_command = ["./configure",
+                       "--enable-libgdbm-compat",
+                       "--prefix=#{install_dir}/embedded"]
+
+  if platform == "freebsd"
+    configure_command << "--with-pic"
+  end
+
+  command configure_command.join(" ")
+  command "make -j #{max_build_jobs}"
+  command "make install"
+end

--- a/spec/data/complicated/config/software/gecode.rb
+++ b/spec/data/complicated/config/software/gecode.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "gecode"
+default_version "3.7.3"
+
+source :url => "http://www.gecode.org/download/gecode-3.7.3.tar.gz",
+       :md5 => "7a5cb9945e0bb48f222992f2106130ac"
+
+relative_path "gecode-3.7.3"
+
+test = Mixlib::ShellOut.new("test -f /usr/bin/gcc44")
+test.run_command
+
+configure_env = if test.exitstatus == 0
+                  {"CC" => "gcc44", "CXX" => "g++44"}
+                else
+                  {}
+                end
+
+build do
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--disable-doc-dot",
+           "--disable-doc-search",
+           "--disable-doc-tagfile",
+           "--disable-doc-chm",
+           "--disable-doc-docset",
+           "--disable-qt",
+           "--disable-examples"].join(" "),
+          :env => configure_env)
+  command "make -j #{max_build_jobs}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+  command "make install"
+end

--- a/spec/data/complicated/config/software/git.rb
+++ b/spec/data/complicated/config/software/git.rb
@@ -1,0 +1,40 @@
+name "git"
+default_version "1.9.1"
+
+dependency "curl"
+dependency "zlib"
+dependency "openssl"
+dependency "pcre"
+dependency "libiconv"
+dependency "expat"
+dependency "perl"
+
+relative_path "git-#{version}"
+
+source :url => "https://github.com/git/git/archive/v#{version}.tar.gz",
+       :md5 => "906f984f5c8913176547dc456608be16"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+
+  "NO_GETTEXT" => "1",
+  "NO_PYTHON" => "1",
+  "NO_TCLTK" => "1",
+  "NO_R_TO_GCC_LINKER" => "1",
+  "NEEDS_LIBICONV" => "1",
+
+  "PERL_PATH" => "#{install_dir}/embedded/bin/perl",
+  "ZLIB_PATH" => "#{install_dir}/embedded",
+  "ICONVDIR" => "#{install_dir}/embedded",
+  "OPENSSLDIR" => "#{install_dir}/embedded",
+  "EXPATDIR" => "#{install_dir}/embedded",
+  "CURLDIR" => "#{install_dir}/embedded",
+  "LIBPCREDIR" => "#{install_dir}/embedded"
+}
+
+build do
+  command "make -j #{max_build_jobs} prefix=#{install_dir}/embedded", :env => env
+  command "make install prefix=#{install_dir}/embedded", :env => env
+end

--- a/spec/data/complicated/config/software/help2man.rb
+++ b/spec/data/complicated/config/software/help2man.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "help2man"
+default_version "1.40.5"
+
+source :url => "http://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
+       :md5 => "75a7d2f93765cd367aab98986a75f88c"
+
+relative_path "help2man-1.40.5"
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded"
+  command "make"
+  command "make install"
+end

--- a/spec/data/complicated/config/software/icu.rb
+++ b/spec/data/complicated/config/software/icu.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "icu"
+default_version "4.8.1.1"
+
+source :url => "http://download.icu-project.org/files/icu4c/4.8.1.1/icu4c-4_8_1_1-src.tgz",
+:md5 => "ea93970a0275be6b42f56953cd332c17"
+
+relative_path "icu"
+
+working_dir = "#{project_dir}/source"
+
+build do
+  command("./configure --prefix=#{install_dir}/embedded",
+          :env => {
+            "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+          },
+          :cwd => working_dir)
+  command("make -j #{max_build_jobs}",
+          :env => {
+            "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+          },
+          :cwd => working_dir)
+  command "make install", :cwd => working_dir
+end

--- a/spec/data/complicated/config/software/jre.rb
+++ b/spec/data/complicated/config/software/jre.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "jre"
+default_version "7u3-b04"
+
+dependency "rsync"
+
+whitelist_file "jre/bin/javaws"
+whitelist_file "jre/bin/policytool"
+whitelist_file "jre/lib"
+whitelist_file "jre/plugin"
+
+if OHAI.kernel['machine'] =~ /x86_64/
+  # TODO: download x86 version on x86 machines
+  source :url => "http://download.oracle.com/otn-pub/java/jdk/7u3-b04/jre-7u3-linux-x64.tar.gz",
+         :md5 => "3d3e206cea84129f1daa8e62bf656a28",
+         :cookie => 'oraclelicensejre-7u3-oth-JPR=accept-securebackup-cookie;gpw_e24=http://www.oracle.com/technetwork/java/javase/downloads/jre-7u3-download-1501631.html',
+         :warning => "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+else
+  source :url => "http://download.oracle.com/otn-pub/java/jdk/7u3-b04/jre-7u3-linux-i586.tar.gz",
+         :md5 => "cfce10a05f8d152d39aef892f2cd4011",
+         :cookie => 'oraclelicensejre-7u3-oth-JPR=accept-securebackup-cookie;gpw_e24=http://www.oracle.com/technetwork/java/javase/downloads/jre-7u3-download-1501631.html',
+         :warning => "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+end
+
+relative_path "jre1.7.0_03"
+
+jre_dir = "#{install_dir}/embedded/jre"
+
+build do
+  command "mkdir -p #{jre_dir}"
+  command "#{install_dir}/embedded/bin/rsync -a . #{jre_dir}/"
+end

--- a/spec/data/complicated/config/software/keepalived.rb
+++ b/spec/data/complicated/config/software/keepalived.rb
@@ -1,0 +1,45 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "keepalived"
+default_version "1.2.9"
+
+dependency "popt"
+dependency "openssl"
+
+source :url => "http://www.keepalived.org/software/keepalived-1.2.9.tar.gz",
+       :md5 => "adfad98a2cc34230867d794ebc633492"
+
+relative_path "keepalived-1.2.9"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  # This is cherry-picked from change
+  # d384ce8b3492b9d76af23e621a20bed8da9c6016 of keepalived, (master
+  # branch), and should be no longer necessary after 1.2.9.
+  patch :source => "keepalived-1.2.9_opscode_centos_5.patch"
+  command "./configure --prefix=#{install_dir}/embedded --disable-iconv", :env => env
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end
+
+

--- a/spec/data/complicated/config/software/libarchive.rb
+++ b/spec/data/complicated/config/software/libarchive.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: Copyright (c) 2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# A requirement for api.berkshelf.com that is used in berkshelf specs
+# https://github.com/berkshelf/api.berkshelf.com
+
+name "libarchive"
+default_version "3.1.2"
+
+source :url => "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
+  :md5 => 'efad5a503f66329bb9d2f4308b5de98a'
+
+relative_path "libarchive-#{version}"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include "
+}
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded \
+    --without-lzma \
+    --without-lzo2 \
+    --without-nettle \
+    --without-xml2 \
+    --without-expat \
+    --without-bz2lib \
+    --without-iconv \
+    --without-zlib \
+    --disable-bsdtar \
+    --disable-bsdcpio \
+    --without-lzmadec \
+    --without-openssl", :env => env
+  command "make", :env => env
+  command "make install", :env => env
+end

--- a/spec/data/complicated/config/software/libedit.rb
+++ b/spec/data/complicated/config/software/libedit.rb
@@ -1,0 +1,69 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libedit"
+default_version "20120601-3.0"
+
+dependency "ncurses"
+dependency "libgcc"
+
+version "20120601-3.0" do
+  source md5: "e50f6a7afb4de00c81650f7b1a0f5aea"
+end
+
+version "20130712-3.1" do
+  source md5: "0891336c697362727a1fa7e60c5cb96c"
+end
+
+source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
+
+relative_path "libedit-#{version}"
+
+env = case platform
+      when "aix"
+        {
+          "CC" => "xlc -q64",
+          "CXX" => "xlC -q64",
+          "LD" => "ld -b64",
+          "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+          "CXXFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+          "OBJECT_MODE" => "64",
+          "ARFLAGS" => "-X64 cru",
+          "M4" => "/opt/freeware/bin/m4",
+          "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+        }
+      else
+        {
+          "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+          "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
+        }
+      end
+
+build do
+  # The patch is from the FreeBSD ports tree and is for GCC compatibility.
+  # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
+  if platform == "freebsd"
+    patch :source => "freebsd-vi-fix.patch"
+  end
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded"
+           ].join(" "), :env => env
+  command "make -j #{max_build_jobs}", :env => env
+  command "make -j #{max_build_jobs} install"
+end

--- a/spec/data/complicated/config/software/libffi.rb
+++ b/spec/data/complicated/config/software/libffi.rb
@@ -1,0 +1,71 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libffi"
+default_version "3.0.13"
+
+dependency "libgcc"
+dependency "libtool"
+
+# TODO: this link is subject to change with each new release of zlib.
+#       we'll need to use a more robust link (sourceforge) that will
+#       not change over time.
+source :url => "ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz",
+       :md5 => '45f3b6dbc9ee7c7dfbbbc5feba571529'
+
+relative_path "libffi-3.0.13"
+configure_env =
+  case platform
+  when "aix"
+    {
+      "LDFLAGS" => "-maix64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+      "CFLAGS" => "-maix64 -I#{install_dir}/embedded/include",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib -DNO_VIZ"
+    }
+  else
+    {
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}"
+  command "make -j #{max_build_jobs} install"
+  # libffi's default install location of header files is aweful...
+  command "cp -f #{install_dir}/embedded/lib/libffi-3.0.13/include/* #{install_dir}/embedded/include"
+
+  # On centos libffi libraries are places under /embedded/lib64
+  # move them over to lib
+  if platform == "centos"
+    command "mv #{install_dir}/embedded/lib64/* #{install_dir}/embedded/lib/"
+    command "rm -rf #{install_dir}/embedded/lib64"
+  end
+end

--- a/spec/data/complicated/config/software/libgcc.rb
+++ b/spec/data/complicated/config/software/libgcc.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libgcc"
+description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
+
+if (platform == "solaris2" && Omnibus.config.solaris_compiler == "gcc")
+  build do
+    if File.exists?("/opt/csw/lib/libgcc_s.so.1")
+      command "cp /opt/csw/lib/libgcc_s.so.1 #{install_dir}/embedded/lib/"
+    else
+      raise "cannot find libgcc_s.so.1 -- where is your gcc compiler?"
+    end
+  end
+end
+
+if platform == "aix"
+  build do
+    if File.exists?("/opt/freeware/lib/pthread/ppc64/libgcc_s.a")
+      command "cp -f /opt/freeware/lib/pthread/ppc64/libgcc_s.a #{install_dir}/embedded/lib/"
+    else
+      raise "cannot find libgcc_s.a -- where is your gcc compiler?"
+    end
+  end
+end
+

--- a/spec/data/complicated/config/software/libiconv.rb
+++ b/spec/data/complicated/config/software/libiconv.rb
@@ -1,0 +1,66 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libiconv"
+default_version "1.14"
+
+dependency "libgcc"
+
+source :url => "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
+       :md5 => 'e34509b1623cec449dfeb73d7ce9c6c6'
+
+relative_path "libiconv-#{version}"
+
+env = case platform
+      when "aix"
+        {
+          "CC" => "xlc -q64",
+          "CXX" => "xlC -q64",
+          "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+          "CFLAGS" => "-O -q64 -I#{install_dir}/embedded/include",
+          "CXXFLAGS" => "-O -q64 -I#{install_dir}/embedded/include",
+          "LD" => "ld -b64",
+          "OBJECT_MODE" => "64",
+          "ARFLAGS" => "-X64 cru "
+        }
+      else
+        {
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+        }
+      end
+
+if platform == "solaris2"
+  env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc", "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
+end
+
+def glibc_dropped_gets?
+  return false unless OHAI["os"] == "linux"
+
+  output = `/usr/bin/env getconf GNU_LIBC_VERSION`
+
+  return false unless output =~ /^glibc/
+
+  output.sub(/glibc /, "").to_f >= 2.16
+end
+
+build do
+  patch :source => 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch' if glibc_dropped_gets?
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
+  command "make -j #{max_build_jobs}", :env => env
+  command "make -j #{max_build_jobs} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env
+end

--- a/spec/data/complicated/config/software/libjpeg.rb
+++ b/spec/data/complicated/config/software/libjpeg.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libjpeg"
+default_version "8d"
+
+source :url => "http://www.ijg.org/files/jpegsrc.v8d.tar.gz",
+       :md5 => "52654eb3b2e60c35731ea8fc87f1bd29"
+
+relative_path "jpeg-8d"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded --enable-shared --enable-static", :env => configure_env
+  command "mkdir -p #{install_dir}/embedded/man/man1"
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+  command "rm -rf #{install_dir}/embedded/man"
+end

--- a/spec/data/complicated/config/software/libpng.rb
+++ b/spec/data/complicated/config/software/libpng.rb
@@ -1,0 +1,38 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libpng"
+default_version "1.5.17"
+
+dependency "zlib"
+
+source :url => "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng15/libpng-#{version}.tar.gz",
+       :md5 => "d2e27dbd8c6579d1582b3f128fd284b4"
+
+relative_path "libpng-#{version}"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded --with-zlib-prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/libtool.rb
+++ b/spec/data/complicated/config/software/libtool.rb
@@ -1,0 +1,52 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libtool"
+default_version "2.4"
+
+version "2.4" do
+  source md5: "b32b04148ecdd7344abc6fe8bd1bb021"
+end
+
+version "2.4.2" do
+  source md5: "d2f3b7d4627e69e13514a40e72a24d50"
+end
+
+source url: "http://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
+
+relative_path "libtool-#{version}"
+
+build do
+  env = case platform
+        when "aix"
+        {
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+            "CFLAGS" => "-maix64 -O -I#{install_dir}/embedded/include",
+            "OBJECT_MODE" => "64",
+            "CC" => "gcc -maix64",
+            "CXX" => "g++ -maix64",
+        }
+  end
+  if platform == "aix"
+    command "./configure --prefix=#{install_dir}/embedded --with-gcc", :env => env
+    command "make", :env => env
+  else
+    command "./configure --prefix=#{install_dir}/embedded"
+    command "make"
+  end
+  command "make install"
+end

--- a/spec/data/complicated/config/software/libwrap.rb
+++ b/spec/data/complicated/config/software/libwrap.rb
@@ -1,0 +1,50 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libwrap"
+default_version "7.6"
+
+source :url => "ftp://ftp.porcupine.org/pub/security/tcp_wrappers_7.6.tar.gz",
+       :md5 => "e6fa25f71226d090f34de3f6b122fb5a"
+
+relative_path "tcp_wrappers_7.6"
+
+########################################################################
+#
+# libwrap (tcp_wrappers) build instructions pulled from
+# http://www.linuxfromscratch.org/blfs/view/6.3/basicnet/tcpwrappers.html
+#
+########################################################################
+#
+# patches:
+# * shared_lib_plus_plus-1: Required Patch (Fixes some build issues
+#   and adds building a shared library)
+# * malloc-fix: replaces the `sed` command from the build instructions
+#   linked above
+# * makefile-dest-fix: patches the makefile to not add "/usr/" to
+#   destination dir for library install and doesn't set ownership of
+#   the libraries
+#
+
+build do
+  patch :source => "tcp_wrappers-7.6-shared_lib_plus_plus-1.patch"
+  patch :source => "tcp_wrappers-7.6-malloc-fix.patch"
+  patch :source => "tcp_wrappers-7.6-makefile-dest-fix.patch"
+  command "make STYLE=-DPROCESS_OPTIONS linux"
+  command "make DESTDIR=#{install_dir}/embedded install-lib"
+  command "make DESTDIR=#{install_dir}/embedded install-dev"
+end

--- a/spec/data/complicated/config/software/libxml2.rb
+++ b/spec/data/complicated/config/software/libxml2.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libxml2"
+default_version "2.7.8"
+
+dependency "zlib"
+dependency "libiconv"
+
+version "2.7.8" do
+  source md5: "8127a65e8c3b08856093099b52599c86"
+end
+
+version "2.9.1" do
+  source md5: "9c0cfef285d5c4a5c80d00904ddab380"
+end
+
+source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
+
+relative_path "libxml2-#{version}"
+
+build do
+  cmd = ["./configure",
+         "--prefix=#{install_dir}/embedded",
+         "--with-zlib=#{install_dir}/embedded",
+         "--with-iconv=#{install_dir}/embedded",
+         "--without-python",
+         "--without-icu"].join(" ")
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+  }
+  command cmd, :env => env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+end

--- a/spec/data/complicated/config/software/libxslt.rb
+++ b/spec/data/complicated/config/software/libxslt.rb
@@ -1,0 +1,52 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libxslt"
+default_version "1.1.26"
+
+dependency "libxml2"
+dependency "libtool" if platform == "solaris2"
+
+version "1.1.26" do
+  source md5: "e61d0364a30146aaa3001296f853b2b9"
+end
+
+version "1.1.28" do
+  source md5: "9667bf6f9310b957254fdcf6596600b7"
+end
+
+source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+
+relative_path "libxslt-#{version}"
+
+build do
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+  }
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-libxml-prefix=#{install_dir}/embedded",
+           "--with-libxml-include-prefix=#{install_dir}/embedded/include",
+           "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
+           "--without-python",
+           "--without-crypto"].join(" "),
+          :env => env)
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
+  command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
+end

--- a/spec/data/complicated/config/software/libyaml-windows.rb
+++ b/spec/data/complicated/config/software/libyaml-windows.rb
@@ -1,0 +1,43 @@
+#
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# libyaml 0.1.5 fixes a security vulnerability to 0.1.4.
+# Since the rubyinstaller.org doesn't release ruby when a dependency gets
+# patched, we are manually patching the dependency until we get a new
+# ruby release on windows.
+# See: https://github.com/oneclick/rubyinstaller/issues/210
+# This component should be removed when libyaml 0.1.5 ships with ruby builds
+# of rubyinstaller.org
+#
+name "libyaml-windows"
+default_version "0.1.6"
+
+dependency "ruby-windows"
+
+source :url => "http://packages.openknapsack.org/libyaml/libyaml-0.1.6-x86-windows.tar.lzma",
+       :md5 => "8bb5d8e43cf18ec48b4751bdd0111c84"
+
+build do
+  temp_directory = File.join(cache_dir, "libyaml-cache")
+  # First extract the tar file out of lzma archive.
+  command "7z.exe x #{project_file} -o#{temp_directory} -r -y"
+  # Now extract the files out of tar archive.
+  command "7z.exe x #{File.join(temp_directory, "libyaml-0.1.6-x86-windows.tar")} -o#{temp_directory} -r -y"
+  # Now copy over libyaml-0-2.dll to the build dir
+  command "cp #{File.join(temp_directory, "bin", "libyaml-0-2.dll")} #{File.join(install_dir, "embedded", "bin", "libyaml-0-2.dll")}"
+end

--- a/spec/data/complicated/config/software/libyaml.rb
+++ b/spec/data/complicated/config/software/libyaml.rb
@@ -1,0 +1,62 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libyaml"
+default_version '0.1.6'
+
+source :url => "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
+       :md5 => '5fe00cda18ca5daeb43762b80c38e06e'
+
+relative_path "yaml-#{version}"
+
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -DNO_VIZ"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => configure_env
+  command "make -j #{max_build_jobs} install", :env => configure_env
+end

--- a/spec/data/complicated/config/software/logrotate.rb
+++ b/spec/data/complicated/config/software/logrotate.rb
@@ -1,0 +1,41 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "logrotate"
+default_version "3.8.5"
+
+dependency "popt"
+
+source :url => "https://fedorahosted.org/releases/l/o/logrotate/logrotate-#{version}.tar.gz",
+       :md5 => "d3c13e2a963a55c584cfaa83e96b173d"
+
+relative_path "logrotate-#{version}"
+
+env = {
+  # Patch allows this to be set manually
+  "BASEDIR" => "#{install_dir}/embedded",
+  # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS
+  # and CFLAGS
+  "EXTRA_LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "EXTRA_CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+}
+
+build do
+  patch :source => "logrotate_basedir_override.patch", :plevel => 0
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/makedepend.rb
+++ b/spec/data/complicated/config/software/makedepend.rb
@@ -1,0 +1,73 @@
+#
+# Copyright:: Copyright (c) 2014 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "makedepend"
+default_version "1.0.5"
+
+source :url => 'http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz',
+  :md5 => 'efb2d7c7e22840947863efaedc175747'
+
+relative_path 'makedepend-1.0.5'
+
+dependency "xproto"
+dependency 'util-macros'
+dependency 'pkg-config'
+
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+configure_env["PKG_CONFIG_PATH"] = "#{install_dir}/embedded/lib/pkgconfig" +
+  File::PATH_SEPARATOR +
+  "#{install_dir}/embedded/share/pkgconfig"
+
+# For pkg-config
+configure_env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => configure_env
+  command "make -j #{max_build_jobs} install", :env => configure_env
+end

--- a/spec/data/complicated/config/software/mysql2.rb
+++ b/spec/data/complicated/config/software/mysql2.rb
@@ -1,0 +1,42 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Enable MySQL support by adding the following to '/etc/chef-server/chef-server.rb':
+#
+#   database_type = 'mysql'
+#   postgresql['enable'] = false
+#   mysql['enable'] = true
+#   mysql['destructive_migrate'] = true
+#
+# Then run 'chef-server-ctl reconfigure'
+#
+
+name "mysql2"
+versions_to_install = [ "0.3.6", "0.3.7" ]
+default_version versions_to_install.join("-")
+
+dependency "ruby"
+dependency "bundler"
+
+build do
+  gem "install rake-compiler"
+  command "mkdir -p #{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
+  versions_to_install.each do |ver|
+    gem "fetch mysql2 --version #{ver}", :cwd => "#{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
+  end
+end

--- a/spec/data/complicated/config/software/nagios-plugins.rb
+++ b/spec/data/complicated/config/software/nagios-plugins.rb
@@ -1,0 +1,53 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nagios-plugins"
+default_version "1.4.15"
+
+dependency "zlib"
+dependency "openssl"
+dependency "postgresql"
+dependency "libiconv"
+
+# the url is the location of a redirect from sourceforge
+source :url => "http://downloads.sourceforge.net/project/nagiosplug/nagiosplug/1.4.15/nagios-plugins-1.4.15.tar.gz",
+       :md5 => "56abd6ade8aa860b38c4ca4a6ac5ab0d"
+
+relative_path "nagios-plugins-1.4.15"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+gem_env = {"GEM_PATH" => nil, "GEM_HOME" => nil}
+
+build do
+  # configure it
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded/nagios",
+           "--with-trusted-path=#{install_dir}/bin:#{install_dir}/embedded/bin:/bin:/sbin:/usr/bin:/usr/sbin",
+           "--with-openssl=#{install_dir}/embedded",
+           "--with-pgsql=#{install_dir}/embedded",
+           "--with-libiconv-prefix=#{install_dir}/embedded"].join(" "),
+          :env => configure_env)
+
+  # build it
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "sudo make install"
+end

--- a/spec/data/complicated/config/software/nagios.rb
+++ b/spec/data/complicated/config/software/nagios.rb
@@ -1,0 +1,66 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nagios"
+default_version "3.3.1"
+
+dependency "gd"
+dependency "php"
+dependency "spawn-fcgi"
+
+source :url => "http://downloads.sourceforge.net/project/nagios/nagios-3.x/nagios-3.3.1/nagios-3.3.1.tar.gz",
+       :md5 => "c935354ce0d78a63bfabc3055fa77ad5"
+
+relative_path "nagios"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  # configure it
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded/nagios",
+           "--with-nagios-user=opscode-nagios",
+           "--with-nagios-group=opscode-nagios",
+           "--with-command-group=opscode-nagios-cmd",
+           "--with-command-user=opscode-nagios-cmd",
+           "--with-gd-lib=#{install_dir}/embedded/lib",
+           "--with-gd-inc=#{install_dir}/embedded/include",
+           "--with-temp-dir=/var#{install_dir}/nagios/tmp",
+           "--with-lockfile=/var#{install_dir}/nagios/lock",
+           "--with-checkresult-dir=/var#{install_dir}/nagios/checkresult",
+           "--with-mail=/usr/bin/mail"].join(" "),
+          :env => env)
+
+  # so dome hacky shit
+  command "sed -i 's:for file in includes/rss/\\*;:for file in includes/rss/\\*.\\*;:g' ./html/Makefile"
+  command "sed -i 's:for file in includes/rss/extlib/\\*;:for file in includes/rss/extlib/\\*.\\*;:g' ./html/Makefile"
+  command "bash -c \"find . -name 'Makefile' | xargs sed -i 's:-o opscode-nagios-cmd -g opscode-nagios-cmd:-o root -g root:g'\""
+  command "bash -c \"find . -name 'Makefile' | xargs sed -i 's:-o opscode-nagios -g opscode-nagios:-o root -g root:g'\""
+
+  # build it
+  command "make -j #{max_build_jobs} all", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+  command "sudo make install"
+  command "sudo make install-config"
+  command "sudo make install-exfoliation"
+
+  # clean up the install
+  command "sudo rm -rf #{install_dir}/embedded/nagios/etc/*"
+end

--- a/spec/data/complicated/config/software/ncurses.rb
+++ b/spec/data/complicated/config/software/ncurses.rb
@@ -1,0 +1,149 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ncurses"
+default_version "5.9"
+
+dependency "libgcc"
+dependency "libtool" if platform == "aix"
+
+source :url => "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
+       :md5 => "8cb9c412e5f2d96bc6f459aa8c6282a1"
+
+relative_path "ncurses-5.9"
+
+env = case platform
+      when "aix"
+        {
+          "PATH" => "#{install_dir}/embedded/bin:" + ENV['PATH'],
+          "LDFLAGS" => "-Wl,-brtl -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+          "CXXFLAGS" => "-O -I#{install_dir}/embedded/include",
+          "CFLAGS" => "-O -I#{install_dir}/embedded/include",
+          "OBJECT_MODE" => "64",
+          "CC" => "gcc -maix64",
+          "CXX" => "g++ -maix64",
+          "CFLAGS" => "-maix64 -I#{install_dir}/embedded/include",
+          "ARFLAGS" => "-X64 cru"
+        }
+      else
+        {
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+          "LDFLAGS" => "-L#{install_dir}/embedded/lib"
+        }
+      end
+
+if platform == "solaris2"
+  env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc"})
+  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
+  # gcc4 from opencsw fails to compile ncurses
+  env.merge!({"PATH" => "/opt/csw/gcc3/bin:/opt/csw/bin:/usr/local/bin:/usr/sfw/bin:/usr/ccs/bin:/usr/sbin:/usr/bin"})
+  env.merge!({"CC" => "/opt/csw/gcc3/bin/gcc"})
+  env.merge!({"CXX" => "/opt/csw/gcc3/bin/g++"})
+elsif platform == "smartos"
+  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib "})
+end
+
+########################################################################
+#
+# wide-character support:
+# Ruby 1.9 optimistically builds against libncursesw for UTF-8
+# support. In order to prevent Ruby from linking against a
+# package-installed version of ncursesw, we build wide-character
+# support into ncurses with the "--enable-widec" configure parameter.
+# To support other applications and libraries that still try to link
+# against libncurses, we also have to create non-wide libraries.
+#
+# The methods below are adapted from:
+# http://www.linuxfromscratch.org/lfs/view/development/chapter06/ncurses.html
+#
+########################################################################
+
+build do
+  if platform == "smartos"
+    # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
+    # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0
+    # compatibility:
+    # http://ftp.netbsd.org/pub/pkgsrc/current/pkgsrc/devel/ncurses/patches/
+    patch :source => 'patch-aa', :plevel => 0
+    patch :source => 'patch-ab', :plevel => 0
+    patch :source => 'patch-ac', :plevel => 0
+    patch :source => 'patch-ad', :plevel => 0
+    patch :source => 'patch-cxx_cursesf.h', :plevel => 0
+    patch :source => 'patch-cxx_cursesm.h', :plevel => 0
+
+    # Opscode patches - <someara@opscode.com>
+    # The configure script from the pristine tarball detects xopen_source_extended incorrectly.
+    # Manually working around a false positive.
+    patch :source => 'ncurses-5.9-solaris-xopen_source_extended-detection.patch', :plevel => 0
+  end
+
+  if platform == "aix"
+    patch :source => 'patch-aix-configure', :plevel => 0
+  end
+
+  if platform == "mac_os_x"
+    # References:
+    # https://github.com/Homebrew/homebrew-dupes/issues/43
+    # http://invisible-island.net/ncurses/NEWS.html#t20110409
+    #
+    # Patches ncurses for clang compiler. Changes have been accepted into
+    # upstream, but occurred shortly after the 5.9 release. We should be able
+    # to remove this after upgrading to any release created after June 2012
+    patch :source => 'ncurses-clang.patch'
+  end
+
+  # build wide-character libraries
+  cmd_array = ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-shared",
+           "--with-termlib",
+           "--without-debug",
+           "--without-normal", # AIX doesn't like building static libs
+           "--enable-overwrite",
+           "--enable-widec"]
+
+  cmd_array << "--with-libtool" if platform == 'aix'
+  command(cmd_array.join(" "),
+          :env => env)
+  command "make -j #{max_build_jobs}", :env => env
+  command "make -j #{max_build_jobs} install", :env => env
+
+  # build non-wide-character libraries
+  command "make distclean"
+  cmd_array = ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-shared",
+           "--with-termlib",
+           "--without-debug",
+           "--without-normal",
+           "--enable-overwrite"]
+  cmd_array << "--with-libtool" if platform == 'aix'
+  command(cmd_array.join(" "),
+          :env => env)
+  command "make -j #{max_build_jobs}", :env => env
+
+  # installing the non-wide libraries will also install the non-wide
+  # binaries, which doesn't happen to be a problem since we don't
+  # utilize the ncurses binaries in private-chef (or oss chef)
+  command "make -j #{max_build_jobs} install", :env => env
+
+  # Ensure embedded ncurses wins in the LD search path
+  if platform == "smartos"
+    command "ln -sf #{install_dir}/embedded/lib/libcurses.so #{install_dir}/embedded/lib/libcurses.so.1"
+  end
+end

--- a/spec/data/complicated/config/software/nginx.rb
+++ b/spec/data/complicated/config/software/nginx.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nginx"
+default_version "1.4.4"
+
+dependency "pcre"
+dependency "openssl"
+
+source :url => "http://nginx.org/download/nginx-#{version}.tar.gz",
+       :md5 => "5dfaba1cbeae9087f3949860a02caa9f"
+
+relative_path "nginx-#{version}"
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-http_ssl_module",
+           "--with-http_stub_status_module",
+           "--with-ipv6",
+           "--with-debug",
+           "--with-ld-opt=-L#{install_dir}/embedded/lib",
+           "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\""].join(" ")
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/nodejs.rb
+++ b/spec/data/complicated/config/software/nodejs.rb
@@ -1,0 +1,44 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nodejs"
+default_version "0.10.10"
+
+version "0.10.10" do
+  source :md5 => "a47a9141567dd591eec486db05b09e1c"
+end
+
+version "0.10.26" do
+  source :md5 => "15e9018dadc63a2046f61eb13dfd7bd6"
+end
+
+source :url => "http://nodejs.org/dist/v#{version}/node-v#{version}.tar.gz"
+
+relative_path "node-v#{version}"
+
+# Ensure we run with Python 2.6 on Redhats < 6
+if OHAI['platform_family'] == "rhel" && OHAI['platform_version'].to_f < 6
+  python = 'python26'
+else
+  python = 'python'
+end
+
+build do
+  command "#{python} ./configure --prefix=#{install_dir}/embedded"
+  command "make -j #{max_build_jobs}"
+  command "make install"
+end

--- a/spec/data/complicated/config/software/nokogiri.rb
+++ b/spec/data/complicated/config/software/nokogiri.rb
@@ -1,0 +1,55 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nokogiri"
+default_version "1.6.1"
+
+if platform == 'windows'
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+  dependency "rubygems"
+  dependency "libxml2"
+  dependency "libxslt"
+  dependency "libiconv"
+  dependency "zlib"
+end
+
+# nokogiri uses pkg-config, and on a mac that will find the system pkg-config
+# which will find the system pkg-configs which will pull in libicucore from the
+# libxml2 pkg-config spec.  override pkg-configs path here to point into our
+# /opt/chef/embedded pkg-configs.  this should probably be done more generally,
+# in core ominbus-ruby.
+env = {
+  "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+  "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
+}
+
+build do
+  gem ["install",
+       "nokogiri",
+       "-v #{version}",
+       "--",
+       "--use-system-libraries",
+       "--with-xml2-lib=#{install_dir}/embedded/lib",
+       "--with-xml2-include=#{install_dir}/embedded/include/libxml2",
+       "--with-xslt-lib=#{install_dir}/embedded/lib",
+       "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
+       "--with-iconv-dir=#{install_dir}/embedded",
+       "--with-zlib-dir=#{install_dir}/embedded"].join(" "), :env => env
+end

--- a/spec/data/complicated/config/software/nrpe.rb
+++ b/spec/data/complicated/config/software/nrpe.rb
@@ -1,0 +1,61 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "nrpe"
+default_version "2.13"
+
+dependency "zlib"
+dependency "openssl"
+dependency "libwrap"
+
+# tarball location comes from sourceforge download redirect
+source :url => "http://downloads.sourceforge.net/project/nagios/nrpe-2.x/nrpe-2.13/nrpe-2.13.tar.gz",
+       :md5 => "e5176d9b258123ce9cf5872e33a77c1a"
+
+relative_path "nrpe-2.13"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  # TODO: OMG THIS IS HORRIBLE
+  command "sed -i 's:\\r::g' ./src/nrpe.c"
+
+  patch :source => "fix_for_runit.patch",
+        :target => "./src/nrpe.c"
+
+  # configure it
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-ssl=#{install_dir}/embedded",
+           "--with-ssl-lib=#{install_dir}/embedded/lib",
+           "--with-ssl-inc=#{install_dir}/embedded/include"].join(" "),
+          :env => env)
+
+  # build it
+  command "make all", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+
+  # move it
+  command "mkdir -p #{install_dir}/embedded/nagios/libexec"
+  command "mkdir -p #{install_dir}/embedded/nagios/bin"
+  command "cp ./src/check_nrpe #{install_dir}/embedded/nagios/libexec"
+  command "sudo cp ./src/nrpe #{install_dir}/embedded/nagios/bin"
+end

--- a/spec/data/complicated/config/software/ohai.rb
+++ b/spec/data/complicated/config/software/ohai.rb
@@ -1,0 +1,64 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ohai"
+if platform == 'windows'
+  dependency "ruby-windows" #includes rubygems
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+  dependency "rubygems"
+  dependency "yajl"
+end
+
+dependency "bundler"
+
+default_version "master"
+
+source :git => "git://github.com/opscode/ohai"
+
+relative_path "ohai"
+
+env =
+  case platform
+  when "solaris2"
+    {
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  when "aix"
+    {
+      "LDFLAGS" => "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+      "CFLAGS" => "-I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  end
+
+build do
+
+  # install chef first so that ohai gets installed into /opt/chef/bin/ohai
+  rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+  gem ["install pkg/ohai*.gem",
+      "-n #{install_dir}/bin",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
+
+end

--- a/spec/data/complicated/config/software/omnibus-ctl.rb
+++ b/spec/data/complicated/config/software/omnibus-ctl.rb
@@ -1,0 +1,35 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "omnibus-ctl"
+default_version "0.0.7"
+
+dependency "ruby"
+dependency "rubygems"
+dependency "bundler"
+
+source :git => "git://github.com/opscode/omnibus-ctl.git"
+
+relative_path "omnibus-ctl"
+
+build do
+  gem "build omnibus-ctl.gemspec"
+  gem "install omnibus-ctl-#{version}.gem"
+  command "mkdir -p #{install_dir}/embedded/service/omnibus-ctl"
+  command "touch #{install_dir}/embedded/service/omnibus-ctl/.gitkeep"
+end
+

--- a/spec/data/complicated/config/software/openresty.rb
+++ b/spec/data/complicated/config/software/openresty.rb
@@ -1,0 +1,67 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "openresty"
+default_version "1.4.3.6"
+
+dependency "pcre"
+dependency "openssl"
+dependency "zlib"
+
+source :url => "http://openresty.org/download/ngx_openresty-#{version}.tar.gz",
+       :md5 => "5e5359ae3f1b8db4046b358d84fabbc8"
+
+relative_path "ngx_openresty-#{version}"
+
+build do
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+  }
+
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--sbin-path=#{install_dir}/embedded/sbin/nginx",
+           "--conf-path=#{install_dir}/embedded/conf/nginx.conf",
+           "--with-http_ssl_module",
+           "--with-debug",
+           "--with-http_stub_status_module",
+           # Building Nginx with non-system OpenSSL
+           # http://www.ruby-forum.com/topic/207287#902308
+           "--with-ld-opt=\"-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz\"",
+           "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"",
+           # Options inspired by the OpenResty Cookbook
+           '--with-md5-asm',
+           '--with-sha1-asm',
+           '--with-pcre-jit',
+           '--with-luajit',
+           '--without-http_ssi_module',
+           '--without-mail_smtp_module',
+           '--without-mail_imap_module',
+           '--without-mail_pop3_module',
+           '--with-ipv6',
+           # AIO support define in Openresty cookbook. Requires Kernel >= 2.6.22
+           # Ubuntu 10.04 reports: 2.6.32-38-server #83-Ubuntu SMP
+           # However, they require libatomic-ops-dev and libaio
+           #'--with-file-aio',
+           #'--with-libatomic'
+          ].join(" "), :env => env
+
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/openssl.rb
+++ b/spec/data/complicated/config/software/openssl.rb
@@ -1,0 +1,158 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "openssl"
+
+dependency "zlib"
+dependency "cacerts"
+dependency "libgcc"
+dependency "makedepend"
+
+
+if platform == "aix"
+  # XXX: OpenSSL has an open bug on 1.0.1e where it fails to install on AIX
+  #      http://rt.openssl.org/Ticket/Display.html?id=2986&user=guest&pass=guest
+  default_version "1.0.1c"
+  source :url => "http://www.openssl.org/source/openssl-1.0.1c.tar.gz",
+         :md5 => "ae412727c8c15b67880aef7bd2999b2e"
+else
+  default_version "1.0.1g"
+  source :url => "http://www.openssl.org/source/openssl-1.0.1g.tar.gz",
+         :md5 => "de62b43dfcd858e66a74bee1c834e959"
+end
+
+relative_path "openssl-#{version}"
+
+build do
+  patch :source => "openssl-1.0.1f-do-not-build-docs.patch"
+
+  env = case platform
+        when "mac_os_x"
+          {
+            "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+            "LDFLAGS" => "-arch x86_64 -R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses"
+          }
+        when "aix"
+        {
+            "CC" => "xlc -q64",
+            "CXX" => "xlC -q64",
+            "LD" => "ld -b64",
+            "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+            "CXXFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+            "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+            "OBJECT_MODE" => "64",
+            "AR" => "/usr/bin/ar",
+            "ARFLAGS" => "-X64 cru",
+            "M4" => "/opt/freeware/bin/m4",
+        }
+        when "solaris2"
+          {
+            "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+            "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+            "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
+          }
+        else
+          {
+            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+          }
+        end
+
+  common_args = [
+    "--prefix=#{install_dir}/embedded",
+    "--with-zlib-lib=#{install_dir}/embedded/lib",
+    "--with-zlib-include=#{install_dir}/embedded/include",
+    "no-idea",
+    "no-mdc2",
+    "no-rc5",
+    "zlib",
+    "shared",
+  ].join(" ")
+
+  configure_command = case platform
+                      when "aix"
+                        ["perl", "./Configure",
+                         "aix64-cc",
+                         common_args,
+                        "-L#{install_dir}/embedded/lib",
+                        "-I#{install_dir}/embedded/include",
+                        "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib"].join(" ")
+                      when "mac_os_x"
+                        ["./Configure",
+                         "darwin64-x86_64-cc",
+                         common_args,
+                        ].join(" ")
+                      when "smartos"
+                        ["/bin/bash ./Configure",
+                         "solaris64-x86_64-gcc",
+                         common_args,
+                         "-L#{install_dir}/embedded/lib",
+                         "-I#{install_dir}/embedded/include",
+                         "-R#{install_dir}/embedded/lib",
+                        "-static-libgcc"].join(" ")
+                      when "solaris2"
+                        if Omnibus.config.solaris_compiler == "gcc"
+                          if architecture == "sparc"
+                            ["/bin/sh ./Configure",
+                             "solaris-sparcv9-gcc",
+                             common_args,
+                            "-L#{install_dir}/embedded/lib",
+                            "-I#{install_dir}/embedded/include",
+                            "-R#{install_dir}/embedded/lib",
+                            "-static-libgcc"].join(" ")
+                          else
+                            # This should not require a /bin/sh, but without it we get
+                            # Errno::ENOEXEC: Exec format error
+                            ["/bin/sh ./Configure",
+                             "solaris-x86-gcc",
+                             common_args,
+                            "-L#{install_dir}/embedded/lib",
+                            "-I#{install_dir}/embedded/include",
+                            "-R#{install_dir}/embedded/lib",
+                            "-static-libgcc"].join(" ")
+                          end
+                        else
+                          raise "sorry, we don't support building openssl on non-gcc solaris builds right now."
+                        end
+                      else
+                        ["./config",
+                        common_args,
+                        "disable-gost",  # fixes build on linux, but breaks solaris
+                        "-L#{install_dir}/embedded/lib",
+                        "-I#{install_dir}/embedded/include",
+                        "-Wl,-rpath,#{install_dir}/embedded/lib"].join(" ")
+                      end
+
+  # openssl build process uses a `makedepend` tool that we build inside the bundle.
+  env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+
+  # @todo: move into omnibus-ruby
+  has_gmake = system("gmake --version")
+
+  if has_gmake
+    env.merge!({'MAKE' => 'gmake'})
+    make_binary = 'gmake'
+  else
+    make_binary = 'make'
+  end
+
+  command configure_command, :env => env
+  command "#{make_binary} depend", :env => env
+  # make -j N on openssl is not reliable
+  command "#{make_binary}", :env => env
+  command "#{make_binary} install", :env => env
+end

--- a/spec/data/complicated/config/software/pcre.rb
+++ b/spec/data/complicated/config/software/pcre.rb
@@ -1,0 +1,42 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "pcre"
+default_version "8.31"
+
+dependency "libedit"
+dependency "ncurses"
+
+source :url => "http://iweb.dl.sourceforge.net/project/pcre/pcre/8.31/pcre-8.31.tar.gz",
+       :md5 => "fab1bb3b91a4c35398263a5c1e0858c1"
+
+relative_path "pcre-8.31"
+
+configure_env = {
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+}
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--enable-pcretest-libedit"].join(" "), :env => configure_env
+  command("make -j #{max_build_jobs}",
+          :env => {
+            "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+          })
+  command "make install"
+end

--- a/spec/data/complicated/config/software/perl-extutils-embed.rb
+++ b/spec/data/complicated/config/software/perl-extutils-embed.rb
@@ -1,0 +1,15 @@
+name "perl-extutils-embed"
+default_version "1.14"
+
+dependency "perl"
+
+source :url => "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed-#{version}.tar.gz",
+       :md5 => "b2a2c26a18bca3ce69f8a0b1b54a0105"
+
+relative_path "ExtUtils-Embed-#{version}"
+
+build do
+    command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
+    command "make"
+    command "make install"
+end

--- a/spec/data/complicated/config/software/perl-extutils-makemaker.rb
+++ b/spec/data/complicated/config/software/perl-extutils-makemaker.rb
@@ -1,0 +1,15 @@
+name "perl-extutils-makemaker"
+default_version "6.78"
+
+dependency "perl"
+
+source :url => "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-#{version}.tar.gz",
+       :md5 => "843886bc1060b5e5c619e34029343eba"
+
+relative_path "ExtUtils-MakeMaker-#{version}"
+
+build do
+    command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
+    command "make"
+    command "make install"
+end

--- a/spec/data/complicated/config/software/perl.rb
+++ b/spec/data/complicated/config/software/perl.rb
@@ -1,0 +1,48 @@
+name "perl"
+default_version "5.18.1"
+
+source :url => "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz",
+       :md5 => "304cb5bd18e48c44edd6053337d3386d"
+
+relative_path "perl-#{version}"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command [
+            "sh Configure",
+            "-de",
+            "-Dprefix=#{install_dir}/embedded",
+            "-Duseshrplib", ## Compile shared libperl
+            "-Dusethreads", ## Compile ithread support
+            "-Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"
+           ].join(" "), :env => env
+  command "make -j #{max_build_jobs}"
+  command "make install", :env => env
+
+  # Ensure we have a sane omnibus-friendly CPAN config. This should be passed
+  # to cpan any commands with the `-j` option.
+  omnibus_cpan_home = File.join(cache_dir, 'cpan')
+  command "mkdir -p #{omnibus_cpan_home}", :env => env
+  block do
+    open("#{omnibus_cpan_home}/OmnibusConfig.pm", "w") do |file|
+      file.print <<-EOH
+
+$CPAN::Config = {
+  'build_dir' => q[#{omnibus_cpan_home}/build],
+  'cpan_home' => q[#{omnibus_cpan_home}],
+  'histfile' => q[#{omnibus_cpan_home}/histfile],
+  'keep_source_where' => q[#{omnibus_cpan_home}/sources],
+  'prefs_dir' => q[#{omnibus_cpan_home}/prefs],
+  'urllist' => [q[http://cpan.llarian.net/], q[http://cpan.mirror.vexxhost.com/], q[http://noodle.portalus.net/CPAN/]],
+};
+1;
+__END__
+       EOH
+    end
+  end
+end

--- a/spec/data/complicated/config/software/perl_pg_driver.rb
+++ b/spec/data/complicated/config/software/perl_pg_driver.rb
@@ -1,0 +1,12 @@
+name "perl_pg_driver"
+
+dependency "perl"
+dependency "postgresql" # only because we're compiling DBD::Pg here, too.
+
+# Ensure we install with the properly configured embedded `cpan` client
+omnibus_cpan_client = "#{install_dir}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
+
+build do
+  # We're using PostgreSQL as our database engine, so we need the right driver
+  command "yes | #{omnibus_cpan_client} DBD::Pg", :env => env
+end

--- a/spec/data/complicated/config/software/php.rb
+++ b/spec/data/complicated/config/software/php.rb
@@ -1,0 +1,41 @@
+name "php"
+default_version "5.3.10"
+
+dependency "zlib"
+dependency "pcre"
+dependency "libxslt"
+dependency "libxml2"
+dependency "libiconv"
+dependency "openssl"
+dependency "gd"
+
+source :url => "http://us.php.net/distributions/php-5.3.10.tar.gz",
+       :md5 => "2b3d2d0ff22175685978fb6a5cbcdc13"
+
+relative_path "php-5.3.10"
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command(["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--without-pear",
+           "--with-zlib-dir=#{install_dir}/embedded",
+           "--with-pcre-dir=#{install_dir}/embedded",
+           "--with-xsl=#{install_dir}/embedded",
+           "--with-libxml-dir=#{install_dir}/embedded",
+           "--with-iconv=#{install_dir}/embedded",
+           "--with-openssl-dir=#{install_dir}/embedded",
+           "--with-gd=#{install_dir}/embedded",
+           "--enable-fpm",
+           "--with-fpm-user=opscode",
+           "--with-fpm-group=opscode"].join(" "),
+          :env => env)
+
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/pip.rb
+++ b/spec/data/complicated/config/software/pip.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "pip"
+default_version "1.3"
+
+dependency "setuptools"
+
+source :url => "https://pypi.python.org/packages/source/p/pip/pip-#{version}.tar.gz",
+       :md5 => '918559b784e2aca9559d498050bb86e7'
+
+relative_path "pip-#{version}"
+
+build do
+  command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
+end

--- a/spec/data/complicated/config/software/pkg-config.rb
+++ b/spec/data/complicated/config/software/pkg-config.rb
@@ -1,0 +1,66 @@
+#
+# Copyright:: Copyright (c) 2014 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "pkg-config"
+default_version "0.28"
+
+dependency "libiconv" if platform == "freebsd"
+
+source :url => 'http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz',
+  :md5 => 'aa3c86e67551adc3ac865160e34a2a0d'
+
+relative_path 'pkg-config-0.28'
+
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+paths = [ "#{install_dir}/embedded/bin/pkgconfig" ]
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths*':'}", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => configure_env
+  command "make -j #{max_build_jobs} install", :env => configure_env
+end

--- a/spec/data/complicated/config/software/popt.rb
+++ b/spec/data/complicated/config/software/popt.rb
@@ -1,0 +1,47 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "popt"
+default_version "1.16"
+
+source :url => "http://rpm5.org/files/popt/popt-1.16.tar.gz",
+       :md5 => "3743beefa3dd6247a73f8f7a32c14c33"
+
+relative_path "popt-1.16"
+
+env =
+  case platform
+  when "solaris2"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  # --disable-nls => Disable localization support.
+  command "./configure --prefix=#{install_dir}/embedded --disable-nls", :env => env
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/postgresql.rb
+++ b/spec/data/complicated/config/software/postgresql.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "postgresql"
+default_version "9.2.8"
+
+dependency "zlib"
+dependency "openssl"
+dependency "libedit"
+dependency "ncurses"
+
+version "9.2.8" do
+  source :md5 => "c5c65a9b45ee53ead0b659be21ca1b97"
+end
+
+version "9.3.4" do
+  source :md5 => "d0a41f54c377b2d2fab4a003b0dac762"
+end
+
+source :url => "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+relative_path "postgresql-#{version}"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--with-libedit-preferred",
+           "--with-openssl --with-includes=#{install_dir}/embedded/include",
+           "--with-libraries=#{install_dir}/embedded/lib"].join(" "), :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/preparation.rb
+++ b/spec/data/complicated/config/software/preparation.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "preparation"
+description "the steps required to preprare the build"
+default_version '1.0.0'
+
+build do
+  block do
+    %w{embedded/lib embedded/bin bin}.each do |dir|
+      dir_fullpath = File.expand_path(File.join(install_dir, dir))
+      FileUtils.mkdir_p(dir_fullpath)
+      FileUtils.touch(File.join(dir_fullpath, '.gitkeep'))
+    end
+  end
+end

--- a/spec/data/complicated/config/software/pygments.rb
+++ b/spec/data/complicated/config/software/pygments.rb
@@ -1,0 +1,25 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "pygments"
+default_version "1.6"
+
+dependency "pip"
+
+build do
+  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+end

--- a/spec/data/complicated/config/software/python.rb
+++ b/spec/data/complicated/config/software/python.rb
@@ -1,0 +1,49 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "python"
+default_version "2.7.5"
+
+dependency "gdbm"
+dependency "ncurses"
+dependency "zlib"
+dependency "openssl"
+dependency "bzip2"
+
+source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
+       :md5 => 'b4f01a1d0ba0b46b05c73b2ac909b1df'
+
+relative_path "Python-#{version}"
+
+env = {
+  "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+  "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+}
+
+build do
+  command ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--enable-shared",
+           "--with-dbmliborder=gdbm"].join(" "), :env => env
+  command "make", :env => env
+  command "make install", :env => env
+
+  # There exists no configure flag to tell Python to not compile readline support :(
+  block do
+    FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"))
+  end
+end

--- a/spec/data/complicated/config/software/rabbitmq.rb
+++ b/spec/data/complicated/config/software/rabbitmq.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rabbitmq"
+default_version "2.7.1"
+
+dependency "erlang"
+dependency "rsync"
+
+source :url => "http://www.rabbitmq.com/releases/rabbitmq-server/v2.7.1/rabbitmq-server-generic-unix-2.7.1.tar.gz",
+       :md5 => "34a5f9fb6f22e6681092443fcc80324f"
+
+relative_path "rabbitmq_server-2.7.1"
+
+build do
+  command "mkdir -p #{install_dir}/embedded/service/rabbitmq"
+  command "#{install_dir}/embedded/bin/rsync -a ./ #{install_dir}/embedded/service/rabbitmq/"
+
+  %w{rabbitmqctl rabbitmq-env rabbitmq-server}.each do |cmd|
+    command "ln -sf #{install_dir}/embedded/service/rabbitmq/sbin/#{cmd} #{install_dir}/embedded/bin/#{cmd}"
+  end
+end

--- a/spec/data/complicated/config/software/rebar.rb
+++ b/spec/data/complicated/config/software/rebar.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rebar"
+default_version "2.0.0"
+
+dependency "erlang"
+
+source :git => "https://github.com/basho/rebar.git"
+
+relative_path "rebar"
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}",
+  "LD_FLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command "./bootstrap", :env => env
+  command "cp ./rebar #{install_dir}/embedded/bin/"
+end

--- a/spec/data/complicated/config/software/redis.rb
+++ b/spec/data/complicated/config/software/redis.rb
@@ -1,0 +1,33 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "redis"
+default_version "2.8.2"
+
+source :url => "http://download.redis.io/releases/redis-#{version}.tar.gz",
+       :md5 => "ee527b0c37e1e2cbceb497f5f6b8112b"
+
+relative_path "redis-#{version}"
+
+make_args = ["PREFIX=#{install_dir}/embedded",
+             "CFLAGS='-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include'",
+             "LD_RUN_PATH=#{install_dir}/embedded/lib"].join(" ")
+
+build do
+  command ["make -j #{max_build_jobs}", make_args].join(" ")
+  command ["make install", make_args].join(" ")
+end

--- a/spec/data/complicated/config/software/rsync.rb
+++ b/spec/data/complicated/config/software/rsync.rb
@@ -1,0 +1,48 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rsync"
+default_version "3.0.9"
+
+dependency "popt"
+
+source :url => "http://rsync.samba.org/ftp/rsync/src/rsync-3.0.9.tar.gz",
+       :md5 => "5ee72266fe2c1822333c407e1761b92b"
+
+relative_path "rsync-3.0.9"
+
+env =
+  case platform
+  when "solaris2"
+      {
+        "LDFLAGS" => "-R #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+        "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+        "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+      }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded --disable-iconv", :env => env
+  command "make -j #{max_build_jobs}", :env => env
+  command "make install"
+end

--- a/spec/data/complicated/config/software/ruby-windows-devkit.rb
+++ b/spec/data/complicated/config/software/ruby-windows-devkit.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ruby-windows-devkit"
+default_version "4.5.2-20111229-1559"
+
+dependency "ruby-windows"
+
+source :url => "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
+       :md5 => "4bf8f2dd1d582c8733a67027583e19a6"
+
+build do
+  command "DevKit-tdm-32-#{version}-sfx.exe -y -o#{File.expand_path(File.join(install_dir, "embedded")).gsub(/\//, "\\")}"
+  command "echo - #{install_dir}/embedded > config.yml", :cwd => "#{install_dir}/embedded"
+  ruby "dk.rb install", :cwd => "#{install_dir}/embedded"
+end

--- a/spec/data/complicated/config/software/ruby-windows.rb
+++ b/spec/data/complicated/config/software/ruby-windows.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ruby-windows"
+default_version "1.9.3-p484"
+
+relative_path "ruby-#{version}-i386-mingw32"
+
+source :url => "http://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i386-mingw32.7z?direct",
+       :md5 => "a0665113aaeea83f1c4bea02fcf16694"
+
+build do
+  # Robocopy's return code is 1 if it succesfully copies over the
+  # files and 0 if the files are already existing at the destination
+  command "robocopy . #{install_dir}\\embedded\\ /MIR", :returns => [0, 1]
+end

--- a/spec/data/complicated/config/software/ruby.rb
+++ b/spec/data/complicated/config/software/ruby.rb
@@ -1,0 +1,162 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ruby"
+default_version "1.9.3-p484"
+
+dependency "zlib"
+dependency "ncurses"
+dependency "libedit"
+dependency "openssl"
+dependency "libyaml"
+dependency "libiconv"
+dependency "gdbm"
+dependency "libgcc" if (platform == "solaris2" and Omnibus.config.solaris_compiler == "gcc")
+
+version "1.9.3-p484" do
+  source md5: '8ac0dee72fe12d75c8b2d0ef5d0c2968'
+end
+
+version "2.1.1" do
+  source md5: 'e57fdbb8ed56e70c43f39c79da1654b2'
+end
+
+source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
+
+relative_path "ruby-#{version}"
+
+env =
+  case platform
+  when "mac_os_x"
+    {
+      # -Qunused-arguments suppresses "argument unused during compilation"
+      # warnings. These can be produced if you compile a program that doesn't
+      # link to anything in a path given with -Lextra-libs. Normally these
+      # would be harmless, except that autoconf treats any output to stderr as
+      # a failure when it makes a test program to check your CFLAGS (regardless
+      # of the actual exit code from the compiler).
+      "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses -O3 -g -pipe -Qunused-arguments",
+      "LDFLAGS" => "-arch x86_64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses"
+    }
+  when "solaris2"
+    {
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -O3 -g -pipe",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
+    }
+  when "aix"
+    {
+      # see http://www.ibm.com/developerworks/aix/library/au-gnu.html
+      #
+      # specifically:
+      #
+      # "To use AIX run-time linking, you should create the shared object
+      # using gcc -shared -Wl,-G and create executables using the library
+      # by adding the -Wl,-brtl option to the link line. Technically, you
+      # can leave off the -shared option, but it does no harm and reduces
+      # confusion."
+      #
+      # AIX also uses -Wl,-blibpath instead of -R or LD_RUN_PATH, but the
+      # option is not additive, so requires /usr/lib and /lib as well (there
+      # is a -bsvr4 option to allow ld to take an -R flag in addition
+      # to turning on -brtl, but it had other side effects I couldn't fix).
+      #
+      # If libraries linked with gcc -shared have symbol resolution failures
+      # then it may be useful to add -bexpfull to export all symbols.
+      #
+      # -O2 optimized away some configure test which caused ext libs to fail
+      #
+      # We also need prezl's M4 instead of picking up /usr/bin/m4 which
+      # barfs on ruby.
+      #
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -O -qhot -I#{install_dir}/embedded/include",
+      "CXXFLAGS" => "-q64 -O -qhot -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-q64  -L#{install_dir}/embedded/lib -Wl,-brtl -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "M4" => "/opt/freeware/bin/m4",
+      "warnflags" => "-qinfo=por"
+    }
+  else
+    {
+      "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+      "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded",
+                       "--with-out-ext=fiddle,dbm",
+                       "--enable-shared",
+                       "--enable-libedit",
+                       "--with-ext=psych",
+                       "--disable-install-doc"]
+
+  case platform
+  when "aix"
+    patch :source => "ruby-aix-configure.patch", :plevel => 1
+    patch :source => "ruby_aix_1_9_3_448_ssl_EAGAIN.patch", :plevel => 1
+    # --with-opt-dir causes ruby to send bogus commands to the AIX linker
+  when "freebsd"
+    configure_command << "--without-execinfo"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  when "smartos"
+    # Opscode patch - someara@opscode.com
+    # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
+    patch :source => "ruby-openssl-1.0.1c.patch", :plevel => 1
+
+    # Patches taken from RVM.
+    # http://bugs.ruby-lang.org/issues/5384
+    # https://www.illumos.org/issues/1587
+    # https://github.com/wayneeseguin/rvm/issues/719
+    patch :source => "rvm-cflags.patch", :plevel => 1
+
+    # From RVM forum
+    # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
+    configure_command << "ac_cv_func_dl_iterate_phdr=no"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  else
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  end
+
+  # @todo expose bundle_bust() in the DSL
+  env.merge!({
+    "RUBYOPT"         => nil,
+    "BUNDLE_BIN_PATH" => nil,
+    "BUNDLE_GEMFILE"  => nil,
+    "GEM_PATH"        => nil,
+    "GEM_HOME"        => nil
+  })
+
+  # @todo: move into omnibus-ruby
+  has_gmake = system("gmake --version")
+
+  if has_gmake
+    env.merge!({'MAKE' => 'gmake'})
+    make_binary = 'gmake'
+  else
+    make_binary = 'make'
+  end
+
+  command configure_command.join(" "), :env => env
+  command "#{make_binary} -j #{max_build_jobs}", :env => env
+  command "#{make_binary} -j #{max_build_jobs} install", :env => env
+end

--- a/spec/data/complicated/config/software/rubygems-customization.rb
+++ b/spec/data/complicated/config/software/rubygems-customization.rb
@@ -1,0 +1,58 @@
+#
+# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubygems-customization"
+
+default_version "0.1.0"
+
+if platform == 'windows'
+  dependency "ruby-windows"
+else
+  dependency "ruby"
+end
+
+dependency "rubygems"
+
+
+#/opt/chefdk/embedded/bin/ruby -e 'puts Gem.dir'
+# => /opt/chefdk/embedded/lib/ruby/gems/2.1.0
+#
+# /opt/chefdk/embedded/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"
+# => /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0
+
+# result should be /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/defaults/operating_system.rb
+
+
+build do
+
+  block do
+    source_customization_file = File.join(project.files_path, "rubygems_customization", "operating_system.rb")
+    embedded_ruby_site_dir = ""
+    Bundler.with_clean_env do
+      embedded_ruby_site_dir = %x{/opt/chefdk/embedded/bin/ruby -rrbconfig -e "puts RbConfig::CONFIG['sitelibdir']"}.strip
+    end
+
+    raise "could not determine embedded ruby's site dir" if embedded_ruby_site_dir.empty?
+
+    destination_dir = File.join(embedded_ruby_site_dir, 'rubygems', 'defaults')
+    destination = File.join(destination_dir, "operating_system.rb")
+
+    FileUtils.mkdir_p destination_dir
+    command "cp #{source_customization_file} #{destination}"
+  end
+end
+

--- a/spec/data/complicated/config/software/rubygems.rb
+++ b/spec/data/complicated/config/software/rubygems.rb
@@ -1,0 +1,37 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubygems"
+default_version "1.8.24"
+
+dependency "ruby"
+
+version "1.8.24" do
+  source md5: "3a555b9d579f6a1a1e110628f5110c6b"
+end
+
+version "2.2.1" do
+  source md5: "1f0017af0ad3d3ed52665132f80e7443"
+end
+
+source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+
+relative_path "rubygems-#{version}"
+
+build do
+  ruby "setup.rb"
+end

--- a/spec/data/complicated/config/software/runit.rb
+++ b/spec/data/complicated/config/software/runit.rb
@@ -1,0 +1,118 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "runit"
+default_version "2.1.1"
+
+source :url => "http://smarden.org/runit/runit-2.1.1.tar.gz",
+       :md5 => "8fa53ea8f71d88da9503f62793336bc3"
+
+relative_path "admin"
+
+working_dir = "#{project_dir}/runit-2.1.1"
+
+build do
+  # put runit where we want it, not where they tell us to
+  command 'sed -i -e "s/^char\ \*varservice\ \=\"\/service\/\";$/char\ \*varservice\ \=\"' + project.install_path.gsub("/", "\\/") + '\/service\/\";/" src/sv.c', :cwd => working_dir
+  # TODO: the following is not idempotent
+  command "sed -i -e s:-static:: src/Makefile", :cwd => working_dir
+
+  # build it
+  command "make", :cwd => "#{working_dir}/src"
+  command "make check", :cwd => "#{working_dir}/src"
+
+  # move it
+  command "mkdir -p #{install_dir}/embedded/bin"
+  ["src/chpst",
+   "src/runit",
+   "src/runit-init",
+   "src/runsv",
+   "src/runsvchdir",
+   "src/runsvdir",
+   "src/sv",
+   "src/svlogd",
+   "src/utmpset"].each do |bin|
+    command "cp #{bin} #{install_dir}/embedded/bin", :cwd => working_dir
+  end
+
+  block do
+    install_path = self.project.install_path
+    open("#{install_dir}/embedded/bin/runsvdir-start", "w") do |file|
+      file.print <<-EOH
+#!/bin/bash
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PATH=#{install_path}/bin:#{install_path}/embedded/bin:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+
+# enforce our own ulimits
+
+ulimit -c 0
+ulimit -d unlimited
+ulimit -e 0
+ulimit -f unlimited
+ulimit -i 62793
+ulimit -l 64
+ulimit -m unlimited
+# WARNING: increasing the global file descriptor limit increases RAM consumption on startup dramatically
+ulimit -n 50000
+ulimit -q 819200
+ulimit -r 0
+ulimit -s 10240
+ulimit -t unlimited
+ulimit -u unlimited
+ulimit -v unlimited
+ulimit -x unlimited
+echo "1000000" > /proc/sys/fs/file-max
+
+# and our ulimit
+
+umask 022
+
+exec env - PATH=$PATH \
+runsvdir -P #{install_path}/service 'log: ...........................................................................................................................................................................................................................................................................................................................................................................................................'
+       EOH
+    end
+  end
+
+  command "chmod 755 #{install_dir}/embedded/bin/runsvdir-start"
+
+  # set up service directories
+  block do
+    ["#{install_dir}/service",
+     "#{install_dir}/sv",
+     "#{install_dir}/init"].each do |dir|
+      FileUtils.mkdir_p(dir)
+      # make sure cached builds include this dir
+      FileUtils.touch(File.join(dir, '.gitkeep'))
+    end
+  end
+end

--- a/spec/data/complicated/config/software/server-jre.rb
+++ b/spec/data/complicated/config/software/server-jre.rb
@@ -1,0 +1,46 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "server-jre"
+default_version "7u25"
+
+dependency "rsync"
+
+whitelist_file "jre/bin/javaws"
+whitelist_file "jre/bin/policytool"
+whitelist_file "jre/lib"
+whitelist_file "jre/plugin"
+whitelist_file "jre/bin/appletviewer"
+
+if OHAI.kernel['machine'] =~ /x86_64/
+  # TODO: download x86 version on x86 machines
+  source :url => "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
+         :md5 => "7164bd8619d731a2e8c01d0c60110f80",
+         :cookie => 'oraclelicensejre-7u25-oth-JPR=accept-securebackup-cookie;gpw_e24=http://www.oracle.com/technetwork/java/javase/downloads/server-jre7-downloads-1931105.html',
+         :warning => "By including the JRE, you accept the terms of the Oracle Binary Code License Agreement for the Java SE Platform Products and JavaFX, which can be found at http://www.oracle.com/technetwork/java/javase/terms/license/index.html"
+else
+  raise "Server-jre can only be installed on x86_64 systems."
+end
+
+relative_path "jdk1.7.0_25"
+
+jre_dir = "#{install_dir}/embedded/jre"
+
+build do
+  command "mkdir -p #{jre_dir}"
+  command "#{install_dir}/embedded/bin/rsync -a . #{jre_dir}/"
+end

--- a/spec/data/complicated/config/software/setuptools.rb
+++ b/spec/data/complicated/config/software/setuptools.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "setuptools"
+default_version "0.7.7"
+
+dependency "python"
+
+source :url => "https://pypi.python.org/packages/source/s/setuptools/setuptools-#{version}.tar.gz",
+       :md5 => '0d7bc0e1a34b70a97e706ef74aa7f37f'
+
+relative_path "setuptools-#{version}"
+
+build do
+  command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
+end

--- a/spec/data/complicated/config/software/spawn-fcgi.rb
+++ b/spec/data/complicated/config/software/spawn-fcgi.rb
@@ -1,0 +1,40 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "spawn-fcgi"
+default_version "1.6.3"
+
+dependency "fcgi"
+dependency "fcgiwrap"
+
+source :url => "http://www.lighttpd.net/download/spawn-fcgi-1.6.3.tar.gz",
+       :md5 => "6d75f9e9435056fa1e574d836d823cd0"
+
+relative_path "spawn-fcgi-1.6.3"
+
+configure_env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install"
+end

--- a/spec/data/complicated/config/software/sphinx.rb
+++ b/spec/data/complicated/config/software/sphinx.rb
@@ -1,0 +1,26 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "sphinx"
+default_version "1.1.3"
+
+dependency "pip"
+dependency "pygments"
+
+build do
+  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+end

--- a/spec/data/complicated/config/software/spidermonkey.rb
+++ b/spec/data/complicated/config/software/spidermonkey.rb
@@ -1,0 +1,60 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "spidermonkey"
+default_version "1.8.0"
+
+source :url => "http://ftp.mozilla.org/pub/mozilla.org/js/js-1.8.0-rc1.tar.gz",
+       :md5 => "eaad8815dcc66a717ddb87e9724d964e"
+
+relative_path "js"
+
+env = {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+working_dir = "#{project_dir}/src"
+
+# == Build Notes ==
+# The spidermonkey build instructions are copied from here:
+# http://wiki.apache.org/couchdb/Installing_SpiderMonkey
+#
+# These instructions only seem to work with spidermonkey 1.8.0-rc1 and
+# earlier. Since couchdb 1.1.1 is compatible with spidermonkey 1.8.5,
+# we should eventually invest some time into getting that version built.
+#
+
+build do
+  command(["make",
+           "BUILD_OPT=1",
+           "XCFLAGS=-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+           "-f",
+           "Makefile.ref"].join(" "),
+          :env => env,
+          :cwd => working_dir)
+  command(["make",
+           "BUILD_OPT=1",
+           "JS_DIST=#{install_dir}/embedded",
+           "-f",
+           "Makefile.ref",
+           "export"].join(" "),
+          :env => env,
+          :cwd => working_dir)
+
+  if OHAI.kernel['machine'] =~ /x86_64/
+    command "mv #{install_dir}/embedded/lib64/libjs.a #{install_dir}/embedded/lib"
+    command "mv #{install_dir}/embedded/lib64/libjs.so #{install_dir}/embedded/lib"
+  end
+  command "rm -rf #{install_dir}/embedded/lib64"
+end

--- a/spec/data/complicated/config/software/sqitch.rb
+++ b/spec/data/complicated/config/software/sqitch.rb
@@ -1,0 +1,24 @@
+name "sqitch"
+default_version "0.973"
+
+dependency "perl"
+
+source :url => "http://www.cpan.org/authors/id/D/DW/DWHEELER/App-Sqitch-#{version}.tar.gz",
+       :md5 => "0994e9f906a7a4a2e97049c8dbaef584"
+
+relative_path "App-Sqitch-#{version}"
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+# Ensure we install with the properly configured embedded `cpan` client
+omnibus_cpan_client = "#{install_dir}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
+
+# See https://github.com/theory/sqitch for more
+build do
+  command "perl Build.PL", :env => env
+  command "./Build installdeps --cpan_client '#{omnibus_cpan_client}'", :env => env
+  command "./Build", :env => env
+  command "./Build install", :env => env
+end

--- a/spec/data/complicated/config/software/test-kitchen.rb
+++ b/spec/data/complicated/config/software/test-kitchen.rb
@@ -1,0 +1,39 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "test-kitchen"
+default_version "master"
+relative_path "test-kitchen"
+
+source :git => "git://github.com/test-kitchen/test-kitchen"
+
+if platform == 'windows'
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+  dependency "rubygems"
+end
+
+dependency "nokogiri"
+
+build do
+  bundle "install --without guard", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  bundle "exec rake build", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  gem ["install pkg/test-kitchen-*.gem",
+       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+end

--- a/spec/data/complicated/config/software/unicorn.rb
+++ b/spec/data/complicated/config/software/unicorn.rb
@@ -1,0 +1,27 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "unicorn"
+default_version "4.2.0"
+
+dependency "rubygems"
+
+env = { "GEM_HOME" => nil, "GEM_PATH" => nil }
+
+build do
+  gem "install unicorn --no-rdoc --no-ri -v #{version}", :env => env
+end

--- a/spec/data/complicated/config/software/util-macros.rb
+++ b/spec/data/complicated/config/software/util-macros.rb
@@ -1,0 +1,46 @@
+
+name "util-macros"
+default_version "1.18.0"
+
+source :url => 'http://xorg.freedesktop.org/releases/individual/util/util-macros-1.18.0.tar.gz',
+  :md5 => 'fd0ba21b3179703c071bbb4c3e5fb0f4'
+
+relative_path 'util-macros-1.18.0'
+
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => configure_env
+  command "make -j #{max_build_jobs} install", :env => configure_env
+end

--- a/spec/data/complicated/config/software/version-manifest.rb
+++ b/spec/data/complicated/config/software/version-manifest.rb
@@ -1,0 +1,32 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "version-manifest"
+description "generates a version manifest file"
+
+build do
+  block do
+    project_name = project.name
+    project_build_version = project.build_version
+    
+    File.open("#{install_dir}/version-manifest.txt", "w") do |f|
+      f.puts "#{project_name} #{project_build_version}"
+      f.puts ""
+      f.puts Omnibus::Reports.pretty_version_map(project)
+    end
+  end
+end

--- a/spec/data/complicated/config/software/xproto.rb
+++ b/spec/data/complicated/config/software/xproto.rb
@@ -1,0 +1,46 @@
+
+name "xproto"
+default_version "7.0.25"
+
+source :url => 'http://xorg.freedesktop.org/releases/individual/proto/xproto-7.0.25.tar.gz',
+  :md5 => 'a47db46cb117805bd6947aa5928a7436'
+
+relative_path 'xproto-7.0.25'
+
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LD" => "ld -b64",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru "
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
+    }
+  else
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => configure_env
+  command "make -j #{max_build_jobs} install", :env => configure_env
+end

--- a/spec/data/complicated/config/software/yajl.rb
+++ b/spec/data/complicated/config/software/yajl.rb
@@ -1,0 +1,30 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "yajl"
+default_version "1.1.0"
+
+dependency "rubygems"
+
+relative_path "yajl-ruby"
+
+build do
+  gem ["install yajl-ruby",
+       "-v #{version}",
+       "-n #{install_dir}/bin",
+       "--no-rdoc --no-ri"].join(" ")
+end

--- a/spec/data/complicated/config/software/zlib.rb
+++ b/spec/data/complicated/config/software/zlib.rb
@@ -1,0 +1,67 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "zlib"
+default_version "1.2.6"
+
+dependency "libgcc"
+
+version "1.2.6" do
+  source md5: "618e944d7c7cd6521551e30b32322f4a"
+end
+
+version "1.2.8" do
+  source md5: "44d667c142d7cda120332623eab69f40"
+end
+
+source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
+
+relative_path "zlib-#{version}"
+configure_env =
+  case platform
+  when "aix"
+    {
+      "CC" => "xlc -q64",
+      "CXX" => "xlC -q64",
+      "LD" => "ld -b64",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+      "OBJECT_MODE" => "64",
+      "ARFLAGS" => "-X64 cru",
+      "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+    }
+  when "mac_os_x"
+    {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  when "solaris2"
+    {
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -DNO_VIZ"
+    }
+  else
+    {
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
+    }
+  end
+
+build do
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}"
+  command "make -j #{max_build_jobs} install"
+end

--- a/spec/unit/omnibus_spec.rb
+++ b/spec/unit/omnibus_spec.rb
@@ -56,4 +56,37 @@ describe Omnibus do
       end
     end
   end
+
+  describe '#process_dsl_files' do
+    before :each do
+      Omnibus.stub(:project_root) do
+        File.expand_path(
+          File.join(
+            File.dirname(__FILE__),
+            '..',
+            'data',
+            'complicated',
+          ),
+        )
+      end
+    end
+
+    after :each do
+      Omnibus.class_eval { @projects = [] }
+      Omnibus.class_eval { @software_dirs = nil }
+    end
+
+    it 'populates the 5 projects' do
+      Omnibus.process_dsl_files
+
+      expect(Omnibus.projects.count).to eq(5)
+
+      names = Omnibus.projects.map { |m| m.name.to_s }
+      # rubocop:disable WordArray
+      ['angrychef', 'chef-windows', 'chef', 'chefdk-windows', 'chefdk'].each do |project|
+        expect(names).to include(project)
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
This adds test coverage to the Omnibus classes software and project loading. It uses live data from omnibus-chef and omnibus-software. It also adds a test of the library.build_order function for chefdk-windows.

Please check the resulting build order in spec/unit/library_spec.rb, line 176. I cannot get it to non-deterministically fail, although I haven't tried it on Windows. 

The only change to the project descriptions was to set version numbers - otherwise, it's a straight import. 

/cc @danielsdeleo @schisamo 
