### PR TITLE
Refactor sugars into a module instead of a magical load-time thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Omnibus Ruby CHANGELOG
 Unreleased
 ----------
 - Make build commands output during `log.info` instead of `log.debug`
+- Refactor Chef Sugar into an includable module, permitting DSL methods in both Software and Project definitions
 
 
 v3.1.1 (May 20, 2014)

--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -50,6 +50,7 @@ module Omnibus
   autoload :S3Cache,          'omnibus/s3_cache'
   autoload :Software,         'omnibus/software'
   autoload :SoftwareS3URLs,   'omnibus/software_s3_urls'
+  autoload :Sugarable,        'omnibus/sugarable'
   autoload :Util,             'omnibus/util'
 
   # @todo Remove this in the next major release
@@ -381,6 +382,3 @@ module Omnibus
     end
   end
 end
-
-# Sugars must be loaded after everything else has been registered
-require 'omnibus/sugar'

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -29,6 +29,7 @@ module Omnibus
   # @todo: Generate the DSL methods via metaprogramming... they're all so similar
   class Project
     include Logging
+    include Sugarable
     include Util
 
     NULL_ARG = Object.new

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -26,6 +26,7 @@ module Omnibus
   # Omnibus software DSL reader
   class Software
     include Logging
+    include Sugarable
 
     NULL_ARG = Object.new
     UNINITIALIZED = Object.new

--- a/lib/omnibus/sugarable.rb
+++ b/lib/omnibus/sugarable.rb
@@ -29,8 +29,8 @@ require 'chef/sugar/shell'
 require 'chef/sugar/vagrant'
 
 module Omnibus
-  class Project
-    private
+  module Sugarable
+    include Chef::Sugar::DSL
 
     # This method is used by Chef Sugar to easily add the DSL. By mimicing
     # Chef's +node+ object, we can easily include the existing DSL into
@@ -41,7 +41,3 @@ module Omnibus
     end
   end
 end
-
-# Include everything in Omnibus
-Omnibus::Project.send(:include, Chef::Sugar::DSL)
-Omnibus::Software.send(:include, Chef::Sugar::DSL)


### PR DESCRIPTION
This commit moves the sugars into a "Sugarable" mixin that defines a `node` object and wires all the pieces together for a DSL to include Chef Sugar. Individual classes can then `include Sugarable` and they get the DSL.

This commit eliminates the nasty load-time stuff that I did originally.

/cc @opscode/release-engineers @danielsdeleo @sersut 
