### PR TITLE
Don't use ldd.out

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'chef-sugar',      '~> 1.2'
-  gem.add_dependency 'mixlib-shellout', '~> 1.3'
+  gem.add_dependency 'mixlib-shellout', '~> 1.4'
   gem.add_dependency 'mixlib-config',   '~> 2.1'
   gem.add_dependency 'ohai',            '~> 6.12'
   gem.add_dependency 'fpm',             '~> 1.0.0'

--- a/spec/fixtures/health_check/linux-bad.log
+++ b/spec/fixtures/health_check/linux-bad.log
@@ -1,0 +1,14 @@
+/bin/ls:
+	linux-vdso.so.1 =>  (0x00007fff583ff000)
+	libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007fad8592a000)
+	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fad85722000)
+	libacl.so.1 => /lib/x86_64-linux-gnu/libacl.so.1 (0x00007fad85518000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fad8518d000)
+	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fad84f89000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fad85b51000)
+	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fad84d6c000)
+	libattr.so.1 => /lib/x86_64-linux-gnu/libattr.so.1 (0x00007fad84b67000)
+/bin/cat:
+	linux-vdso.so.1 =>  (0x00007fffa4dcf000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4a858cd000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f4a85c5f000)

--- a/spec/fixtures/health_check/linux-good.log
+++ b/spec/fixtures/health_check/linux-good.log
@@ -1,0 +1,8 @@
+/bin/echo:
+	linux-vdso.so.1 =>  (0x00007fff8a6ee000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f70f58c0000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007f70f5c52000)
+/bin/cat:
+	linux-vdso.so.1 =>  (0x00007fff095b3000)
+	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fe868ec0000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fe869252000)

--- a/spec/unit/health_check_spec.rb
+++ b/spec/unit/health_check_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Omnibus::HealthCheck do
+  context 'on linux' do
+    context 'without external dependencies' do
+      it 'should not raise' do
+        expect(Mixlib::ShellOut).to receive(:new).with('find /project/ -type f | xargs ldd', timeout: 3600).and_return(Mixlib::ShellOut.new("cat #{fixtures_path}/health_check/linux-good.log"))
+
+        expect { Omnibus::HealthCheck.run('/project') }.to_not raise_error
+      end
+    end
+
+    context 'with external dependencies' do
+      it 'should raise' do
+        expect(Mixlib::ShellOut).to receive(:new).with('find /project/ -type f | xargs ldd', timeout: 3600).and_return(Mixlib::ShellOut.new("cat #{fixtures_path}/health_check/linux-bad.log"))
+
+        expect { Omnibus::HealthCheck.run('/project') }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This causes build to fail when running multiple omnibus project builds in the same repo as they all use the same ldd.out file.
The comment right above the line indicating ldd.out is added because shellout disables GC. but that's not the  case any more with shellout 1.4 (see https://github.com/opscode/mixlib-shellout/commit/0397bbd953a1fcd05a26fde120e7710ac7fd6862)
