### PR TITLE
Lcg/remove whitelists

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -76,7 +76,6 @@ module Omnibus
       /libssl.so/,
       /libthread.so/,
       /libuutil\.so/,
-      /libz.so/,
       # solaris 11 libraries:
       /libc\.so\.1/,
       /libm\.so\.2/,


### PR DESCRIPTION
removing some entries in the solaris whitelists that clearly violate omnibus principles
