### PR TITLE
Changed broken default version for libpng.

### DIFF
--- a/spec/data/complicated/config/software/libpng.rb
+++ b/spec/data/complicated/config/software/libpng.rb
@@ -16,12 +16,12 @@
 #
 
 name "libpng"
-default_version "1.5.17"
+default_version "1.5.18"
 
 dependency "zlib"
 
 source :url => "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng15/libpng-#{version}.tar.gz",
-       :md5 => "d2e27dbd8c6579d1582b3f128fd284b4"
+       :md5 => "5266905cef49d1224437465ad4d67fd9"
 
 relative_path "libpng-#{version}"
 


### PR DESCRIPTION
The default version set for libpng (1.5.17) does not exist in the source
provided.
I haved changed the version to 1.5.18 and changed the md5 hash to match
the newer version.
