### PR TITLE
Standardize on install_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ name            'chef-full'
 maintainer      'YOUR NAME'
 homepage        'http://yoursite.com'
 
-install_path    '/opt/chef'
+install_dir     '/opt/chef'
 build_version   '0.10.8'
 build_iteration 4
 
@@ -144,7 +144,7 @@ Some DSL methods available include:
 | DSL Method        | Description                                 |
 | :---------------: | --------------------------------------------|
 | `name`            | The name of the project                     |
-| `install_path`    | The desired install location of the package |
+| `install_dir`     | The desired install location of the package |
 | `build_version`   | The package version                         |
 | `build_iteration` | The package iteration number                |
 | `dependency`      | An Omnibus software-defined component to include in this package |

--- a/docs/Building on Windows.md
+++ b/docs/Building on Windows.md
@@ -48,7 +48,7 @@ order to build an MSI. You can also create these files as erb templates and
 omnibus will render them before starting building the MSI.
 
 These files are XML files that are created based on Windows WIX Schema. By
-default they will package the files under configured `install_path` and present
+default they will package the files under configured `install_dir` and present
 a UI that lets users to choose an installation location for the packaged files.
 You can modify these XML files based on the documentation
   [here](http://wixtoolset.org/documentation/manual/v3/xsd/).

--- a/docs/omnibus-build-cache.md
+++ b/docs/omnibus-build-cache.md
@@ -5,7 +5,7 @@ reduces the time it takes to rebuild a project when only a few
 components need to be rebuilt.
 
 The cache uses git to snapshot the project tree after each software
-component build. The entire contents of the project's `install_path`
+component build. The entire contents of the project's `install_dir`
 is included in the snaphot.
 
 When rebuilding, omnibus walks the linearized component list and
@@ -18,7 +18,7 @@ config/software/$COMPONENT).
 
 The default location of the cache (which is just a bare git
 repository) is
-`/var/cache/omnibus/cache/install_path/$INSTALL_PATH`. You can
+`/var/cache/omnibus/cache/install_path/$INSTALL_DIR`. You can
 customize the location of the cache in the `omnibus.rb` config file
 using the key `install_path_cache_dir`. For example:
 

--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -8,7 +8,7 @@ Given(/^I have an omnibus project named "(.+)"$/) do |name|
     name '#{name}'
     maintainer 'Mrs. Maintainer'
     homepage 'https://example.com'
-    install_path './local/build/#{name}'
+    install_dir './local/build/#{name}'
 
     build_version '1.0.0'
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -171,19 +171,19 @@ module Omnibus
     #   all be collapsed into a single underlying implementation, since
     #   they all just differ on the executable being called
     def ruby(*args)
-      @build_commands << bundle_bust(*prepend_cmd("#{install_path}/embedded/bin/ruby", *args))
+      @build_commands << bundle_bust(*prepend_cmd("#{install_dir}/embedded/bin/ruby", *args))
     end
 
     def gem(*args)
-      @build_commands << bundle_bust(*prepend_cmd("#{install_path}/embedded/bin/gem", *args))
+      @build_commands << bundle_bust(*prepend_cmd("#{install_dir}/embedded/bin/gem", *args))
     end
 
     def bundle(*args)
-      @build_commands << bundle_bust(*prepend_cmd("#{install_path}/embedded/bin/bundle", *args))
+      @build_commands << bundle_bust(*prepend_cmd("#{install_dir}/embedded/bin/bundle", *args))
     end
 
     def rake(*args)
-      @build_commands << bundle_bust(*prepend_cmd("#{install_path}/embedded/bin/rake", *args))
+      @build_commands << bundle_bust(*prepend_cmd("#{install_dir}/embedded/bin/rake", *args))
     end
 
     def block(&rb_block)
@@ -208,16 +208,16 @@ module Omnibus
     #
     # @deprecated Use {install_path} instead
     #
-    def install_dir
+    def install_path
       log.deprecated(log_key) do
-        'install_dir (DSL). Please use install_path instead.'
+        'install_path (DSL). Please use install_dir instead.'
       end
 
-      install_path
+      install_dir
     end
 
-    def install_path
-      @software.install_path
+    def install_dir
+      @software.install_dir
     end
 
     def build

--- a/lib/omnibus/cleaner.rb
+++ b/lib/omnibus/cleaner.rb
@@ -58,9 +58,9 @@ module Omnibus
       Dir.glob("#{Config.cache_dir}/**/*").each(&method(:remove_file))
     end
 
-    def clean_install_path
+    def clean_install_dir
       return unless purge?
-      remove_file(@project.install_path)
+      remove_file(@project.install_dir)
     end
 
     private

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -131,17 +131,6 @@ module Omnibus
     #   @return [String]
     default(:project_root) { Dir.pwd }
 
-    # @!attribute [rw] install_dir
-    #   Installation directory
-    #
-    #   Defaults to `"/opt/chef"`.
-    #
-    #   @todo This appears to be unused, and actually conflated with
-    #     {Omnibus::Project#install_path}
-    #
-    #   @return [String]
-    default :install_dir, '/opt/chef'
-
     # @!endgroup
 
     # @!group DMG / PKG configuration options

--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -124,7 +124,7 @@ module Omnibus
     def template_options
       @template_options ||= {
         name: name,
-        install_path: "/opt/#{name}",
+        install_dir: "/opt/#{name}",
       }
     end
   end

--- a/lib/omnibus/generator_files/package_scripts/makeselfinst.erb
+++ b/lib/omnibus/generator_files/package_scripts/makeselfinst.erb
@@ -5,7 +5,7 @@
 
 PROGNAME=`basename $0`
 INSTALLER_DIR=`dirname $0`
-DEST_DIR=<%= config[:install_path] %>
+DEST_DIR=<%= config[:install_dir] %>
 CONFIG_DIR=/etc/<%= config[:name] %>
 USAGE="usage: $0"
 

--- a/lib/omnibus/generator_files/project.rb.erb
+++ b/lib/omnibus/generator_files/project.rb.erb
@@ -3,7 +3,7 @@ name '<%= config[:name] %>'
 maintainer 'CHANGE ME'
 homepage 'https://CHANGE-ME.com'
 
-install_path    '<%= config[:install_path] %>'
+install_dir     '<%= config[:install_dir] %>'
 build_version   Omnibus::BuildVersion.semver
 build_iteration 1
 

--- a/lib/omnibus/generator_files/software/c-example.rb.erb
+++ b/lib/omnibus/generator_files/software/c-example.rb.erb
@@ -17,14 +17,14 @@ source :url => "http://itchy.neckbeard.se/download/c-example-1.0.0.tar.gz",
 relative_path 'c-example-1.0.0'
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--disable-debug",
            "--enable-optimize",
            "--disable-ldap",
@@ -34,8 +34,8 @@ build do
            "--disable-dependency-tracking",
            "--enable-ipv6",
            "--without-libidn",
-           "--with-ssl=#{install_path}/embedded",
-           "--with-zlib=#{install_path}/embedded"].join(" "), :env => env
+           "--with-ssl=#{install_dir}/embedded",
+           "--with-zlib=#{install_dir}/embedded"].join(" "), :env => env
 
   command "make -j #{max_build_jobs}", :env => env
 

--- a/lib/omnibus/generator_files/software/erlang-example.rb.erb
+++ b/lib/omnibus/generator_files/software/erlang-example.rb.erb
@@ -17,22 +17,22 @@ source :git => "git://github.com/example/erlang.git"
 relative_path "erlang-example"
 
 env = {
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}",
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}",
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command "make distclean", :env => env
   command "make rel", :env => env
-  command "mkdir -p #{install_path}/embedded/service/example-erlang"
-  command ["#{install_path}/embedded/bin/rsync",
+  command "mkdir -p #{install_dir}/embedded/service/example-erlang"
+  command ["#{install_dir}/embedded/bin/rsync",
            "-a",
            "--delete",
            "--exclude=.git/***",
            "--exclude=.gitignore",
            "./rel/erlang-example/",
-           "#{install_path}/embedded/service/erlang-example/"].join(" ")
-  command "rm -rf #{install_path}/embedded/service/erlang-example/log"
+           "#{install_dir}/embedded/service/erlang-example/"].join(" ")
+  command "rm -rf #{install_dir}/embedded/service/erlang-example/log"
 end

--- a/lib/omnibus/generator_files/software/ruby-example.rb.erb
+++ b/lib/omnibus/generator_files/software/ruby-example.rb.erb
@@ -18,7 +18,7 @@ source :git => "git://github.com/example/ruby.git"
 relative_path "ruby-example"
 
 build do
-  bundle "install --path=#{install_path}/embedded/service/gem"
-  command "mkdir -p #{install_path}/embedded/service/ruby-example"
-  command "#{install_path}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./ #{install_path}/embedded/service/ruby-example/"
+  bundle "install --path=#{install_dir}/embedded/service/gem"
+  command "mkdir -p #{install_dir}/embedded/service/ruby-example"
+  command "#{install_dir}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./ #{install_dir}/embedded/service/ruby-example/"
 end

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -135,14 +135,14 @@ module Omnibus
       /libutil\.so/,
     ]
 
-    def self.run(install_path, whitelist_files = [])
+    def self.run(install_dir, whitelist_files = [])
       case Ohai['platform']
       when 'mac_os_x'
-        bad_libs = health_check_otool(install_path, whitelist_files)
+        bad_libs = health_check_otool(install_dir, whitelist_files)
       when 'aix'
-        bad_libs = health_check_aix(install_path, whitelist_files)
+        bad_libs = health_check_aix(install_dir, whitelist_files)
       else
-        bad_libs = health_check_ldd(install_path, whitelist_files)
+        bad_libs = health_check_ldd(install_dir, whitelist_files)
       end
 
       unresolved = []
@@ -232,25 +232,25 @@ module Omnibus
       end
     end
 
-    def self.health_check_otool(install_path, whitelist_files)
+    def self.health_check_otool(install_dir, whitelist_files)
       current_library = nil
       bad_libs = {}
 
-      read_shared_libs("find #{install_path}/ -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
+      read_shared_libs("find #{install_dir}/ -type f | egrep '\.(dylib|bundle)$' | xargs otool -L") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]
         when /^\s+(.+) \(.+\)$/
           linked = Regexp.last_match[1]
           name = File.basename(linked)
-          bad_libs = check_for_bad_library(install_path, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
         end
       end
 
       bad_libs
     end
 
-    def self.check_for_bad_library(install_path, bad_libs, whitelist_files, current_library, name, linked)
+    def self.check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
       safe = nil
 
       whitelist_libs = case Ohai['platform']
@@ -279,7 +279,7 @@ module Omnibus
       log.debug(log_key) { "  --> Dependency: #{name}" }
       log.debug(log_key) { "  --> Provided by: #{linked}" }
 
-      if !safe && linked !~ Regexp.new(install_path)
+      if !safe && linked !~ Regexp.new(install_dir)
         log.debug(log_key) { "    -> FAILED: #{current_library} has unsafe dependencies" }
         bad_libs[current_library] ||= {}
         bad_libs[current_library][name] ||= {}
@@ -295,11 +295,11 @@ module Omnibus
       bad_libs
     end
 
-    def self.health_check_aix(install_path, whitelist_files)
+    def self.health_check_aix(install_dir, whitelist_files)
       current_library = nil
       bad_libs = {}
 
-      read_shared_libs("find #{install_path}/ -type f | xargs file | grep \"RISC System\" | awk -F: '{print $1}' | xargs -n 1 ldd") do |line|
+      read_shared_libs("find #{install_dir}/ -type f | xargs file | grep \"RISC System\" | awk -F: '{print $1}' | xargs -n 1 ldd") do |line|
         case line
         when /^(.+) needs:$/
           current_library = Regexp.last_match[1]
@@ -307,7 +307,7 @@ module Omnibus
         when /^\s+(.+)$/
           name = Regexp.last_match[1]
           linked = Regexp.last_match[1]
-          bad_libs = check_for_bad_library(install_path, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
         when /File is not an executable XCOFF file/ # ignore non-executable files
         else
           log.warn(log_key) { "Line did not match for #{current_library}\n#{line}" }
@@ -317,11 +317,11 @@ module Omnibus
       bad_libs
     end
 
-    def self.health_check_ldd(install_path, whitelist_files)
+    def self.health_check_ldd(install_dir, whitelist_files)
       current_library = nil
       bad_libs = {}
 
-      read_shared_libs("find #{install_path}/ -type f | xargs ldd") do |line|
+      read_shared_libs("find #{install_dir}/ -type f | xargs ldd") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]
@@ -329,7 +329,7 @@ module Omnibus
         when /^\s+(.+) \=\>\s+(.+)( \(.+\))?$/
           name = Regexp.last_match[1]
           linked = Regexp.last_match[2]
-          bad_libs = check_for_bad_library(install_path, bad_libs, whitelist_files, current_library, name, linked)
+          bad_libs = check_for_bad_library(install_dir, bad_libs, whitelist_files, current_library, name, linked)
         when /^\s+(.+) \(.+\)$/
           next
         when /^\s+statically linked$/

--- a/lib/omnibus/install_path_cache.rb
+++ b/lib/omnibus/install_path_cache.rb
@@ -21,14 +21,14 @@ module Omnibus
   class InstallPathCache
     include Util
 
-    def initialize(install_path, software)
-      @install_path = install_path.sub(/^([A-Za-z]:)/, '') # strip drive letter on Windows
+    def initialize(install_dir, software)
+      @install_dir = install_dir.sub(/^([A-Za-z]:)/, '') # strip drive letter on Windows
       @software = software
     end
 
-    # The path to the full install_path cache for the project
+    # The path to the full install_dir cache for the project
     def cache_path
-      File.join(Config.install_path_cache_dir, @install_path)
+      File.join(Config.install_path_cache_dir, @install_dir)
     end
 
     # Whether the cache_path above exists
@@ -79,20 +79,20 @@ module Omnibus
     # Create an incremental install path cache for the software step
     def incremental
       create_cache_path
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_path} add -A -f))
+      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_dir} add -A -f))
       begin
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_path} commit -q -m "Backup of #{tag}"))
+        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_dir} commit -q -m "Backup of #{tag}"))
       rescue Mixlib::ShellOut::ShellCommandFailed => e
         if e.message !~ /nothing to commit/
           raise
         end
       end
-      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_path} tag -f "#{tag}"))
+      shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_dir} tag -f "#{tag}"))
     end
 
     def restore
       create_cache_path
-      cmd = shellout(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_path} tag -l "#{tag}"))
+      cmd = shellout(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_dir} tag -l "#{tag}"))
 
       restore_me = false
       cmd.stdout.each_line do |line|
@@ -100,7 +100,7 @@ module Omnibus
       end
 
       if restore_me
-        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_path} checkout -f "#{tag}"))
+        shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{@install_dir} checkout -f "#{tag}"))
         true
       else
         false

--- a/lib/omnibus/packagers/mac_pkg.rb
+++ b/lib/omnibus/packagers/mac_pkg.rb
@@ -81,8 +81,8 @@ module Omnibus
           --identifier "#{identifier}" \\
           --version "#{project.build_version}" \\
           --scripts "#{project.package_scripts_path}" \\
-          --root "#{project.install_path}" \\
-          --install-location "#{project.install_path}" \\
+          --root "#{project.install_dir}" \\
+          --install-location "#{project.install_dir}" \\
           "#{component_pkg}"
       EOH
     end

--- a/lib/omnibus/packagers/windows_msi.rb
+++ b/lib/omnibus/packagers/windows_msi.rb
@@ -49,7 +49,7 @@ module Omnibus
       # harvest the files with heat.exe
       # recursively generate fragment for project directory
       execute [
-        "heat.exe dir \"#{project.install_path}\"",
+        "heat.exe dir \"#{project.install_dir}\"",
         '-nologo -srd -gg -cg ProjectDir',
         '-dr PROJECTLOCATION -var var.ProjectSourceDir',
         '-out project-files.wxs',
@@ -58,7 +58,7 @@ module Omnibus
       # compile with candle.exe
       execute [
         'candle.exe -nologo',
-        "-dProjectSourceDir=\"#{project.install_path}\" project-files.wxs",
+        "-dProjectSourceDir=\"#{project.install_dir}\" project-files.wxs",
         "\"#{resource('source.wxs')}\"",
       ].join(' ')
 

--- a/spec/data/complicated/config/projects/angrychef.rb
+++ b/spec/data/complicated/config/projects/angrychef.rb
@@ -23,7 +23,7 @@ maintainer "Opscode, Inc."
 homepage "http://www.opscode.com"
 
 replaces        "angrychef"
-install_path    "/opt/angrychef"
+install_dir     "/opt/angrychef"
 build_version   '1.0.0'
 build_iteration 4
 

--- a/spec/data/complicated/config/projects/chef-windows.rb
+++ b/spec/data/complicated/config/projects/chef-windows.rb
@@ -22,7 +22,7 @@ homepage "http://www.opscode.com"
 # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
 #       Native gems will use gcc which will barf on files with spaces,
 #       which is only fixable if everyone in the world fixes their Makefiles
-install_path    "c:\\opscode\\chef"
+install_dir    "c:\\opscode\\chef"
 build_version   '1.0.0'
 build_iteration 4
 package_name    "chef-client"

--- a/spec/data/complicated/config/projects/chef.rb
+++ b/spec/data/complicated/config/projects/chef.rb
@@ -21,7 +21,7 @@ maintainer "Opscode, Inc."
 homepage "http://www.opscode.com"
 
 replaces        "chef-full"
-install_path    "/opt/chef"
+install_dir     "/opt/chef"
 build_version   '1.0.0'
 build_iteration 4
 mac_pkg_identifier "com.getchef.pkg.chef"

--- a/spec/data/complicated/config/projects/chefdk-windows.rb
+++ b/spec/data/complicated/config/projects/chefdk-windows.rb
@@ -22,7 +22,7 @@ homepage "http://www.opscode.com"
 # NOTE: Ruby DevKit fundamentally CANNOT be installed into "Program Files"
 #       Native gems will use gcc which will barf on files with spaces,
 #       which is only fixable if everyone in the world fixes their Makefiles
-install_path    "c:\\opscode\\chefdk"
+install_dir     "c:\\opscode\\chefdk"
 build_version   '1.0.0'
 build_iteration 1
 

--- a/spec/data/complicated/config/projects/chefdk.rb
+++ b/spec/data/complicated/config/projects/chefdk.rb
@@ -20,7 +20,7 @@ friendly_name "Chef DK"
 maintainer "Opscode, Inc."
 homepage   "http://www.opscode.com"
 
-install_path    "/opt/chefdk"
+install_dir     "/opt/chefdk"
 build_version   '1.0.0'
 build_iteration 1
 mac_pkg_identifier "com.getchef.pkg.chefdk"

--- a/spec/data/complicated/config/software/autoconf.rb
+++ b/spec/data/complicated/config/software/autoconf.rb
@@ -24,12 +24,12 @@ source :url => "http://ftp.gnu.org/gnu/autoconf/autoconf-2.68.tar.gz",
 relative_path "autoconf-2.68"
 
 env = {
-  "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+  "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 }
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => env
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}"
   command "make install"
 end

--- a/spec/data/complicated/config/software/automake.rb
+++ b/spec/data/complicated/config/software/automake.rb
@@ -26,14 +26,14 @@ source :url => "http://ftp.gnu.org/gnu/automake/automake-1.11.2.tar.gz",
 relative_path "automake-1.11.2"
 
 configure_env = {
-  "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"
+  "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
 }
 
 build do
-  command "./bootstrap", :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./bootstrap", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}"
   command "make install"
 end

--- a/spec/data/complicated/config/software/berkshelf.rb
+++ b/spec/data/complicated/config/software/berkshelf.rb
@@ -37,8 +37,8 @@ dependency "nokogiri"
 dependency "bundler"
 
 build do
-  bundle "install --without guard", :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
-  bundle "exec thor gem:build", :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
+  bundle "install --without guard", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  bundle "exec thor gem:build", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
   gem ["install pkg/berkshelf-*.gem",
-       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
+       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
 end

--- a/spec/data/complicated/config/software/bzip2.rb
+++ b/spec/data/complicated/config/software/bzip2.rb
@@ -29,7 +29,7 @@ source :url => "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
 
 relative_path "#{name}-#{version}"
 
-prefix="#{install_path}/embedded"
+prefix="#{install_dir}/embedded"
 libdir="#{prefix}/lib"
 
 env = {

--- a/spec/data/complicated/config/software/cacerts.rb
+++ b/spec/data/complicated/config/software/cacerts.rb
@@ -25,7 +25,7 @@ relative_path "cacerts-#{version}"
 
 build do
   block do
-    FileUtils.mkdir_p(File.expand_path("embedded/ssl/certs", install_path))
+    FileUtils.mkdir_p(File.expand_path("embedded/ssl/certs", install_dir))
 
     # There is a bug in omnibus-ruby that may or may not have been fixed. Since the source url
     # does not point to an archive, omnibus-ruby tries to copy cacert.pem into the project working
@@ -35,10 +35,10 @@ build do
     # directly from the cache instead.
 
     FileUtils.cp(File.expand_path("cacert.pem", Config.cache_dir),
-                 File.expand_path("embedded/ssl/certs/cacert.pem", install_path))
+                 File.expand_path("embedded/ssl/certs/cacert.pem", install_dir))
   end
 
   unless platform == 'windows'
-    command "ln -sf #{install_path}/embedded/ssl/certs/cacert.pem #{install_path}/embedded/ssl/cert.pem"
+    command "ln -sf #{install_dir}/embedded/ssl/certs/cacert.pem #{install_dir}/embedded/ssl/cert.pem"
   end
 end

--- a/spec/data/complicated/config/software/chef-client-msi.rb
+++ b/spec/data/complicated/config/software/chef-client-msi.rb
@@ -25,7 +25,7 @@ build do
   block do
     src_dir = self.project_dir
 
-    shell = Mixlib::ShellOut.new("heat.exe dir \"#{install_path}\" -nologo -srd -gg -cg ChefClientDir -dr CHEFLOCATION -var var.ChefClientSourceDir -out chef-client-Files.wxs", :cwd => src_dir)
+    shell = Mixlib::ShellOut.new("heat.exe dir \"#{install_dir}\" -nologo -srd -gg -cg ChefClientDir -dr CHEFLOCATION -var var.ChefClientSourceDir -out chef-client-Files.wxs", :cwd => src_dir)
     shell.run_command
     shell.error!
   end
@@ -45,18 +45,18 @@ build do
       @build_version = build_version.split("-")[1] || self.project.build_iteration
 
       # Find path in which chef gem is installed to.
-      # Note that install_path is something like: c:\\opscode\\chef
-      chef_path_regex = "#{install_path.gsub(File::ALT_SEPARATOR, File::SEPARATOR)}/**/gems/chef-[0-9]*"
+      # Note that install_dir is something like: c:\\opscode\\chef
+      chef_path_regex = "#{install_dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR)}/**/gems/chef-[0-9]*"
       chef_gem_paths = Dir[chef_path_regex].select{ |path| File.directory?(path) }
       raise "Expected one but found #{chef_gem_paths.length} installation directories for chef gem using: #{chef_path_regex}. Found paths: #{chef_gem_paths.inspect}." unless chef_gem_paths.length == 1
       @chef_gem_path = chef_gem_paths.first
 
-      # Convert the chef gem path to a relative path based on install_path
+      # Convert the chef gem path to a relative path based on install_dir
       # We are going to use this path in the startup command of chef
       # service. So we need to change file seperators to make windows
       # happy.
       @chef_gem_path.gsub!(File::SEPARATOR, File::ALT_SEPARATOR)
-      @chef_gem_path.slice!(install_path.gsub(File::SEPARATOR, File::ALT_SEPARATOR) + File::ALT_SEPARATOR)
+      @chef_gem_path.slice!(install_dir.gsub(File::SEPARATOR, File::ALT_SEPARATOR) + File::ALT_SEPARATOR)
 
       @guid = "D607A85C-BDFA-4F08-83ED-2ECB4DCD6BC5"
 
@@ -69,19 +69,19 @@ build do
 
   # Create temporary directory to store the files required for msi
   # packaging.
-  command "IF exist #{install_path}\\msi-tmp (echo msi-tmp is found on the system) ELSE (mkdir #{install_path}\\msi-tmp && echo msi-tmp directory is created.) "
+  command "IF exist #{install_dir}\\msi-tmp (echo msi-tmp is found on the system) ELSE (mkdir #{install_dir}\\msi-tmp && echo msi-tmp directory is created.) "
 
   # Copy the localization file into the temporary file directory for packaging
-  command "xcopy chef-client-en-us.wxl #{install_path}\\msi-tmp /Y", :cwd => source[:path]
+  command "xcopy chef-client-en-us.wxl #{install_dir}\\msi-tmp /Y", :cwd => source[:path]
 
   # Copy the asset files into the temporary file directory for packaging
-  command "xcopy assets #{install_path}\\msi-tmp\\assets /I /Y", :cwd => source[:path]
+  command "xcopy assets #{install_dir}\\msi-tmp\\assets /I /Y", :cwd => source[:path]
 
   # compile with candle.exe
   block do
     src_dir = self.project_dir
 
-    shell = Mixlib::ShellOut.new("candle.exe -nologo -out #{install_path}\\msi-tmp\\ -dChefClientSourceDir=\"#{install_path}\" chef-client-Files.wxs chef-client.wxs", :cwd => src_dir)
+    shell = Mixlib::ShellOut.new("candle.exe -nologo -out #{install_dir}\\msi-tmp\\ -dChefClientSourceDir=\"#{install_dir}\" chef-client-Files.wxs chef-client.wxs", :cwd => src_dir)
     shell.run_command
     shell.error!
   end

--- a/spec/data/complicated/config/software/chef-gem.rb
+++ b/spec/data/complicated/config/software/chef-gem.rb
@@ -22,5 +22,5 @@ dependency "ruby"
 dependency "rubygems"
 
 build do
-  gem "install chef -n #{install_path}/embedded/bin --no-rdoc --no-ri -v #{version}"
+  gem "install chef -n #{install_dir}/embedded/bin --no-rdoc --no-ri -v #{version}"
 end

--- a/spec/data/complicated/config/software/chef-vault.rb
+++ b/spec/data/complicated/config/software/chef-vault.rb
@@ -33,7 +33,7 @@ else
 end
 
 
-build_env = {'PATH' => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
+build_env = {'PATH' => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
 
 build do
   bundle 'install --no-cache', :env => build_env

--- a/spec/data/complicated/config/software/chef-windows.rb
+++ b/spec/data/complicated/config/software/chef-windows.rb
@@ -99,19 +99,19 @@ build do
     "libbz2-2.dll" => "libbz2-2.dll",
     "libz-1.dll" => "libz-1.dll"
   }.each do |target, to|
-    source = File.expand_path(File.join(install_path, "embedded", "mingw", "bin", to)).gsub(/\//, "\\")
-    target = File.expand_path(File.join(install_path, "bin", target)).gsub(/\//, "\\")
+    source = File.expand_path(File.join(install_dir, "embedded", "mingw", "bin", to)).gsub(/\//, "\\")
+    target = File.expand_path(File.join(install_dir, "bin", target)).gsub(/\//, "\\")
     command "cp #{source}  #{target}"
   end
 
   rake "gem"
 
   gem ["install pkg/chef*mingw32.gem",
-       "-n #{install_path}/bin",
+       "-n #{install_dir}/bin",
        "--no-rdoc --no-ri"].join(" ")
 
   # XXX: doing a normal bundle_bust here results in gems installed into the outer bundle...
-  command "bundle install", :env => { "PATH" => "#{install_path}/embedded/bin;#{install_path}/embedded/mingw/bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem", "BUNDLE_BIN_PATH" => "#{install_path}/embedded/bin/bundle" , "BUNDLE_GEMFILE" => nil, "GEM_HOME" => "#{install_path}/embedded/lib/ruby/gems/1.9.1", "GEM_PATH" => "#{install_path}/embedded/lib/ruby/gems/1.9.1", "RUBYOPT" => nil }
+  command "bundle install", :env => { "PATH" => "#{install_dir}/embedded/bin;#{install_dir}/embedded/mingw/bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem", "BUNDLE_BIN_PATH" => "#{install_dir}/embedded/bin/bundle" , "BUNDLE_GEMFILE" => nil, "GEM_HOME" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "GEM_PATH" => "#{install_dir}/embedded/lib/ruby/gems/1.9.1", "RUBYOPT" => nil }
 
   # render batch files
   #
@@ -135,22 +135,22 @@ EOBATCH
 
     gem_executables = []
     %w{chef}.each do |gem|
-      puts "#{install_path.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"
+      puts "#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"
       require 'pp'
-      pp Dir["#{install_path.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"]
-      gem_file = Dir["#{install_path.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"].first
+      pp Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"]
+      gem_file = Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*mingw32.gem"].first
       gem_executables << Gem::Format.from_file_by_path(gem_file).spec.executables
     end
 
     # XXX: need to fix ohai to use own gemspec as well and eliminate copypasta
     %w{ohai}.each do |gem|
-      gem_file = Dir["#{install_path.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*.gem"].first
+      gem_file = Dir["#{install_dir.gsub(/\\/, '/')}/embedded/**/cache/#{gem}*.gem"].first
       gem_executables << Gem::Format.from_file_by_path(gem_file).spec.executables
     end
 
     gem_executables.flatten.each do |bin|
       @bin = bin
-      File.open("#{install_path}/bin/#{@bin}.bat", "w") do |f|
+      File.open("#{install_dir}/bin/#{@bin}.bat", "w") do |f|
         f.puts batch_template.result(binding)
       end
     end

--- a/spec/data/complicated/config/software/chef.rb
+++ b/spec/data/complicated/config/software/chef.rb
@@ -34,19 +34,19 @@ env =
   case platform
   when "solaris2"
     {
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "LD_OPTIONS" => "-R#{install_path}/embedded/lib"
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
     }
   when "aix"
     {
-      "LDFLAGS" => "-Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib -L#{install_path}/embedded/lib",
-      "CFLAGS" => "-I#{install_path}/embedded/include"
+      "LDFLAGS" => "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+      "CFLAGS" => "-I#{install_dir}/embedded/include"
     }
   else
     {
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LDFLAGS" => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   end
 
@@ -111,36 +111,36 @@ build do
   # due to the fact that chefdk project has appbundler enabled.
   # Two differences are:
   #   1-) Order of bundle install & rake gem
-  #   2-) "-n #{install_path}/bin" option for gem install
+  #   2-) "-n #{install_dir}/bin" option for gem install
   # We don't expect any side effects from (1) other than not creating
   # link to erubis binary (which is not needed other than ruby 1.8.7 due to
   # change that switched the template syntax checking to native ruby code.
   # Not having (2) does not create symlinks for binaries under
-  # #{install_path}/bin which gets created by appbundler later on.
+  # #{install_dir}/bin which gets created by appbundler later on.
   if project.name == "chef"
     # install chef first so that ohai gets installed into /opt/chef/bin/ohai
-    rake "gem", :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
     command "rm -f pkg/chef-*-x86-mingw32.gem"
 
     gem ["install pkg/chef-*.gem",
-      "-n #{install_path}/bin",
-      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+      "-n #{install_dir}/bin",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
     # install the whole bundle, so that we get dev gems (like rspec) and can later test in CI
     # against all the exact gems that we ship (we will run rspec unbundled in the test phase).
-    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
   else
     # install the whole bundle first
-    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+    bundle "install --without server docgen", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
-    rake "gem", :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+    rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
     command "rm -f pkg/chef-*-x86-mingw32.gem"
 
-    # Don't use -n #{install_path}/bin. Appbundler will take care of them later
+    # Don't use -n #{install_dir}/bin. Appbundler will take care of them later
     gem ["install pkg/chef-*.gem",
-      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
   end
 
   auxiliary_gems = []
@@ -148,7 +148,7 @@ build do
 
   gem ["install",
        auxiliary_gems.join(" "),
-       "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+       "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
   #
   # TODO: the "clean up" section below was cargo-culted from the
@@ -165,6 +165,6 @@ build do
    "ssl/man",
    "man",
    "info"].each do |dir|
-    command "rm -rf #{install_path}/embedded/#{dir}"
+    command "rm -rf #{install_dir}/embedded/#{dir}"
   end
 end

--- a/spec/data/complicated/config/software/chefdk.rb
+++ b/spec/data/complicated/config/software/chefdk.rb
@@ -36,12 +36,12 @@ dependency "berkshelf"
 dependency "chef-vault"
 
 sep = File::PATH_SEPARATOR || ":"
-path = "#{install_path}/embedded/bin#{sep}#{ENV['PATH']}"
+path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
 
 env = {
   # rubocop pulls in nokogiri 1.5.11, so needs PKG_CONFIG_PATH and
   # NOKOGIRI_USE_SYSTEM_LIBRARIES until rubocop stops doing that
-  "PKG_CONFIG_PATH" => "#{install_path}/embedded/lib/pkgconfig",
+  "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
   "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
   "PATH" => path
 }
@@ -58,10 +58,10 @@ build do
 
   def appbuilder(app_path, bin_path)
     sep = File::PATH_SEPARATOR || ":"
-    path = "#{install_path}/embedded/bin#{sep}#{ENV['PATH']}"
+    path = "#{install_dir}/embedded/bin#{sep}#{ENV['PATH']}"
 
     gemfile = File.join(app_path, "Gemfile.lock")
-    command("#{install_path}/embedded/bin/appbundler #{app_path} #{bin_path}",
+    command("#{install_dir}/embedded/bin/appbundler #{app_path} #{bin_path}",
             :env => {
       'RUBYOPT'         => nil,
       'BUNDLE_BIN_PATH' => nil,
@@ -90,14 +90,14 @@ build do
 
   # do multiple gem installs to better isolate/debug failures
   auxiliary_gems.each do |g|
-    gem "install #{g[:name]} -v #{g[:version]} -n #{install_path}/bin --no-rdoc --no-ri --verbose", :env => env
+    gem "install #{g[:name]} -v #{g[:version]} -n #{install_dir}/bin --no-rdoc --no-ri --verbose", :env => env
   end
 
-  block { FileUtils.mkdir_p("#{install_path}/embedded/apps") }
+  block { FileUtils.mkdir_p("#{install_dir}/embedded/apps") }
 
   appbundler_apps = %w[chef berkshelf test-kitchen chef-dk chef-vault]
   appbundler_apps.each do |app_name|
-    block { FileUtils.cp_r("#{source_dir}/#{app_name}", "#{install_path}/embedded/apps/") }
-    appbuilder("#{install_path}/embedded/apps/#{app_name}", "#{install_path}/bin")
+    block { FileUtils.cp_r("#{source_dir}/#{app_name}", "#{install_dir}/embedded/apps/") }
+    appbuilder("#{install_dir}/embedded/apps/#{app_name}", "#{install_dir}/bin")
   end
 end

--- a/spec/data/complicated/config/software/couchdb.rb
+++ b/spec/data/complicated/config/software/couchdb.rb
@@ -29,25 +29,25 @@ source :url => "http://archive.apache.org/dist/couchdb/#{version}/apache-couchdb
 relative_path "apache-couchdb-#{version}"
 
 build_env = {
-  "RPATH" => "#{install_path}/embedded/lib",
-  "CURL_CONFIG" => "#{install_path}/embedded/bin/curl-config",
-  "ICU_CONFIG" => "#{install_path}/embedded/bin/icu-config",
-  "ERL" => "#{install_path}/embedded/bin/erl",
-  "ERLC" => "#{install_path}/embedded/bin/erlc",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "RPATH" => "#{install_dir}/embedded/lib",
+  "CURL_CONFIG" => "#{install_dir}/embedded/bin/curl-config",
+  "ICU_CONFIG" => "#{install_dir}/embedded/bin/icu-config",
+  "ERL" => "#{install_dir}/embedded/bin/erl",
+  "ERLC" => "#{install_dir}/embedded/bin/erlc",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
 #  command "./bootstrap", :env => build_env
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--disable-init",
            "--disable-launchd",
-           "--with-erlang=#{install_path}/embedded/lib/erlang/usr/include",
-           "--with-js-include=#{install_path}/embedded/include",
-           "--with-js-lib=#{install_path}/embedded/lib"].join(" "), :env => build_env
+           "--with-erlang=#{install_dir}/embedded/lib/erlang/usr/include",
+           "--with-js-include=#{install_dir}/embedded/include",
+           "--with-js-lib=#{install_dir}/embedded/lib"].join(" "), :env => build_env
   command "make -j #{max_build_jobs}", :env => build_env
   command "make install", :env => build_env
 end

--- a/spec/data/complicated/config/software/curl.rb
+++ b/spec/data/complicated/config/software/curl.rb
@@ -28,7 +28,7 @@ relative_path "curl-#{version}"
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--disable-debug",
            "--enable-optimize",
            "--disable-ldap",
@@ -40,9 +40,9 @@ build do
            "--without-libidn",
            "--without-gnutls",
            "--without-librtmp",
-           "--with-ssl=#{install_path}/embedded",
-           "--with-zlib=#{install_path}/embedded"].join(" ")
+           "--with-ssl=#{install_dir}/embedded",
+           "--with-zlib=#{install_dir}/embedded"].join(" ")
 
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/erlang.rb
+++ b/spec/data/complicated/config/software/erlang.rb
@@ -35,20 +35,20 @@ end
 source :url => "http://www.erlang.org/download/otp_src_#{version}.tar.gz"
 
 env = {
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/erlang/include",
-  "LDFLAGS" => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/erlang/include"
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include",
+  "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/erlang/include"
 }
 
 build do
   # set up the erlang include dir
-  command "mkdir -p #{install_path}/embedded/erlang/include"
+  command "mkdir -p #{install_dir}/embedded/erlang/include"
   %w{ncurses openssl zlib.h zconf.h}.each do |link|
-    command "ln -fs #{install_path}/embedded/include/#{link} #{install_path}/embedded/erlang/include/#{link}"
+    command "ln -fs #{install_dir}/embedded/include/#{link} #{install_dir}/embedded/erlang/include/#{link}"
   end
 
   # TODO: build cross-platform. this is for linux
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--enable-threads",
            "--enable-smp-support",
            "--enable-kernel-poll",
@@ -56,7 +56,7 @@ build do
            "--enable-shared-zlib",
            "--enable-hipe",
            "--without-javac",
-           "--with-ssl=#{install_path}/embedded",
+           "--with-ssl=#{install_dir}/embedded",
            "--disable-debug"].join(" "),
           :env => env)
 

--- a/spec/data/complicated/config/software/expat.rb
+++ b/spec/data/complicated/config/software/expat.rb
@@ -7,14 +7,14 @@ source :url => "http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat
        :md5 => "dd7dab7a5fea97d2a6a43f511449b7cd"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded"].join(" "), :env => env
+           "--prefix=#{install_dir}/embedded"].join(" "), :env => env
 
   command "make -j #{max_build_jobs}", :env => env
   command "make install"

--- a/spec/data/complicated/config/software/fcgi.rb
+++ b/spec/data/complicated/config/software/fcgi.rb
@@ -27,13 +27,13 @@ source :url => "http://fastcgi.com/dist/fcgi-2.4.0.tar.gz",
 
 relative_path "fcgi-2.4.0"
 
-reconf_env = {"PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"}
+reconf_env = {"PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"}
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -L/lib -L/usr/lib",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -L/lib -L/usr/lib",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
@@ -50,7 +50,7 @@ D
   command "libtoolize", :env => reconf_env
 
   # configure and build
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/fcgiwrap.rb
+++ b/spec/data/complicated/config/software/fcgiwrap.rb
@@ -27,15 +27,15 @@ source :git => "git://github.com/gnosek/fcgiwrap"
 relative_path "fcgiwrap"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
   command "autoreconf -i", :env => env
-  command "./configure --prefix=#{install_path}/embedded", :env => env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/gd.rb
+++ b/spec/data/complicated/config/software/gd.rb
@@ -32,25 +32,25 @@ relative_path "libgd-gd-libgd-486e81dea984"
 source_dir = "#{project_dir}/src"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   "LIBS" => "-liconv"
 }
 
 build do
   patch :source => 'gd-2.0.33-configure-libpng.patch'
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
-           "--with-libiconv-prefix=#{install_path}/embedded",
-           "--with-jpeg=#{install_path}/embedded",
-           "--with-png=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
+           "--with-libiconv-prefix=#{install_dir}/embedded",
+           "--with-jpeg=#{install_dir}/embedded",
+           "--with-png=#{install_dir}/embedded",
            "--without-x", "--without-freetype",
            "--without-fontconfig",
            "--without-xpm"].join(" "),
           :env => configure_env,
           :cwd => source_dir)
 
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/bin", "LIBS" => "-liconv"}, :cwd => source_dir
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin", "LIBS" => "-liconv"}, :cwd => source_dir
   command "make install", :cwd => source_dir
 end

--- a/spec/data/complicated/config/software/gdbm.rb
+++ b/spec/data/complicated/config/software/gdbm.rb
@@ -28,7 +28,7 @@ relative_path "gdbm-1.9.1"
 build do
   configure_command = ["./configure",
                        "--enable-libgdbm-compat",
-                       "--prefix=#{install_path}/embedded"]
+                       "--prefix=#{install_dir}/embedded"]
 
   if platform == "freebsd"
     configure_command << "--with-pic"

--- a/spec/data/complicated/config/software/gecode.rb
+++ b/spec/data/complicated/config/software/gecode.rb
@@ -34,7 +34,7 @@ configure_env = if test.exitstatus == 0
 
 build do
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--disable-doc-dot",
            "--disable-doc-search",
            "--disable-doc-tagfile",
@@ -43,6 +43,6 @@ build do
            "--disable-qt",
            "--disable-examples"].join(" "),
           :env => configure_env)
-  command "make -j #{max_build_jobs}", :env => { "LD_RUN_PATH" => "#{install_path}/embedded/lib" }
+  command "make -j #{max_build_jobs}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
 end

--- a/spec/data/complicated/config/software/git.rb
+++ b/spec/data/complicated/config/software/git.rb
@@ -15,9 +15,9 @@ source :url => "https://github.com/git/git/archive/v#{version}.tar.gz",
        :md5 => "906f984f5c8913176547dc456608be16"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
 
   "NO_GETTEXT" => "1",
   "NO_PYTHON" => "1",
@@ -25,16 +25,16 @@ env = {
   "NO_R_TO_GCC_LINKER" => "1",
   "NEEDS_LIBICONV" => "1",
 
-  "PERL_PATH" => "#{install_path}/embedded/bin/perl",
-  "ZLIB_PATH" => "#{install_path}/embedded",
-  "ICONVDIR" => "#{install_path}/embedded",
-  "OPENSSLDIR" => "#{install_path}/embedded",
-  "EXPATDIR" => "#{install_path}/embedded",
-  "CURLDIR" => "#{install_path}/embedded",
-  "LIBPCREDIR" => "#{install_path}/embedded"
+  "PERL_PATH" => "#{install_dir}/embedded/bin/perl",
+  "ZLIB_PATH" => "#{install_dir}/embedded",
+  "ICONVDIR" => "#{install_dir}/embedded",
+  "OPENSSLDIR" => "#{install_dir}/embedded",
+  "EXPATDIR" => "#{install_dir}/embedded",
+  "CURLDIR" => "#{install_dir}/embedded",
+  "LIBPCREDIR" => "#{install_dir}/embedded"
 }
 
 build do
-  command "make -j #{max_build_jobs} prefix=#{install_path}/embedded", :env => env
-  command "make install prefix=#{install_path}/embedded", :env => env
+  command "make -j #{max_build_jobs} prefix=#{install_dir}/embedded", :env => env
+  command "make install prefix=#{install_dir}/embedded", :env => env
 end

--- a/spec/data/complicated/config/software/help2man.rb
+++ b/spec/data/complicated/config/software/help2man.rb
@@ -24,7 +24,7 @@ source :url => "http://ftp.gnu.org/gnu/help2man/help2man-1.40.5.tar.gz",
 relative_path "help2man-1.40.5"
 
 build do
-  command "./configure --prefix=#{install_path}/embedded"
+  command "./configure --prefix=#{install_dir}/embedded"
   command "make"
   command "make install"
 end

--- a/spec/data/complicated/config/software/icu.rb
+++ b/spec/data/complicated/config/software/icu.rb
@@ -26,14 +26,14 @@ relative_path "icu"
 working_dir = "#{project_dir}/source"
 
 build do
-  command("./configure --prefix=#{install_path}/embedded",
+  command("./configure --prefix=#{install_dir}/embedded",
           :env => {
-            "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+            "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
           },
           :cwd => working_dir)
   command("make -j #{max_build_jobs}",
           :env => {
-            "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+            "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
           },
           :cwd => working_dir)
   command "make install", :cwd => working_dir

--- a/spec/data/complicated/config/software/jre.rb
+++ b/spec/data/complicated/config/software/jre.rb
@@ -40,9 +40,9 @@ end
 
 relative_path "jre1.7.0_03"
 
-jre_dir = "#{install_path}/embedded/jre"
+jre_dir = "#{install_dir}/embedded/jre"
 
 build do
   command "mkdir -p #{jre_dir}"
-  command "#{install_path}/embedded/bin/rsync -a . #{jre_dir}/"
+  command "#{install_dir}/embedded/bin/rsync -a . #{jre_dir}/"
 end

--- a/spec/data/complicated/config/software/keepalived.rb
+++ b/spec/data/complicated/config/software/keepalived.rb
@@ -27,9 +27,9 @@ source :url => "http://www.keepalived.org/software/keepalived-1.2.9.tar.gz",
 relative_path "keepalived-1.2.9"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
@@ -37,7 +37,7 @@ build do
   # d384ce8b3492b9d76af23e621a20bed8da9c6016 of keepalived, (master
   # branch), and should be no longer necessary after 1.2.9.
   patch :source => "keepalived-1.2.9_opscode_centos_5.patch"
-  command "./configure --prefix=#{install_path}/embedded --disable-iconv", :env => env
+  command "./configure --prefix=#{install_dir}/embedded --disable-iconv", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make install"
 end

--- a/spec/data/complicated/config/software/libarchive.rb
+++ b/spec/data/complicated/config/software/libarchive.rb
@@ -27,12 +27,12 @@ source :url => "http://www.libarchive.org/downloads/libarchive-#{version}.tar.gz
 relative_path "libarchive-#{version}"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include "
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include "
 }
 
 build do
-  command "./configure --prefix=#{install_path}/embedded \
+  command "./configure --prefix=#{install_dir}/embedded \
     --without-lzma \
     --without-lzo2 \
     --without-nettle \

--- a/spec/data/complicated/config/software/libedit.rb
+++ b/spec/data/complicated/config/software/libedit.rb
@@ -39,19 +39,19 @@ env = case platform
           "CC" => "xlc -q64",
           "CXX" => "xlC -q64",
           "LD" => "ld -b64",
-          "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
-          "CXXFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+          "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+          "CXXFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
           "OBJECT_MODE" => "64",
           "ARFLAGS" => "-X64 cru",
           "M4" => "/opt/freeware/bin/m4",
-          "LDFLAGS" => "-q64 -L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
+          "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
         }
       else
         {
-          "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses",
-          "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses",
-          "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-          "LD_OPTIONS" => "-R#{install_path}/embedded/lib"
+          "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+          "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
         }
       end
 
@@ -62,7 +62,7 @@ build do
     patch :source => "freebsd-vi-fix.patch"
   end
   command ["./configure",
-           "--prefix=#{install_path}/embedded"
+           "--prefix=#{install_dir}/embedded"
            ].join(" "), :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make -j #{max_build_jobs} install"

--- a/spec/data/complicated/config/software/libffi.rb
+++ b/spec/data/complicated/config/software/libffi.rb
@@ -32,40 +32,40 @@ configure_env =
   case platform
   when "aix"
     {
-      "LDFLAGS" => "-maix64 -L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
-      "CFLAGS" => "-maix64 -I#{install_path}/embedded/include",
+      "LDFLAGS" => "-maix64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+      "CFLAGS" => "-maix64 -I#{install_dir}/embedded/include",
       "LD" => "ld -b64",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru "
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib -DNO_VIZ"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib -DNO_VIZ"
     }
   else
     {
-      "LDFLAGS" => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}"
   command "make -j #{max_build_jobs} install"
   # libffi's default install location of header files is aweful...
-  command "cp -f #{install_path}/embedded/lib/libffi-3.0.13/include/* #{install_path}/embedded/include"
+  command "cp -f #{install_dir}/embedded/lib/libffi-3.0.13/include/* #{install_dir}/embedded/include"
 
   # On centos libffi libraries are places under /embedded/lib64
   # move them over to lib
   if platform == "centos"
-    command "mv #{install_path}/embedded/lib64/* #{install_path}/embedded/lib/"
-    command "rm -rf #{install_path}/embedded/lib64"
+    command "mv #{install_dir}/embedded/lib64/* #{install_dir}/embedded/lib/"
+    command "rm -rf #{install_dir}/embedded/lib64"
   end
 end

--- a/spec/data/complicated/config/software/libgcc.rb
+++ b/spec/data/complicated/config/software/libgcc.rb
@@ -21,7 +21,7 @@ description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
 if (platform == "solaris2" && Config.solaris_compiler == "gcc")
   build do
     if File.exists?("/opt/csw/lib/libgcc_s.so.1")
-      command "cp /opt/csw/lib/libgcc_s.so.1 #{install_path}/embedded/lib/"
+      command "cp /opt/csw/lib/libgcc_s.so.1 #{install_dir}/embedded/lib/"
     else
       raise "cannot find libgcc_s.so.1 -- where is your gcc compiler?"
     end
@@ -31,7 +31,7 @@ end
 if platform == "aix"
   build do
     if File.exists?("/opt/freeware/lib/pthread/ppc64/libgcc_s.a")
-      command "cp -f /opt/freeware/lib/pthread/ppc64/libgcc_s.a #{install_path}/embedded/lib/"
+      command "cp -f /opt/freeware/lib/pthread/ppc64/libgcc_s.a #{install_dir}/embedded/lib/"
     else
       raise "cannot find libgcc_s.a -- where is your gcc compiler?"
     end

--- a/spec/data/complicated/config/software/libiconv.rb
+++ b/spec/data/complicated/config/software/libiconv.rb
@@ -31,25 +31,25 @@ env = case platform
           "CC" => "xlc -q64",
           "CXX" => "xlC -q64",
           "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
-          "CFLAGS" => "-O -q64 -I#{install_path}/embedded/include",
-          "CXXFLAGS" => "-O -q64 -I#{install_path}/embedded/include",
+          "CFLAGS" => "-O -q64 -I#{install_dir}/embedded/include",
+          "CXXFLAGS" => "-O -q64 -I#{install_dir}/embedded/include",
           "LD" => "ld -b64",
           "OBJECT_MODE" => "64",
           "ARFLAGS" => "-X64 cru "
         }
       else
         {
-          "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-          "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
         }
       end
 
 if platform == "solaris2"
-  env.merge!({"LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc", "LD_OPTIONS" => "-R#{install_path}/embedded/lib"})
+  env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc", "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
 end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => env
+  command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{max_build_jobs}", :env => env
-  command "make -j #{max_build_jobs} install-lib libdir=#{install_path}/embedded/lib includedir=#{install_path}/embedded/include", :env => env
+  command "make -j #{max_build_jobs} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env
 end

--- a/spec/data/complicated/config/software/libjpeg.rb
+++ b/spec/data/complicated/config/software/libjpeg.rb
@@ -24,16 +24,16 @@ source :url => "http://www.ijg.org/files/jpegsrc.v8d.tar.gz",
 relative_path "jpeg-8d"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
-  command "./configure --prefix=#{install_path}/embedded --enable-shared --enable-static", :env => configure_env
-  command "mkdir -p #{install_path}/embedded/man/man1"
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "./configure --prefix=#{install_dir}/embedded --enable-shared --enable-static", :env => configure_env
+  command "mkdir -p #{install_dir}/embedded/man/man1"
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
-  command "rm -rf #{install_path}/embedded/man"
+  command "rm -rf #{install_dir}/embedded/man"
 end

--- a/spec/data/complicated/config/software/libpng.rb
+++ b/spec/data/complicated/config/software/libpng.rb
@@ -26,13 +26,13 @@ source :url => "ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng15/libpng-#
 relative_path "libpng-#{version}"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
-  command "./configure --prefix=#{install_path}/embedded --with-zlib-prefix=#{install_path}/embedded", :env => configure_env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "./configure --prefix=#{install_dir}/embedded --with-zlib-prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/libtool.rb
+++ b/spec/data/complicated/config/software/libtool.rb
@@ -34,18 +34,18 @@ build do
   env = case platform
         when "aix"
         {
-            "LDFLAGS" => "-L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
-            "CFLAGS" => "-maix64 -O -I#{install_path}/embedded/include",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+            "CFLAGS" => "-maix64 -O -I#{install_dir}/embedded/include",
             "OBJECT_MODE" => "64",
             "CC" => "gcc -maix64",
             "CXX" => "g++ -maix64",
         }
   end
   if platform == "aix"
-    command "./configure --prefix=#{install_path}/embedded --with-gcc", :env => env
+    command "./configure --prefix=#{install_dir}/embedded --with-gcc", :env => env
     command "make", :env => env
   else
-    command "./configure --prefix=#{install_path}/embedded"
+    command "./configure --prefix=#{install_dir}/embedded"
     command "make"
   end
   command "make install"

--- a/spec/data/complicated/config/software/libwrap.rb
+++ b/spec/data/complicated/config/software/libwrap.rb
@@ -45,6 +45,6 @@ build do
   patch :source => "tcp_wrappers-7.6-malloc-fix.patch"
   patch :source => "tcp_wrappers-7.6-makefile-dest-fix.patch"
   command "make STYLE=-DPROCESS_OPTIONS linux"
-  command "make DESTDIR=#{install_path}/embedded install-lib"
-  command "make DESTDIR=#{install_path}/embedded install-dev"
+  command "make DESTDIR=#{install_dir}/embedded install-lib"
+  command "make DESTDIR=#{install_dir}/embedded install-dev"
 end

--- a/spec/data/complicated/config/software/libxml2.rb
+++ b/spec/data/complicated/config/software/libxml2.rb
@@ -35,17 +35,17 @@ relative_path "libxml2-#{version}"
 
 build do
   cmd = ["./configure",
-         "--prefix=#{install_path}/embedded",
-         "--with-zlib=#{install_path}/embedded",
-         "--with-iconv=#{install_path}/embedded",
+         "--prefix=#{install_dir}/embedded",
+         "--with-zlib=#{install_dir}/embedded",
+         "--with-iconv=#{install_dir}/embedded",
          "--without-python",
          "--without-icu"].join(" ")
   env = {
-    "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
   }
   command cmd, :env => env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
-  command "make install", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
 end

--- a/spec/data/complicated/config/software/libxslt.rb
+++ b/spec/data/complicated/config/software/libxslt.rb
@@ -35,18 +35,18 @@ relative_path "libxslt-#{version}"
 
 build do
   env = {
-    "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
   }
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
-           "--with-libxml-prefix=#{install_path}/embedded",
-           "--with-libxml-include-prefix=#{install_path}/embedded/include",
-           "--with-libxml-libs-prefix=#{install_path}/embedded/lib",
+           "--prefix=#{install_dir}/embedded",
+           "--with-libxml-prefix=#{install_dir}/embedded",
+           "--with-libxml-include-prefix=#{install_dir}/embedded/include",
+           "--with-libxml-libs-prefix=#{install_dir}/embedded/lib",
            "--without-python",
            "--without-crypto"].join(" "),
           :env => env)
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/bin"}
-  command "make install", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/bin"}
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
+  command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/bin"}
 end

--- a/spec/data/complicated/config/software/libyaml-windows.rb
+++ b/spec/data/complicated/config/software/libyaml-windows.rb
@@ -39,5 +39,5 @@ build do
   # Now extract the files out of tar archive.
   command "7z.exe x #{File.join(temp_directory, "libyaml-0.1.6-x86-windows.tar")} -o#{temp_directory} -r -y"
   # Now copy over libyaml-0-2.dll to the build dir
-  command "cp #{File.join(temp_directory, "bin", "libyaml-0-2.dll")} #{File.join(install_path, "embedded", "bin", "libyaml-0-2.dll")}"
+  command "cp #{File.join(temp_directory, "bin", "libyaml-0-2.dll")} #{File.join(install_dir, "embedded", "bin", "libyaml-0-2.dll")}"
 end

--- a/spec/data/complicated/config/software/libyaml.rb
+++ b/spec/data/complicated/config/software/libyaml.rb
@@ -30,7 +30,7 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
@@ -40,23 +40,23 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -DNO_VIZ"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -DNO_VIZ"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}", :env => configure_env
   command "make -j #{max_build_jobs} install", :env => configure_env
 end

--- a/spec/data/complicated/config/software/logrotate.rb
+++ b/spec/data/complicated/config/software/logrotate.rb
@@ -27,11 +27,11 @@ relative_path "logrotate-#{version}"
 
 env = {
   # Patch allows this to be set manually
-  "BASEDIR" => "#{install_path}/embedded",
+  "BASEDIR" => "#{install_dir}/embedded",
   # These EXTRA_* vars allow us to append to the Makefile's hardcoded LDFLAGS
   # and CFLAGS
-  "EXTRA_LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "EXTRA_CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
+  "EXTRA_LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "EXTRA_CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
 }
 
 build do

--- a/spec/data/complicated/config/software/makedepend.rb
+++ b/spec/data/complicated/config/software/makedepend.rb
@@ -34,7 +34,7 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
@@ -44,30 +44,30 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
-configure_env["PKG_CONFIG_PATH"] = "#{install_path}/embedded/lib/pkgconfig" +
+configure_env["PKG_CONFIG_PATH"] = "#{install_dir}/embedded/lib/pkgconfig" +
   File::PATH_SEPARATOR +
-  "#{install_path}/embedded/share/pkgconfig"
+  "#{install_dir}/embedded/share/pkgconfig"
 
 # For pkg-config
-configure_env["PATH"] = "#{install_path}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+configure_env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}", :env => configure_env
   command "make -j #{max_build_jobs} install", :env => configure_env
 end

--- a/spec/data/complicated/config/software/mysql2.rb
+++ b/spec/data/complicated/config/software/mysql2.rb
@@ -35,8 +35,8 @@ dependency "bundler"
 
 build do
   gem "install rake-compiler"
-  command "mkdir -p #{install_path}/embedded/service/gem/ruby/1.9.1/cache"
+  command "mkdir -p #{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
   versions_to_install.each do |ver|
-    gem "fetch mysql2 --version #{ver}", :cwd => "#{install_path}/embedded/service/gem/ruby/1.9.1/cache"
+    gem "fetch mysql2 --version #{ver}", :cwd => "#{install_dir}/embedded/service/gem/ruby/1.9.1/cache"
   end
 end

--- a/spec/data/complicated/config/software/nagios-plugins.rb
+++ b/spec/data/complicated/config/software/nagios-plugins.rb
@@ -30,9 +30,9 @@ source :url => "http://downloads.sourceforge.net/project/nagiosplug/nagiosplug/1
 relative_path "nagios-plugins-1.4.15"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 gem_env = {"GEM_PATH" => nil, "GEM_HOME" => nil}
@@ -40,14 +40,14 @@ gem_env = {"GEM_PATH" => nil, "GEM_HOME" => nil}
 build do
   # configure it
   command(["./configure",
-           "--prefix=#{install_path}/embedded/nagios",
-           "--with-trusted-path=#{install_path}/bin:#{install_path}/embedded/bin:/bin:/sbin:/usr/bin:/usr/sbin",
-           "--with-openssl=#{install_path}/embedded",
-           "--with-pgsql=#{install_path}/embedded",
-           "--with-libiconv-prefix=#{install_path}/embedded"].join(" "),
+           "--prefix=#{install_dir}/embedded/nagios",
+           "--with-trusted-path=#{install_dir}/bin:#{install_dir}/embedded/bin:/bin:/sbin:/usr/bin:/usr/sbin",
+           "--with-openssl=#{install_dir}/embedded",
+           "--with-pgsql=#{install_dir}/embedded",
+           "--with-libiconv-prefix=#{install_dir}/embedded"].join(" "),
           :env => configure_env)
 
   # build it
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "sudo make install"
 end

--- a/spec/data/complicated/config/software/nagios.rb
+++ b/spec/data/complicated/config/software/nagios.rb
@@ -28,24 +28,24 @@ source :url => "http://downloads.sourceforge.net/project/nagios/nagios-3.x/nagio
 relative_path "nagios"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   # configure it
   command(["./configure",
-           "--prefix=#{install_path}/embedded/nagios",
+           "--prefix=#{install_dir}/embedded/nagios",
            "--with-nagios-user=opscode-nagios",
            "--with-nagios-group=opscode-nagios",
            "--with-command-group=opscode-nagios-cmd",
            "--with-command-user=opscode-nagios-cmd",
-           "--with-gd-lib=#{install_path}/embedded/lib",
-           "--with-gd-inc=#{install_path}/embedded/include",
-           "--with-temp-dir=/var#{install_path}/nagios/tmp",
-           "--with-lockfile=/var#{install_path}/nagios/lock",
-           "--with-checkresult-dir=/var#{install_path}/nagios/checkresult",
+           "--with-gd-lib=#{install_dir}/embedded/lib",
+           "--with-gd-inc=#{install_dir}/embedded/include",
+           "--with-temp-dir=/var#{install_dir}/nagios/tmp",
+           "--with-lockfile=/var#{install_dir}/nagios/lock",
+           "--with-checkresult-dir=/var#{install_dir}/nagios/checkresult",
            "--with-mail=/usr/bin/mail"].join(" "),
           :env => env)
 
@@ -56,11 +56,11 @@ build do
   command "bash -c \"find . -name 'Makefile' | xargs sed -i 's:-o opscode-nagios -g opscode-nagios:-o root -g root:g'\""
 
   # build it
-  command "make -j #{max_build_jobs} all", :env => { "LD_RUN_PATH" => "#{install_path}/embedded/lib" }
+  command "make -j #{max_build_jobs} all", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "sudo make install"
   command "sudo make install-config"
   command "sudo make install-exfoliation"
 
   # clean up the install
-  command "sudo rm -rf #{install_path}/embedded/nagios/etc/*"
+  command "sudo rm -rf #{install_dir}/embedded/nagios/etc/*"
 end

--- a/spec/data/complicated/config/software/ncurses.rb
+++ b/spec/data/complicated/config/software/ncurses.rb
@@ -29,33 +29,33 @@ relative_path "ncurses-5.9"
 env = case platform
       when "aix"
         {
-          "PATH" => "#{install_path}/embedded/bin:" + ENV['PATH'],
-          "LDFLAGS" => "-Wl,-brtl -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib -L#{install_path}/embedded/lib",
-          "CXXFLAGS" => "-O -I#{install_path}/embedded/include",
-          "CFLAGS" => "-O -I#{install_path}/embedded/include",
+          "PATH" => "#{install_dir}/embedded/bin:" + ENV['PATH'],
+          "LDFLAGS" => "-Wl,-brtl -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+          "CXXFLAGS" => "-O -I#{install_dir}/embedded/include",
+          "CFLAGS" => "-O -I#{install_dir}/embedded/include",
           "OBJECT_MODE" => "64",
           "CC" => "gcc -maix64",
           "CXX" => "g++ -maix64",
-          "CFLAGS" => "-maix64 -I#{install_path}/embedded/include",
+          "CFLAGS" => "-maix64 -I#{install_dir}/embedded/include",
           "ARFLAGS" => "-X64 cru"
         }
       else
         {
-          "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-          "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-          "LDFLAGS" => "-L#{install_path}/embedded/lib"
+          "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+          "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+          "LDFLAGS" => "-L#{install_dir}/embedded/lib"
         }
       end
 
 if platform == "solaris2"
-  env.merge!({"LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc"})
-  env.merge!({"LD_OPTIONS" => "-R#{install_path}/embedded/lib"})
+  env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc"})
+  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
   # gcc4 from opencsw fails to compile ncurses
   env.merge!({"PATH" => "/opt/csw/gcc3/bin:/opt/csw/bin:/usr/local/bin:/usr/sfw/bin:/usr/ccs/bin:/usr/sbin:/usr/bin"})
   env.merge!({"CC" => "/opt/csw/gcc3/bin/gcc"})
   env.merge!({"CXX" => "/opt/csw/gcc3/bin/g++"})
 elsif platform == "smartos"
-  env.merge!({"LD_OPTIONS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib "})
+  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib "})
 end
 
 ########################################################################
@@ -109,7 +109,7 @@ build do
 
   # build wide-character libraries
   cmd_array = ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--with-shared",
            "--with-termlib",
            "--without-debug",
@@ -126,7 +126,7 @@ build do
   # build non-wide-character libraries
   command "make distclean"
   cmd_array = ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--with-shared",
            "--with-termlib",
            "--without-debug",
@@ -144,6 +144,6 @@ build do
 
   # Ensure embedded ncurses wins in the LD search path
   if platform == "smartos"
-    command "ln -sf #{install_path}/embedded/lib/libcurses.so #{install_path}/embedded/lib/libcurses.so.1"
+    command "ln -sf #{install_dir}/embedded/lib/libcurses.so #{install_dir}/embedded/lib/libcurses.so.1"
   end
 end

--- a/spec/data/complicated/config/software/nginx.rb
+++ b/spec/data/complicated/config/software/nginx.rb
@@ -28,13 +28,13 @@ relative_path "nginx-#{version}"
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--with-http_ssl_module",
            "--with-http_stub_status_module",
            "--with-ipv6",
            "--with-debug",
-           "--with-ld-opt=-L#{install_path}/embedded/lib",
-           "--with-cc-opt=\"-L#{install_path}/embedded/lib -I#{install_path}/embedded/include\""].join(" ")
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+           "--with-ld-opt=-L#{install_dir}/embedded/lib",
+           "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\""].join(" ")
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/nodejs.rb
+++ b/spec/data/complicated/config/software/nodejs.rb
@@ -38,7 +38,7 @@ else
 end
 
 build do
-  command "#{python} ./configure --prefix=#{install_path}/embedded"
+  command "#{python} ./configure --prefix=#{install_dir}/embedded"
   command "make -j #{max_build_jobs}"
   command "make install"
 end

--- a/spec/data/complicated/config/software/nokogiri.rb
+++ b/spec/data/complicated/config/software/nokogiri.rb
@@ -36,7 +36,7 @@ end
 # /opt/chef/embedded pkg-configs.  this should probably be done more generally,
 # in core ominbus-ruby.
 env = {
-  "PKG_CONFIG_PATH" => "#{install_path}/embedded/lib/pkgconfig",
+  "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
   "NOKOGIRI_USE_SYSTEM_LIBRARIES" => "true",
 }
 
@@ -46,10 +46,10 @@ build do
        "-v #{version}",
        "--",
        "--use-system-libraries",
-       "--with-xml2-lib=#{install_path}/embedded/lib",
-       "--with-xml2-include=#{install_path}/embedded/include/libxml2",
-       "--with-xslt-lib=#{install_path}/embedded/lib",
-       "--with-xslt-include=#{install_path}/embedded/include/libxslt",
-       "--with-iconv-dir=#{install_path}/embedded",
-       "--with-zlib-dir=#{install_path}/embedded"].join(" "), :env => env
+       "--with-xml2-lib=#{install_dir}/embedded/lib",
+       "--with-xml2-include=#{install_dir}/embedded/include/libxml2",
+       "--with-xslt-lib=#{install_dir}/embedded/lib",
+       "--with-xslt-include=#{install_dir}/embedded/include/libxslt",
+       "--with-iconv-dir=#{install_dir}/embedded",
+       "--with-zlib-dir=#{install_dir}/embedded"].join(" "), :env => env
 end

--- a/spec/data/complicated/config/software/nrpe.rb
+++ b/spec/data/complicated/config/software/nrpe.rb
@@ -29,10 +29,10 @@ source :url => "http://downloads.sourceforge.net/project/nagios/nrpe-2.x/nrpe-2.
 relative_path "nrpe-2.13"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
@@ -44,18 +44,18 @@ build do
 
   # configure it
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
-           "--with-ssl=#{install_path}/embedded",
-           "--with-ssl-lib=#{install_path}/embedded/lib",
-           "--with-ssl-inc=#{install_path}/embedded/include"].join(" "),
+           "--prefix=#{install_dir}/embedded",
+           "--with-ssl=#{install_dir}/embedded",
+           "--with-ssl-lib=#{install_dir}/embedded/lib",
+           "--with-ssl-inc=#{install_dir}/embedded/include"].join(" "),
           :env => env)
 
   # build it
-  command "make all", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "make all", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
 
   # move it
-  command "mkdir -p #{install_path}/embedded/nagios/libexec"
-  command "mkdir -p #{install_path}/embedded/nagios/bin"
-  command "cp ./src/check_nrpe #{install_path}/embedded/nagios/libexec"
-  command "sudo cp ./src/nrpe #{install_path}/embedded/nagios/bin"
+  command "mkdir -p #{install_dir}/embedded/nagios/libexec"
+  command "mkdir -p #{install_dir}/embedded/nagios/bin"
+  command "cp ./src/check_nrpe #{install_dir}/embedded/nagios/libexec"
+  command "sudo cp ./src/nrpe #{install_dir}/embedded/nagios/bin"
 end

--- a/spec/data/complicated/config/software/ohai.rb
+++ b/spec/data/complicated/config/software/ohai.rb
@@ -37,28 +37,28 @@ env =
   case platform
   when "solaris2"
     {
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   when "aix"
     {
-      "LDFLAGS" => "-Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib -L#{install_path}/embedded/lib",
-      "CFLAGS" => "-I#{install_path}/embedded/include"
+      "LDFLAGS" => "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib -L#{install_dir}/embedded/lib",
+      "CFLAGS" => "-I#{install_dir}/embedded/include"
     }
   else
     {
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LDFLAGS" => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   end
 
 build do
 
   # install chef first so that ohai gets installed into /opt/chef/bin/ohai
-  rake "gem", :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+  rake "gem", :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
   gem ["install pkg/ohai*.gem",
-      "-n #{install_path}/bin",
-      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"})
+      "-n #{install_dir}/bin",
+      "--no-rdoc --no-ri"].join(" "), :env => env.merge({"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"})
 
 end

--- a/spec/data/complicated/config/software/omnibus-ctl.rb
+++ b/spec/data/complicated/config/software/omnibus-ctl.rb
@@ -29,6 +29,6 @@ relative_path "omnibus-ctl"
 build do
   gem "build omnibus-ctl.gemspec"
   gem "install omnibus-ctl-#{version}.gem"
-  command "mkdir -p #{install_path}/embedded/service/omnibus-ctl"
-  command "touch #{install_path}/embedded/service/omnibus-ctl/.gitkeep"
+  command "mkdir -p #{install_dir}/embedded/service/omnibus-ctl"
+  command "touch #{install_dir}/embedded/service/omnibus-ctl/.gitkeep"
 end

--- a/spec/data/complicated/config/software/openresty.rb
+++ b/spec/data/complicated/config/software/openresty.rb
@@ -29,22 +29,22 @@ relative_path "ngx_openresty-#{version}"
 
 build do
   env = {
-    "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-    "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
   }
 
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
-           "--sbin-path=#{install_path}/embedded/sbin/nginx",
-           "--conf-path=#{install_path}/embedded/conf/nginx.conf",
+           "--prefix=#{install_dir}/embedded",
+           "--sbin-path=#{install_dir}/embedded/sbin/nginx",
+           "--conf-path=#{install_dir}/embedded/conf/nginx.conf",
            "--with-http_ssl_module",
            "--with-debug",
            "--with-http_stub_status_module",
            # Building Nginx with non-system OpenSSL
            # http://www.ruby-forum.com/topic/207287#902308
-           "--with-ld-opt=\"-L#{install_path}/embedded/lib -Wl,-rpath,#{install_path}/embedded/lib -lssl -lcrypto -ldl -lz\"",
-           "--with-cc-opt=\"-L#{install_path}/embedded/lib -I#{install_path}/embedded/include\"",
+           "--with-ld-opt=\"-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib -lssl -lcrypto -ldl -lz\"",
+           "--with-cc-opt=\"-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include\"",
            # Options inspired by the OpenResty Cookbook
            '--with-md5-asm',
            '--with-sha1-asm',

--- a/spec/data/complicated/config/software/openssl.rb
+++ b/spec/data/complicated/config/software/openssl.rb
@@ -43,17 +43,17 @@ build do
   env = case platform
         when "mac_os_x"
           {
-            "CFLAGS" => "-arch x86_64 -m64 -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses",
-            "LDFLAGS" => "-arch x86_64 -R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses"
+            "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
+            "LDFLAGS" => "-arch x86_64 -R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses"
           }
         when "aix"
         {
             "CC" => "xlc -q64",
             "CXX" => "xlC -q64",
             "LD" => "ld -b64",
-            "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
-            "CXXFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
-            "LDFLAGS" => "-q64 -L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
+            "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+            "CXXFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
+            "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
             "OBJECT_MODE" => "64",
             "AR" => "/usr/bin/ar",
             "ARFLAGS" => "-X64 cru",
@@ -61,21 +61,21 @@ build do
         }
         when "solaris2"
           {
-            "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-            "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-            "LD_OPTIONS" => "-R#{install_path}/embedded/lib"
+            "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+            "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+            "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
           }
         else
           {
-            "CFLAGS" => "-I#{install_path}/embedded/include",
-            "LDFLAGS" => "-Wl,-rpath,#{install_path}/embedded/lib -L#{install_path}/embedded/lib"
+            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
           }
         end
 
   common_args = [
-    "--prefix=#{install_path}/embedded",
-    "--with-zlib-lib=#{install_path}/embedded/lib",
-    "--with-zlib-include=#{install_path}/embedded/include",
+    "--prefix=#{install_dir}/embedded",
+    "--with-zlib-lib=#{install_dir}/embedded/lib",
+    "--with-zlib-include=#{install_dir}/embedded/include",
     "no-idea",
     "no-mdc2",
     "no-rc5",
@@ -88,9 +88,9 @@ build do
                         ["perl", "./Configure",
                          "aix64-cc",
                          common_args,
-                        "-L#{install_path}/embedded/lib",
-                        "-I#{install_path}/embedded/include",
-                        "-Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib"].join(" ")
+                        "-L#{install_dir}/embedded/lib",
+                        "-I#{install_dir}/embedded/include",
+                        "-Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib"].join(" ")
                       when "mac_os_x"
                         ["./Configure",
                          "darwin64-x86_64-cc",
@@ -100,9 +100,9 @@ build do
                         ["/bin/bash ./Configure",
                          "solaris64-x86_64-gcc",
                          common_args,
-                         "-L#{install_path}/embedded/lib",
-                         "-I#{install_path}/embedded/include",
-                         "-R#{install_path}/embedded/lib",
+                         "-L#{install_dir}/embedded/lib",
+                         "-I#{install_dir}/embedded/include",
+                         "-R#{install_dir}/embedded/lib",
                         "-static-libgcc"].join(" ")
                       when "solaris2"
                         if Config.solaris_compiler == "gcc"
@@ -110,9 +110,9 @@ build do
                             ["/bin/sh ./Configure",
                              "solaris-sparcv9-gcc",
                              common_args,
-                            "-L#{install_path}/embedded/lib",
-                            "-I#{install_path}/embedded/include",
-                            "-R#{install_path}/embedded/lib",
+                            "-L#{install_dir}/embedded/lib",
+                            "-I#{install_dir}/embedded/include",
+                            "-R#{install_dir}/embedded/lib",
                             "-static-libgcc"].join(" ")
                           else
                             # This should not require a /bin/sh, but without it we get
@@ -120,9 +120,9 @@ build do
                             ["/bin/sh ./Configure",
                              "solaris-x86-gcc",
                              common_args,
-                            "-L#{install_path}/embedded/lib",
-                            "-I#{install_path}/embedded/include",
-                            "-R#{install_path}/embedded/lib",
+                            "-L#{install_dir}/embedded/lib",
+                            "-I#{install_dir}/embedded/include",
+                            "-R#{install_dir}/embedded/lib",
                             "-static-libgcc"].join(" ")
                           end
                         else
@@ -132,13 +132,13 @@ build do
                         ["./config",
                         common_args,
                         "disable-gost",  # fixes build on linux, but breaks solaris
-                        "-L#{install_path}/embedded/lib",
-                        "-I#{install_path}/embedded/include",
-                        "-Wl,-rpath,#{install_path}/embedded/lib"].join(" ")
+                        "-L#{install_dir}/embedded/lib",
+                        "-I#{install_dir}/embedded/include",
+                        "-Wl,-rpath,#{install_dir}/embedded/lib"].join(" ")
                       end
 
   # openssl build process uses a `makedepend` tool that we build inside the bundle.
-  env["PATH"] = "#{install_path}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
+  env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
   # @todo: move into omnibus-ruby
   has_gmake = system("gmake --version")

--- a/spec/data/complicated/config/software/pcre.rb
+++ b/spec/data/complicated/config/software/pcre.rb
@@ -27,16 +27,16 @@ source :url => "http://iweb.dl.sourceforge.net/project/pcre/pcre/8.31/pcre-8.31.
 relative_path "pcre-8.31"
 
 configure_env = {
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 }
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--enable-pcretest-libedit"].join(" "), :env => configure_env
   command("make -j #{max_build_jobs}",
           :env => {
-            "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+            "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
           })
   command "make install"
 end

--- a/spec/data/complicated/config/software/perl-extutils-embed.rb
+++ b/spec/data/complicated/config/software/perl-extutils-embed.rb
@@ -9,7 +9,7 @@ source :url => "http://search.cpan.org/CPAN/authors/id/D/DO/DOUGM/ExtUtils-Embed
 relative_path "ExtUtils-Embed-#{version}"
 
 build do
-    command "#{install_path}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_path}/embedded"
+    command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
     command "make"
     command "make install"
 end

--- a/spec/data/complicated/config/software/perl-extutils-makemaker.rb
+++ b/spec/data/complicated/config/software/perl-extutils-makemaker.rb
@@ -9,7 +9,7 @@ source :url => "http://search.cpan.org/CPAN/authors/id/B/BI/BINGOS/ExtUtils-Make
 relative_path "ExtUtils-MakeMaker-#{version}"
 
 build do
-    command "#{install_path}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_path}/embedded"
+    command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
     command "make"
     command "make install"
 end

--- a/spec/data/complicated/config/software/perl.rb
+++ b/spec/data/complicated/config/software/perl.rb
@@ -7,16 +7,16 @@ source :url => "http://www.cpan.org/src/5.0/perl-#{version}.tar.gz",
 relative_path "perl-#{version}"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command [
             "sh Configure",
             "-de",
-            "-Dprefix=#{install_path}/embedded",
+            "-Dprefix=#{install_dir}/embedded",
             "-Duseshrplib", ## Compile shared libperl
             "-Dusethreads", ## Compile ithread support
             "-Dnoextensions='DB_File GDBM_File NDBM_File ODBM_File'"

--- a/spec/data/complicated/config/software/perl_pg_driver.rb
+++ b/spec/data/complicated/config/software/perl_pg_driver.rb
@@ -4,7 +4,7 @@ dependency "perl"
 dependency "postgresql" # only because we're compiling DBD::Pg here, too.
 
 # Ensure we install with the properly configured embedded `cpan` client
-omnibus_cpan_client = "#{install_path}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
+omnibus_cpan_client = "#{install_dir}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
 
 build do
   # We're using PostgreSQL as our database engine, so we need the right driver

--- a/spec/data/complicated/config/software/php.rb
+++ b/spec/data/complicated/config/software/php.rb
@@ -15,27 +15,27 @@ source :url => "http://us.php.net/distributions/php-5.3.10.tar.gz",
 relative_path "php-5.3.10"
 
 env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command(["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--without-pear",
-           "--with-zlib-dir=#{install_path}/embedded",
-           "--with-pcre-dir=#{install_path}/embedded",
-           "--with-xsl=#{install_path}/embedded",
-           "--with-libxml-dir=#{install_path}/embedded",
-           "--with-iconv=#{install_path}/embedded",
-           "--with-openssl-dir=#{install_path}/embedded",
-           "--with-gd=#{install_path}/embedded",
+           "--with-zlib-dir=#{install_dir}/embedded",
+           "--with-pcre-dir=#{install_dir}/embedded",
+           "--with-xsl=#{install_dir}/embedded",
+           "--with-libxml-dir=#{install_dir}/embedded",
+           "--with-iconv=#{install_dir}/embedded",
+           "--with-openssl-dir=#{install_dir}/embedded",
+           "--with-gd=#{install_dir}/embedded",
            "--enable-fpm",
            "--with-fpm-user=opscode",
            "--with-fpm-group=opscode"].join(" "),
           :env => env)
 
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/pip.rb
+++ b/spec/data/complicated/config/software/pip.rb
@@ -26,5 +26,5 @@ source :url => "https://pypi.python.org/packages/source/p/pip/pip-#{version}.tar
 relative_path "pip-#{version}"
 
 build do
-  command "#{install_path}/embedded/bin/python setup.py install --prefix=#{install_path}/embedded"
+  command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
 end

--- a/spec/data/complicated/config/software/pkg-config.rb
+++ b/spec/data/complicated/config/software/pkg-config.rb
@@ -32,7 +32,7 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
@@ -42,25 +42,25 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
-paths = [ "#{install_path}/embedded/bin/pkgconfig" ]
+paths = [ "#{install_dir}/embedded/bin/pkgconfig" ]
 
 build do
-  command "./configure --prefix=#{install_path}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths*':'}", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths*':'}", :env => configure_env
   command "make -j #{max_build_jobs}", :env => configure_env
   command "make -j #{max_build_jobs} install", :env => configure_env
 end

--- a/spec/data/complicated/config/software/popt.rb
+++ b/spec/data/complicated/config/software/popt.rb
@@ -27,21 +27,21 @@ env =
   case platform
   when "solaris2"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
     }
   end
 
 build do
   # --disable-nls => Disable localization support.
-  command "./configure --prefix=#{install_path}/embedded --disable-nls", :env => env
+  command "./configure --prefix=#{install_dir}/embedded --disable-nls", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make install"
 end

--- a/spec/data/complicated/config/software/postgresql.rb
+++ b/spec/data/complicated/config/software/postgresql.rb
@@ -35,17 +35,17 @@ source :url => "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{ve
 relative_path "postgresql-#{version}"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--with-libedit-preferred",
-           "--with-openssl --with-includes=#{install_path}/embedded/include",
-           "--with-libraries=#{install_path}/embedded/lib"].join(" "), :env => configure_env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+           "--with-openssl --with-includes=#{install_dir}/embedded/include",
+           "--with-libraries=#{install_dir}/embedded/lib"].join(" "), :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/preparation.rb
+++ b/spec/data/complicated/config/software/preparation.rb
@@ -22,7 +22,7 @@ default_version '1.0.0'
 build do
   block do
     %w{embedded/lib embedded/bin bin}.each do |dir|
-      dir_fullpath = File.expand_path(File.join(install_path, dir))
+      dir_fullpath = File.expand_path(File.join(install_dir, dir))
       FileUtils.mkdir_p(dir_fullpath)
       FileUtils.touch(File.join(dir_fullpath, '.gitkeep'))
     end

--- a/spec/data/complicated/config/software/pygments.rb
+++ b/spec/data/complicated/config/software/pygments.rb
@@ -21,5 +21,5 @@ default_version "1.6"
 dependency "pip"
 
 build do
-  command "#{install_path}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
 end

--- a/spec/data/complicated/config/software/python.rb
+++ b/spec/data/complicated/config/software/python.rb
@@ -30,13 +30,13 @@ source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
 relative_path "Python-#{version}"
 
 env = {
-  "CFLAGS" => "-I#{install_path}/embedded/include -O3 -g -pipe",
-  "LDFLAGS" => "-Wl,-rpath,#{install_path}/embedded/lib -L#{install_path}/embedded/lib"
+  "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+  "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
 }
 
 build do
   command ["./configure",
-           "--prefix=#{install_path}/embedded",
+           "--prefix=#{install_dir}/embedded",
            "--enable-shared",
            "--with-dbmliborder=gdbm"].join(" "), :env => env
   command "make", :env => env
@@ -44,6 +44,6 @@ build do
 
   # There exists no configure flag to tell Python to not compile readline support :(
   block do
-    FileUtils.rm_f(Dir.glob("#{install_path}/embedded/lib/python2.7/lib-dynload/readline.*"))
+    FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python2.7/lib-dynload/readline.*"))
   end
 end

--- a/spec/data/complicated/config/software/rabbitmq.rb
+++ b/spec/data/complicated/config/software/rabbitmq.rb
@@ -27,10 +27,10 @@ source :url => "http://www.rabbitmq.com/releases/rabbitmq-server/v2.7.1/rabbitmq
 relative_path "rabbitmq_server-2.7.1"
 
 build do
-  command "mkdir -p #{install_path}/embedded/service/rabbitmq"
-  command "#{install_path}/embedded/bin/rsync -a ./ #{install_path}/embedded/service/rabbitmq/"
+  command "mkdir -p #{install_dir}/embedded/service/rabbitmq"
+  command "#{install_dir}/embedded/bin/rsync -a ./ #{install_dir}/embedded/service/rabbitmq/"
 
   %w{rabbitmqctl rabbitmq-env rabbitmq-server}.each do |cmd|
-    command "ln -sf #{install_path}/embedded/service/rabbitmq/sbin/#{cmd} #{install_path}/embedded/bin/#{cmd}"
+    command "ln -sf #{install_dir}/embedded/service/rabbitmq/sbin/#{cmd} #{install_dir}/embedded/bin/#{cmd}"
   end
 end

--- a/spec/data/complicated/config/software/rebar.rb
+++ b/spec/data/complicated/config/software/rebar.rb
@@ -25,12 +25,12 @@ source :git => "https://github.com/basho/rebar.git"
 relative_path "rebar"
 
 env = {
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}",
-  "LD_FLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}",
+  "LD_FLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
 }
 
 build do
   command "./bootstrap", :env => env
-  command "cp ./rebar #{install_path}/embedded/bin/"
+  command "cp ./rebar #{install_dir}/embedded/bin/"
 end

--- a/spec/data/complicated/config/software/redis.rb
+++ b/spec/data/complicated/config/software/redis.rb
@@ -23,9 +23,9 @@ source :url => "http://download.redis.io/releases/redis-#{version}.tar.gz",
 
 relative_path "redis-#{version}"
 
-make_args = ["PREFIX=#{install_path}/embedded",
-             "CFLAGS='-L#{install_path}/embedded/lib -I#{install_path}/embedded/include'",
-             "LD_RUN_PATH=#{install_path}/embedded/lib"].join(" ")
+make_args = ["PREFIX=#{install_dir}/embedded",
+             "CFLAGS='-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include'",
+             "LD_RUN_PATH=#{install_dir}/embedded/lib"].join(" ")
 
 build do
   command ["make -j #{max_build_jobs}", make_args].join(" ")

--- a/spec/data/complicated/config/software/rsync.rb
+++ b/spec/data/complicated/config/software/rsync.rb
@@ -29,20 +29,20 @@ env =
   case platform
   when "solaris2"
       {
-        "LDFLAGS" => "-R #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-        "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-        "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+        "LDFLAGS" => "-R #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+        "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+        "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
       }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "LD_RUN_PATH" => "#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded --disable-iconv", :env => env
+  command "./configure --prefix=#{install_dir}/embedded --disable-iconv", :env => env
   command "make -j #{max_build_jobs}", :env => env
   command "make install"
 end

--- a/spec/data/complicated/config/software/ruby-windows-devkit.rb
+++ b/spec/data/complicated/config/software/ruby-windows-devkit.rb
@@ -24,7 +24,7 @@ source :url => "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-
        :md5 => "4bf8f2dd1d582c8733a67027583e19a6"
 
 build do
-  command "DevKit-tdm-32-#{version}-sfx.exe -y -o#{File.expand_path(File.join(install_path, "embedded")).gsub(/\//, "\\")}"
-  command "echo - #{install_path}/embedded > config.yml", :cwd => "#{install_path}/embedded"
-  ruby "dk.rb install", :cwd => "#{install_path}/embedded"
+  command "DevKit-tdm-32-#{version}-sfx.exe -y -o#{File.expand_path(File.join(install_dir, "embedded")).gsub(/\//, "\\")}"
+  command "echo - #{install_dir}/embedded > config.yml", :cwd => "#{install_dir}/embedded"
+  ruby "dk.rb install", :cwd => "#{install_dir}/embedded"
 end

--- a/spec/data/complicated/config/software/ruby-windows.rb
+++ b/spec/data/complicated/config/software/ruby-windows.rb
@@ -26,5 +26,5 @@ source :url => "http://dl.bintray.com/oneclick/rubyinstaller/ruby-#{version}-i38
 build do
   # Robocopy's return code is 1 if it succesfully copies over the
   # files and 0 if the files are already existing at the destination
-  command "robocopy . #{install_path}\\embedded\\ /MIR", :returns => [0, 1]
+  command "robocopy . #{install_dir}\\embedded\\ /MIR", :returns => [0, 1]
 end

--- a/spec/data/complicated/config/software/ruby.rb
+++ b/spec/data/complicated/config/software/ruby.rb
@@ -49,14 +49,14 @@ env =
       # would be harmless, except that autoconf treats any output to stderr as
       # a failure when it makes a test program to check your CFLAGS (regardless
       # of the actual exit code from the compiler).
-      "CFLAGS" => "-arch x86_64 -m64 -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses -O3 -g -pipe -Qunused-arguments",
-      "LDFLAGS" => "-arch x86_64 -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -I#{install_path}/embedded/include/ncurses"
+      "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses -O3 -g -pipe -Qunused-arguments",
+      "LDFLAGS" => "-arch x86_64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses"
     }
   when "solaris2"
     {
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -O3 -g -pipe",
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "LD_OPTIONS" => "-R#{install_path}/embedded/lib"
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -O3 -g -pipe",
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"
     }
   when "aix"
     {
@@ -86,9 +86,9 @@ env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -O -qhot -I#{install_path}/embedded/include",
-      "CXXFLAGS" => "-q64 -O -qhot -I#{install_path}/embedded/include",
-      "LDFLAGS" => "-q64  -L#{install_path}/embedded/lib -Wl,-brtl -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
+      "CFLAGS" => "-q64 -O -qhot -I#{install_dir}/embedded/include",
+      "CXXFLAGS" => "-q64 -O -qhot -I#{install_dir}/embedded/include",
+      "LDFLAGS" => "-q64  -L#{install_dir}/embedded/lib -Wl,-brtl -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
       "M4" => "/opt/freeware/bin/m4",
@@ -96,14 +96,14 @@ env =
     }
   else
     {
-      "CFLAGS" => "-I#{install_path}/embedded/include -O3 -g -pipe",
-      "LDFLAGS" => "-Wl,-rpath,#{install_path}/embedded/lib -L#{install_path}/embedded/lib"
+      "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+      "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
   configure_command = ["./configure",
-                       "--prefix=#{install_path}/embedded",
+                       "--prefix=#{install_dir}/embedded",
                        "--with-out-ext=fiddle,dbm",
                        "--enable-shared",
                        "--enable-libedit",
@@ -117,7 +117,7 @@ build do
     # --with-opt-dir causes ruby to send bogus commands to the AIX linker
   when "freebsd"
     configure_command << "--without-execinfo"
-    configure_command << "--with-opt-dir=#{install_path}/embedded"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
   when "smartos"
     # Opscode patch - someara@opscode.com
     # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
@@ -132,9 +132,9 @@ build do
     # From RVM forum
     # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
     configure_command << "ac_cv_func_dl_iterate_phdr=no"
-    configure_command << "--with-opt-dir=#{install_path}/embedded"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
   else
-    configure_command << "--with-opt-dir=#{install_path}/embedded"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
   end
 
   # @todo expose bundle_bust() in the DSL

--- a/spec/data/complicated/config/software/runit.rb
+++ b/spec/data/complicated/config/software/runit.rb
@@ -27,7 +27,7 @@ working_dir = "#{project_dir}/runit-2.1.1"
 
 build do
   # put runit where we want it, not where they tell us to
-  command 'sed -i -e "s/^char\ \*varservice\ \=\"\/service\/\";$/char\ \*varservice\ \=\"' + project.install_path.gsub("/", "\\/") + '\/service\/\";/" src/sv.c', :cwd => working_dir
+  command 'sed -i -e "s/^char\ \*varservice\ \=\"\/service\/\";$/char\ \*varservice\ \=\"' + project.install_dir.gsub("/", "\\/") + '\/service\/\";/" src/sv.c', :cwd => working_dir
   # TODO: the following is not idempotent
   command "sed -i -e s:-static:: src/Makefile", :cwd => working_dir
 
@@ -36,7 +36,7 @@ build do
   command "make check", :cwd => "#{working_dir}/src"
 
   # move it
-  command "mkdir -p #{install_path}/embedded/bin"
+  command "mkdir -p #{install_dir}/embedded/bin"
   ["src/chpst",
    "src/runit",
    "src/runit-init",
@@ -46,12 +46,12 @@ build do
    "src/sv",
    "src/svlogd",
    "src/utmpset"].each do |bin|
-    command "cp #{bin} #{install_path}/embedded/bin", :cwd => working_dir
+    command "cp #{bin} #{install_dir}/embedded/bin", :cwd => working_dir
   end
 
   block do
-    install_path = self.project.install_path
-    open("#{install_path}/embedded/bin/runsvdir-start", "w") do |file|
+    install_dir = self.project.install_dir
+    open("#{install_dir}/embedded/bin/runsvdir-start", "w") do |file|
       file.print <<-EOH
 #!/bin/bash
 #
@@ -71,7 +71,7 @@ build do
 # limitations under the License.
 #
 
-PATH=#{install_path}/bin:#{install_path}/embedded/bin:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+PATH=#{install_dir}/bin:#{install_dir}/embedded/bin:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
 
 # enforce our own ulimits
 
@@ -98,18 +98,18 @@ echo "1000000" > /proc/sys/fs/file-max
 umask 022
 
 exec env - PATH=$PATH \
-runsvdir -P #{install_path}/service 'log: ...........................................................................................................................................................................................................................................................................................................................................................................................................'
+runsvdir -P #{install_dir}/service 'log: ...........................................................................................................................................................................................................................................................................................................................................................................................................'
        EOH
     end
   end
 
-  command "chmod 755 #{install_path}/embedded/bin/runsvdir-start"
+  command "chmod 755 #{install_dir}/embedded/bin/runsvdir-start"
 
   # set up service directories
   block do
-    ["#{install_path}/service",
-     "#{install_path}/sv",
-     "#{install_path}/init"].each do |dir|
+    ["#{install_dir}/service",
+     "#{install_dir}/sv",
+     "#{install_dir}/init"].each do |dir|
       FileUtils.mkdir_p(dir)
       # make sure cached builds include this dir
       FileUtils.touch(File.join(dir, '.gitkeep'))

--- a/spec/data/complicated/config/software/server-jre.rb
+++ b/spec/data/complicated/config/software/server-jre.rb
@@ -38,9 +38,9 @@ end
 
 relative_path "jdk1.7.0_25"
 
-jre_dir = "#{install_path}/embedded/jre"
+jre_dir = "#{install_dir}/embedded/jre"
 
 build do
   command "mkdir -p #{jre_dir}"
-  command "#{install_path}/embedded/bin/rsync -a . #{jre_dir}/"
+  command "#{install_dir}/embedded/bin/rsync -a . #{jre_dir}/"
 end

--- a/spec/data/complicated/config/software/setuptools.rb
+++ b/spec/data/complicated/config/software/setuptools.rb
@@ -26,5 +26,5 @@ source :url => "https://pypi.python.org/packages/source/s/setuptools/setuptools-
 relative_path "setuptools-#{version}"
 
 build do
-  command "#{install_path}/embedded/bin/python setup.py install --prefix=#{install_path}/embedded"
+  command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
 end

--- a/spec/data/complicated/config/software/spawn-fcgi.rb
+++ b/spec/data/complicated/config/software/spawn-fcgi.rb
@@ -27,14 +27,14 @@ source :url => "http://www.lighttpd.net/download/spawn-fcgi-1.6.3.tar.gz",
 relative_path "spawn-fcgi-1.6.3"
 
 configure_env = {
-  "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  "LD_RUN_PATH" => "#{install_path}/embedded/lib",
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
-  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
+  command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
 end

--- a/spec/data/complicated/config/software/sphinx.rb
+++ b/spec/data/complicated/config/software/sphinx.rb
@@ -22,5 +22,5 @@ dependency "pip"
 dependency "pygments"
 
 build do
-  command "#{install_path}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
 end

--- a/spec/data/complicated/config/software/spidermonkey.rb
+++ b/spec/data/complicated/config/software/spidermonkey.rb
@@ -23,7 +23,7 @@ source :url => "http://ftp.mozilla.org/pub/mozilla.org/js/js-1.8.0-rc1.tar.gz",
 
 relative_path "js"
 
-env = {"LD_RUN_PATH" => "#{install_path}/embedded/lib"}
+env = {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
 working_dir = "#{project_dir}/src"
 
 # == Build Notes ==
@@ -38,14 +38,14 @@ working_dir = "#{project_dir}/src"
 build do
   command(["make",
            "BUILD_OPT=1",
-           "XCFLAGS=-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
+           "XCFLAGS=-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
            "-f",
            "Makefile.ref"].join(" "),
           :env => env,
           :cwd => working_dir)
   command(["make",
            "BUILD_OPT=1",
-           "JS_DIST=#{install_path}/embedded",
+           "JS_DIST=#{install_dir}/embedded",
            "-f",
            "Makefile.ref",
            "export"].join(" "),
@@ -53,8 +53,8 @@ build do
           :cwd => working_dir)
 
   if Ohai.kernel['machine'] =~ /x86_64/
-    command "mv #{install_path}/embedded/lib64/libjs.a #{install_path}/embedded/lib"
-    command "mv #{install_path}/embedded/lib64/libjs.so #{install_path}/embedded/lib"
+    command "mv #{install_dir}/embedded/lib64/libjs.a #{install_dir}/embedded/lib"
+    command "mv #{install_dir}/embedded/lib64/libjs.so #{install_dir}/embedded/lib"
   end
-  command "rm -rf #{install_path}/embedded/lib64"
+  command "rm -rf #{install_dir}/embedded/lib64"
 end

--- a/spec/data/complicated/config/software/sqitch.rb
+++ b/spec/data/complicated/config/software/sqitch.rb
@@ -9,11 +9,11 @@ source :url => "http://www.cpan.org/authors/id/D/DW/DWHEELER/App-Sqitch-#{versio
 relative_path "App-Sqitch-#{version}"
 
 env = {
-  "PATH" => "#{install_path}/embedded/bin:#{ENV["PATH"]}"
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
 }
 
 # Ensure we install with the properly configured embedded `cpan` client
-omnibus_cpan_client = "#{install_path}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
+omnibus_cpan_client = "#{install_dir}/embedded/bin/cpan -j #{cache_dir}/cpan/OmnibusConfig.pm"
 
 # See https://github.com/theory/sqitch for more
 build do

--- a/spec/data/complicated/config/software/test-kitchen.rb
+++ b/spec/data/complicated/config/software/test-kitchen.rb
@@ -32,8 +32,8 @@ end
 dependency "nokogiri"
 
 build do
-  bundle "install --without guard", :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
-  bundle "exec rake build", :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
+  bundle "install --without guard", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
+  bundle "exec rake build", :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
   gem ["install pkg/test-kitchen-*.gem",
-       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_path}/embedded/bin:#{ENV['PATH']}"}
+       "--no-rdoc --no-ri"].join(" "), :env => {"PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"}
 end

--- a/spec/data/complicated/config/software/util-macros.rb
+++ b/spec/data/complicated/config/software/util-macros.rb
@@ -14,7 +14,7 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
@@ -24,23 +24,23 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}", :env => configure_env
   command "make -j #{max_build_jobs} install", :env => configure_env
 end

--- a/spec/data/complicated/config/software/version-manifest.rb
+++ b/spec/data/complicated/config/software/version-manifest.rb
@@ -23,7 +23,7 @@ build do
     project_name = project.name
     project_build_version = project.build_version
 
-    File.open("#{install_path}/version-manifest.txt", "w") do |f|
+    File.open("#{install_dir}/version-manifest.txt", "w") do |f|
       f.puts "#{project_name} #{project_build_version}"
       f.puts ""
       f.puts Omnibus::Reports.pretty_version_map(project)

--- a/spec/data/complicated/config/software/xproto.rb
+++ b/spec/data/complicated/config/software/xproto.rb
@@ -14,7 +14,7 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
@@ -24,23 +24,23 @@ configure_env =
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
     }
   else
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}", :env => configure_env
   command "make -j #{max_build_jobs} install", :env => configure_env
 end

--- a/spec/data/complicated/config/software/yajl.rb
+++ b/spec/data/complicated/config/software/yajl.rb
@@ -25,6 +25,6 @@ relative_path "yajl-ruby"
 build do
   gem ["install yajl-ruby",
        "-v #{version}",
-       "-n #{install_path}/bin",
+       "-n #{install_dir}/bin",
        "--no-rdoc --no-ri"].join(" ")
 end

--- a/spec/data/complicated/config/software/zlib.rb
+++ b/spec/data/complicated/config/software/zlib.rb
@@ -38,30 +38,30 @@ configure_env =
       "CC" => "xlc -q64",
       "CXX" => "xlC -q64",
       "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_path}/embedded/include -O",
+      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
       "OBJECT_MODE" => "64",
       "ARFLAGS" => "-X64 cru",
-      "LDFLAGS" => "-q64 -L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
+      "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
     }
   when "mac_os_x"
     {
-      "LDFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   when "solaris2"
     {
-      "LDFLAGS" => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -DNO_VIZ"
+      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -DNO_VIZ"
     }
   else
     {
-      "LDFLAGS" => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      "CFLAGS" => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib"
+      "LDFLAGS" => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib"
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", :env => configure_env
+  command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{max_build_jobs}"
   command "make -j #{max_build_jobs} install"
 end

--- a/spec/data/projects/chefdk.rb
+++ b/spec/data/projects/chefdk.rb
@@ -19,7 +19,7 @@ name 'chefdk'
 maintainer 'Chef Software, Inc.'
 homepage 'http://www.getchef.com'
 
-install_path '/opt/chefdk'
+install_dir '/opt/chefdk'
 build_version Omnibus::BuildVersion.new.git_describe
 build_iteration 4
 

--- a/spec/data/projects/sample.rb
+++ b/spec/data/projects/sample.rb
@@ -1,5 +1,5 @@
 name 'sample'
-install_path '/sample'
+install_dir '/sample'
 maintainer 'Sample Devs'
 homepage 'http://example.com/'
 

--- a/spec/data/software/erchef.rb
+++ b/spec/data/software/erchef.rb
@@ -27,16 +27,16 @@ source git: 'git://github.com/opscode/erchef'
 relative_path 'erchef'
 
 env = {
-  'PATH' => "#{install_path}/embedded/bin:#{ENV["PATH"]}",
-  'LDFLAGS' => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  'CFLAGS' => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-  'LD_RUN_PATH' => "#{install_path}/embedded/lib",
+  'PATH' => "#{install_dir}/embedded/bin:#{ENV["PATH"]}",
+  'LDFLAGS' => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  'CFLAGS' => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  'LD_RUN_PATH' => "#{install_dir}/embedded/lib",
 }
 
 build do
   command 'make distclean', env: env
   command 'make rel', env: env
-  command "mkdir -p #{install_path}/embedded/service/erchef"
-  command "#{install_path}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./rel/erchef/ #{install_path}/embedded/service/erchef/"
-  command "rm -rf #{install_path}/embedded/service/erchef/log"
+  command "mkdir -p #{install_dir}/embedded/service/erchef"
+  command "#{install_dir}/embedded/bin/rsync -a --delete --exclude=.git/*** --exclude=.gitignore ./rel/erchef/ #{install_dir}/embedded/service/erchef/"
+  command "rm -rf #{install_dir}/embedded/service/erchef/log"
 end

--- a/spec/data/software/zlib.rb
+++ b/spec/data/software/zlib.rb
@@ -38,30 +38,30 @@ configure_env =
       'CC' => 'xlc -q64',
       'CXX' => 'xlC -q64',
       'LD' => 'ld -b64',
-      'CFLAGS' => "-q64 -I#{install_path}/embedded/include -O",
+      'CFLAGS' => "-q64 -I#{install_dir}/embedded/include -O",
       'OBJECT_MODE' => '64',
       'ARFLAGS' => '-X64 cru',
-      'LDFLAGS' => "-q64 -L#{install_path}/embedded/lib -Wl,-blibpath:#{install_path}/embedded/lib:/usr/lib:/lib",
+      'LDFLAGS' => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
     }
   when 'mac_os_x'
     {
-      'LDFLAGS' => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      'CFLAGS' => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib",
+      'LDFLAGS' => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      'CFLAGS' => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
     }
   when 'solaris2'
     {
-      'LDFLAGS' => "-R#{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include -static-libgcc",
-      'CFLAGS' => "-L#{install_path}/embedded/lib -I#{install_path}/embedded/include -DNO_VIZ",
+      'LDFLAGS' => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
+      'CFLAGS' => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -DNO_VIZ",
     }
   else
     {
-      'LDFLAGS' => "-Wl,-rpath #{install_path}/embedded/lib -L#{install_path}/embedded/lib -I#{install_path}/embedded/include",
-      'CFLAGS' => "-I#{install_path}/embedded/include -L#{install_path}/embedded/lib",
+      'LDFLAGS' => "-Wl,-rpath #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      'CFLAGS' => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
     }
   end
 
 build do
-  command "./configure --prefix=#{install_path}/embedded", env: configure_env
+  command "./configure --prefix=#{install_dir}/embedded", env: configure_env
   command "make -j #{max_build_jobs}"
   command "make -j #{max_build_jobs} install"
 end

--- a/spec/functional/packagers/mac_spec.rb
+++ b/spec/functional/packagers/mac_spec.rb
@@ -13,7 +13,7 @@ module Omnibus
           maintainer         'Chef'
           homepage           'https://getchef.com'
           build_version      '#{version}'
-          install_path       '#{tmp_path}/opt/#{name}'
+          install_dir        '#{tmp_path}/opt/#{name}'
           mac_pkg_identifier 'test.pkg.#{name}'
         EOH
 
@@ -39,7 +39,7 @@ module Omnibus
       Config.project_root "#{fixtures_path}/sample"
 
       # Create the target directory
-      FileUtils.mkdir_p(project.install_path)
+      FileUtils.mkdir_p(project.install_dir)
     end
 
     it 'builds a pkg and a dmg' do

--- a/spec/functional/packagers/windows_spec.rb
+++ b/spec/functional/packagers/windows_spec.rb
@@ -30,7 +30,7 @@ module Omnibus
           maintainer         'Chef'
           homepage           'https://getchef.com'
           build_version      '#{version}'
-          install_path       '#{tmp_path}\\opt\\#{name}'
+          install_dir        '#{tmp_path}\\opt\\#{name}'
         EOH
 
       Project.load('/project.rb')
@@ -52,10 +52,10 @@ module Omnibus
       Config.project_root "#{fixtures_path}/sample"
 
       # Create the target directory
-      FileUtils.mkdir_p(project.install_path)
+      FileUtils.mkdir_p(project.install_dir)
 
       # Create a file to be included in the MSI
-      FileUtils.touch(File.join(project.install_path, 'golden_file'))
+      FileUtils.touch(File.join(project.install_dir, 'golden_file'))
     end
 
     it 'builds a pkg and a dmg' do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -43,7 +43,6 @@ module Omnibus
     include_examples 'a configurable', :package_dir, '/var/cache/omnibus/pkg'
     include_examples 'a configurable', :package_tmp, '/var/cache/omnibus/pkg-tmp'
     include_examples 'a configurable', :project_root, Dir.pwd
-    include_examples 'a configurable', :install_dir, '/opt/chef'
     include_examples 'a configurable', :build_dmg, true
     include_examples 'a configurable', :dmg_window_bounds, '100, 100, 750, 600'
     include_examples 'a configurable', :dmg_pkg_position, '535, 50'

--- a/spec/unit/library_spec.rb
+++ b/spec/unit/library_spec.rb
@@ -41,7 +41,7 @@ module Omnibus
             homepage      'http://getchef.com'
             build_version '1.0.0'
 
-            install_path '/opt/chef-server'
+            install_dir '/opt/chef-server'
 
             dependency 'preparation'
             dependency 'erchef'
@@ -111,7 +111,7 @@ module Omnibus
               homepage      'http://getchef.com'
               build_version '1.0.0'
 
-              install_path '/opt/chefdk'
+              install_dir '/opt/chefdk'
 
               dependency 'preparation'
               dependency 'erchef'

--- a/spec/unit/packagers/base_spec.rb
+++ b/spec/unit/packagers/base_spec.rb
@@ -12,7 +12,7 @@ module Omnibus
         build_version: '1.0.0',
         iteration: '12902349',
         mac_pkg_identifier: 'com.chef.hamlet',
-        install_path: '/opt/hamlet',
+        install_dir: '/opt/hamlet',
         package_scripts_path: 'package-scripts',
         files_path: 'files',
         resources_path: nil,

--- a/spec/unit/packagers/mac_pkg_spec.rb
+++ b/spec/unit/packagers/mac_pkg_spec.rb
@@ -52,7 +52,7 @@ module Omnibus
         build_version: '23.4.2',
         iteration: 4,
         maintainer: "Joe's Software",
-        install_path: '/opt/myproject',
+        install_dir: '/opt/myproject',
         files_path: files_path,
         package_scripts_path: scripts_path,
         mac_pkg_identifier: mac_pkg_identifier,

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -11,6 +11,7 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :friendly_name, 'Chef'
     it_behaves_like 'a cleanroom setter', :msi_parameters, { foo: 'bar' }
     it_behaves_like 'a cleanroom setter', :package_name, 'chef.package'
+    it_behaves_like 'a cleanroom setter', :install_dir, '/opt/chef'
     it_behaves_like 'a cleanroom setter', :install_path, '/opt/chef'
     it_behaves_like 'a cleanroom setter', :maintainer, 'Chef Software, Inc'
     it_behaves_like 'a cleanroom setter', :homepage, 'https://getchef.com'
@@ -37,8 +38,8 @@ module Omnibus
         expect(project.name).to eq('sample')
       end
 
-      it 'should return an install path' do
-        expect(project.install_path).to eq('/sample')
+      it 'should return an install_dir' do
+        expect(project.install_dir).to eq('/sample')
       end
 
       it 'should return a maintainer' do

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -8,7 +8,7 @@ module Omnibus
     let(:project) {
       project = double(Project,
         name: 'chef',
-        install_path: '/monkeys',
+        install_dir: '/monkeys',
         overrides: {}
       )
 
@@ -207,7 +207,7 @@ module Omnibus
       context 'on Windows' do
         before do
           stub_ohai(platform: 'windows', version: '2012')
-          project.stub(:install_path).and_return('c:/monkeys')
+          allow(project).to receive(:install_dir).and_return('c:/monkeys')
           stub_env('Path', windows_path)
         end
 


### PR DESCRIPTION
Sorry for the confusion folks, but it seems like the move to install_path was an unwise one. It is impossible to retain backwards compatibility using install_path, and all the other methods in omnibus use the "_dir" suffix, especially those in the Config object. 

This commit is basically a revert of c4c604b, but has some additional fixes thus making it not a real "revert".
