### PR TITLE
Support for changing the path of the package-scripts directory

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -944,11 +944,11 @@ module Omnibus
     #
     # @return [String]
     #
-    # @todo This documentation really should be up at a higher level,
-    #   particularly since the user has no way to change the path.
+    # @todo This documentation really should be up at a higher level
     #
-    def package_scripts_path
-      "#{Config.project_root}/package-scripts/#{name}"
+    def package_scripts_path(val = NULL_ARG)
+      @package_scripts_path = val unless val.equal?(NULL_ARG)
+      @package_scripts_path || "#{Omnibus.project_root}/package-scripts/#{name}"
     end
 
     def build_me


### PR DESCRIPTION
Hi,

We're working on packaging a multi-project omnibus setup, so we needed different package-scripts for each project.

This fix allows the user to change the package-scripts path using package_scripts_path in the project DSL.

Thanks in advance.
