### PR TITLE
Fix compiler_flag logic

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -478,7 +478,7 @@ module Omnibus
       env ||= {}
       opts ||= {}
       compiler_flags =
-        case Ohai['platform']
+        case Ohai['platform'].chomp
         when "aix"
           cc_flags =
             if opts[:aix] && opts[:aix][:use_gcc]


### PR DESCRIPTION
Change from platform to Ohai['platform'] in c16c8d9fd5f4b9c98cdb70bc705cebd101c019bc broke this completely via introduction of a newline.

Probably want to fix this upstream?  I expect there's other potential subtle chaos that will ensue elsewhere in places where Ohai is used (although I've been switching software defn code to chef-sugar so that'll help).

The server builds are likely unaffected by this due to them being on CentOS and Ubuntu which are both Linux and both fall through into the 'else' block anyway.  The chef-client builds on non-Linux systems will be broke but we haven't bumped the Gemfile.lock during the 11.14.0.rc release cycle.
