### PR TITLE
Don't rely on an unreleased version of Ohai

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'chef-sugar',      '~> 1.2'
   gem.add_dependency 'mixlib-shellout', '~> 1.4'
-  gem.add_dependency 'ohai',            '~> 7.2.0.rc'
+  gem.add_dependency 'ohai',            '~> 7.2'
   gem.add_dependency 'fpm',             '~> 0.4'
   gem.add_dependency 'uber-s3'
   gem.add_dependency 'thor',            '~> 0.18'


### PR DESCRIPTION
Need to wait for Ohai 7.2 to actually be released + update the `Gemfile.lock` too.
