### PR TITLE
Fix software DSL misleading line number

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -90,7 +90,7 @@ module Omnibus
 
       @dependencies = []
       @whitelist_files = []
-      instance_eval(io, filename, 0)
+      instance_eval(io, filename)
     end
 
     # Retrieves the override_version


### PR DESCRIPTION
Remove explicit line number 0 (in instance_eval) might cause misleading
exception and backtrace messages.
Removed the line number as it defaults to 1 and to match how it is used
in project DSL.
