### PR TITLE
Additions to standard compiler flags API

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -511,6 +511,8 @@ module Omnibus
     # @params opt [Hash]
     # @return [Hash]
     def with_standard_compiler_flags(env = {}, opts = {})
+      env ||= {}
+      opts ||= {}
       compiler_flags =
         case platform
         when "aix"
@@ -562,7 +564,8 @@ module Omnibus
       extra_linker_flags = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
       }
-      # solaris linker can also use LD_OPTIONS, so we throw the kitchen sink against it
+      # solaris linker can also use LD_OPTIONS, so we throw the kitchen sink against
+      # the linker, to find every way to make it use our rpath.
       extra_linker_flags.merge!(
         {
           "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -23,16 +23,16 @@ describe Omnibus::Software do
         stub_ohai(platform: 'ubuntu')
       end
       it "should set the defaults" do
-        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH" => "/monkeys/embedded/lib", "PKG_CONFIG_PATH" => "/monkeys/embedded/lib/pkgconfig")
       end
       it "should override LDFLAGS" do
-        expect(software.with_standard_compiler_flags("LDFLAGS"=>"foo")).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags("LDFLAGS"=>"foo")).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH" => "/monkeys/embedded/lib", "PKG_CONFIG_PATH" => "/monkeys/embedded/lib/pkgconfig")
       end
       it "should override CFLAGS" do
-        expect(software.with_standard_compiler_flags("CFLAGS"=>"foo")).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags("CFLAGS"=>"foo")).to eq("LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH" => "/monkeys/embedded/lib", "PKG_CONFIG_PATH" => "/monkeys/embedded/lib/pkgconfig")
       end
       it "should preserve anything else" do
-        expect(software.with_standard_compiler_flags("numberwang"=>4)).to eq("numberwang"=>4,"LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags("numberwang"=>4)).to eq("numberwang"=>4,"LDFLAGS"=>"-Wl,-rpath,/monkeys/embedded/lib -L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH" => "/monkeys/embedded/lib", "PKG_CONFIG_PATH" => "/monkeys/embedded/lib/pkgconfig")
       end
     end
     context "on solaris2" do
@@ -40,7 +40,7 @@ describe Omnibus::Software do
         stub_ohai(platform: 'solaris2')
       end
       it "should set the defaults" do
-        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-R/monkeys/embedded/lib -L/monkeys/embedded/lib -static-libgcc", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-R/monkeys/embedded/lib -L/monkeys/embedded/lib -static-libgcc", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH"=>"/monkeys/embedded/lib", "LD_OPTIONS"=>"-R/monkeys/embedded/lib", "PKG_CONFIG_PATH"=>"/monkeys/embedded/lib/pkgconfig")
       end
     end
     context "on mac_os_x" do
@@ -48,7 +48,23 @@ describe Omnibus::Software do
         stub_ohai(platform: 'mac_os_x')
       end
       it "should set the defaults" do
-        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include")
+        expect(software.with_standard_compiler_flags).to eq("LDFLAGS"=>"-L/monkeys/embedded/lib", "CFLAGS"=>"-I/monkeys/embedded/include", "LD_RUN_PATH"=>"/monkeys/embedded/lib", "PKG_CONFIG_PATH"=>"/monkeys/embedded/lib/pkgconfig")
+      end
+    end
+    context "on aix" do
+      before do
+        stub_ohai(platform: 'aix')
+      end
+      it "should set the defaults" do
+        expect(software.with_standard_compiler_flags).to eq("CC"=>"xlc -q64", "CXX"=>"xlC -q64", "CFLAGS"=>"-q64 -I/monkeys/embedded/include -O", "LDFLAGS"=>"-q64 -L/monkeys/embedded/lib -Wl,-blibpath:/monkeys/embedded/lib:/usr/lib:/lib", "LD"=>"ld -b64", "OBJECT_MODE"=>"64", "ARFLAGS"=>"-X64 cru", "LD_RUN_PATH"=>"/monkeys/embedded/lib", "PKG_CONFIG_PATH"=>"/monkeys/embedded/lib/pkgconfig")
+      end
+    end
+    context "on aix with gcc" do
+      before do
+        stub_ohai(platform: 'aix')
+      end
+      it "should set the defaults" do
+        expect(software.with_standard_compiler_flags(nil, :aix => { :use_gcc => true })).to eq("CC"=>"gcc -maix64", "CXX"=>"g++ -maix64", "CFLAGS"=>"-maix64 -O -I/monkeys/embedded/include", "LDFLAGS"=>"-L/monkeys/embedded/lib -Wl,-blibpath:/monkeys/embedded/lib:/usr/lib:/lib", "LD"=>"ld -b64", "OBJECT_MODE"=>"64", "ARFLAGS"=>"-X64 cru", "LD_RUN_PATH"=>"/monkeys/embedded/lib", "PKG_CONFIG_PATH"=>"/monkeys/embedded/lib/pkgconfig")
       end
     end
   end


### PR DESCRIPTION
More updates to the API, added the ability to switch between xlc and gcc for AIX, also added LD_RUN_PATH and PKG_CONFIG_PATH by default.
