### PR TITLE
Automatically upload checksums if they are present on the Artifact object

### DIFF
--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -29,10 +29,9 @@ module Omnibus
 
         # Upload the actual package
         log.info(log_key) { "Uploading '#{package.name}'" }
-        artifact_for(package).upload_with_checksum(
+        artifact_for(package).upload(
           repository,
           remote_path_for(package),
-          checksum_for(package),
           metadata_for(package),
         )
 
@@ -52,7 +51,14 @@ module Omnibus
     # @return [Artifactory::Resource::Artifact]
     #
     def artifact_for(package)
-      Artifactory::Resource::Artifact.new(local_path: package.path, client: client)
+      Artifactory::Resource::Artifact.new(
+        local_path: package.path,
+        client:     client,
+        checksums: {
+          'md5'  => package.metadata[:md5],
+          'sha1' => package.metadata[:sha1],
+        }
+      )
     end
 
     #
@@ -94,18 +100,6 @@ module Omnibus
         'omnibus.sha256'           => package.metadata[:sha256],
         'omnibus.sha512'           => package.metadata[:sha512],
       }
-    end
-
-    #
-    # The checksum to pass to artifactory to validate the uploaded artifact.
-    #
-    # @param [Package] package
-    #   the package to generate the checksum for
-    #
-    # @return [String]
-    #
-    def checksum_for(package)
-      package.metadata[:sha1]
     end
 
     #

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -32,7 +32,7 @@ module Omnibus
 
     let(:packages) { [package] }
     let(:client)   { double('Artifactory::Client') }
-    let(:artifact) { double('Artifactory::Resource::Artifact', upload_with_checksum: nil) }
+    let(:artifact) { double('Artifactory::Resource::Artifact', upload: nil) }
 
     before do
       subject.stub(:client).and_return(client)
@@ -51,10 +51,9 @@ module Omnibus
       end
 
       it 'uploads the package' do
-        expect(artifact).to receive(:upload_with_checksum).with(
+        expect(artifact).to receive(:upload).with(
           repository,
           'com/getchef/chef/11.0.6/chef.deb',
-          'SHA1',
           an_instance_of(Hash)
         ).once
 


### PR DESCRIPTION
It turns out that upload_with_checksum does not actually set the checksum, but rather compares against the known package and raises an error if it does not yet exist. API design is definitely not in JFrog's book of best practices.

This commit changes the way we deploy artifacts to be more magical.

/cc @opscode/release-engineers 
