### PR TITLE
Generate a real omnibus.rb configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 - Refactor `omnibus release` into a non-S3-specific backend "publisher"
 - Add support for specifying a dir glob to the `publish` command to upload multiple packages
 - "Package" is now a public API
+- Generate a real omnibus configuration file (no more `omnibus.rb.example`)
 
 ### Bug fixes
 - Fix a small typo in the project generator (come -> some)

--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -48,7 +48,7 @@ module Omnibus
       template('Gemfile.erb', "#{target}/Gemfile", template_options)
       template('gitignore.erb', "#{target}/.gitignore", template_options)
       template('README.md.erb', "#{target}/README.md", template_options)
-      template('omnibus.rb.example.erb', "#{target}/omnibus.rb.example", template_options)
+      template('omnibus.rb.erb', "#{target}/omnibus.rb", template_options)
     end
 
     def create_project_definition

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -29,9 +29,9 @@
 # Enable S3 asset caching
 # ------------------------------
 # use_s3_caching true
-# s3_access_key  'something'
-# s3_secret_key  'something'
-# s3_bucket      'some-bucket'
+# s3_access_key  ENV['S3_ACCESS_KEY']
+# s3_secret_key  ENV['S3_SECRET_KEY']
+# s3_bucket      ENV['S3_BUCKET']
 
 # Customize compiler bits
 # ------------------------------


### PR DESCRIPTION
After discussions with @schisamo, I do not see a reason for having the +omnibus.rb.example+ file. This commit updates the generator to make an example omnibus config at +omnibus.rb+, but all the values are commented out. This is in line with how Rails and other generators work.

/cc @opscode/release-engineers 
