### PR TITLE
Ensure that software fetched via path_fetcher are cached correctly

### DIFF
--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -36,6 +36,26 @@ module Omnibus
       instance.hexdigest
     end
 
+    #
+    # Calculate the digest of a directory at the given path.
+    # Each file in the directory is read in binary chunks to
+    # prevent excess memory usage. Filesystem entries of all
+    # types are included in the digest,  including directories,
+    # links, and sockets. The contents of non-file entries are
+    # represented as:
+    #
+    #   $type $path
+    #
+    # while the contents of regular files are represented as:
+    #
+    #   file $path
+    #
+    # and then appended by the binary contents of the file
+    #
+    # @param [String] path
+    #   the path of the directory to digest
+    # @param [Symbol] type
+    #   the type of digest to use
     def digest_directory(path, type = :md5)
       id = type.to_s.upcase
       instance = Digest.const_get(id).new
@@ -44,14 +64,17 @@ module Omnibus
       glob.each do |filename|
         case ftype = File.ftype(filename)
         when 'file'
+          update_with_string(instance, "#{ftype} #{filename}")
           update_with_file_contents(instance, filename)
         else
-          update_with_string(instance, "#{ftype} #{path}")
+          update_with_string(instance, "#{ftype} #{filename}")
         end
       end
 
       instance.hexdigest
     end
+
+    private
 
     def update_with_file_contents(digest, filename)
       File.open(filename) do |io|

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -57,7 +57,7 @@ module Omnibus
     end
 
     def version_for_cache
-      @version_for_cache ||= digest_directory(@project_dir)
+      @version_for_cache ||= digest_directory(@project_dir, :sha256)
     end
 
     def fetch_required?

--- a/spec/unit/digestable_spec.rb
+++ b/spec/unit/digestable_spec.rb
@@ -13,5 +13,26 @@ module Omnibus
         expect(subject.digest(path)).to eq('d41d8cd98f00b204e9800998ecf8427e')
       end
     end
+
+    describe '#digest_directory' do
+      let(:path)    { '/path/to/dir' }
+      let(:glob)    { "#{path}/**/*" }
+      let(:subdir)  { '/path/to/dir/subdir' }
+      let(:subfile) { '/path/to/dir/subfile' }
+      let(:io)      { StringIO.new }
+
+      it 'inspects the file types of glob entries' do
+        expect(Dir).to receive(:glob).with(glob).and_return([subdir])
+        expect(File).to receive(:ftype).with(subdir).and_return('directory')
+        expect(subject.digest_directory(path)).to eq('d4635f6b4c2a85ba603e1f9e6a65bd68')
+      end
+
+      it 'inspects the contents of the files' do
+        expect(Dir).to receive(:glob).with(glob).and_return([subfile])
+        expect(File).to receive(:ftype).with(subfile).and_return('file')
+        expect(File).to receive(:open).with(subfile).and_yield(io)
+        expect(subject.digest_directory(path)).to eq('73d045a78027e674811c36f3dbd09433')
+      end
+    end
   end
 end


### PR DESCRIPTION
When relying on locally-sourced software (e.g. cookbooks in omnibus-chef-server), the version of the files is tracked via the omnibus repo and is not encoded into the build instructions. When using a version of omnibus with git caching, however, changes to these repos are not tracked because the version number in the software definition does not change. This PR will ensure that the version represented to the cache will track the contents of the directory.
