### PR TITLE
Downgrade FPM to ~> 0.4

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mixlib-shellout', '~> 1.3'
   gem.add_dependency 'mixlib-config',   '~> 2.1'
   gem.add_dependency 'ohai',            '~> 6.12'
-  gem.add_dependency 'fpm',             '~> 1.0.0'
+  gem.add_dependency 'fpm',             '~> 0.4'
   gem.add_dependency 'uber-s3'
   gem.add_dependency 'thor',            '~> 0.18'
 


### PR DESCRIPTION
:construction: :construction_worker: :red_circle: 

Newer versions of FPM use the `ffi` gem to attach to some libc functions. Unfortunately this fails miserably on RHEL.
