### PR TITLE
Monkey patch Mash to allow "dot" notation of resource accessors

### DIFF
--- a/spec/unit/ohai_spec.rb
+++ b/spec/unit/ohai_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+module Omnibus
+  describe Ohai do
+    context 'using dot notation' do
+      it 'does not raise an exception' do
+        expect { Ohai.kernel }.to_not raise_error
+        expect { Ohai.kernel.machine }.to_not raise_error
+      end
+    end
+
+    context 'using hash notation' do
+      it 'allows fetching values by hash notation' do
+        expect { Ohai['kernel'] }.to_not raise_error
+        expect { Ohai['kernel']['machine'] }.to_not raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ohai 7 does not allow users to call attributes by method names. Previously in Ohai 6, one could do something like:

``` ruby
Ohai.kernel.machine
```

In Ohai 7, you must use Ohai as a hash:

``` ruby
Ohai['kernel']['machine']
```

This commit restores the functionality presented with the previous version of Ohai, while adding a deprecation message that you should not use the "dot" notation in the future.
