### PR TITLE
Allow the use of deprecated project delegators in templates

### DIFF
--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -70,6 +70,19 @@ module Omnibus
       @project = project
     end
 
+    # Hacky way to get around the fact that older versions of Omnibus used to
+    # delegate magical methods to this DSL.
+    #
+    # @deprecated Use +project+ methods instead
+    def method_missing(m, *args, &block)
+      if project.respond_to?(m) || project.respond_to_missing?(m)
+        log.deprecated("#{log_key}##{m}") { "#{m}. Please use project.#{m} instead." }
+        project.send(m, *args, &block)
+      else
+        super
+      end
+    end
+
     #
     # Generation methods
     # ------------------------------


### PR DESCRIPTION
With the move to a cleanroom, many of the seemingly random methods were removed from the Packager class. It turns out those methods were being used behind the scenes in ERB files.

This is why declaring a public API and having cleanrooms is so important.

/cc @opscode/release-engineers 
