### PR TITLE
use -R not -Wl,-rpath on FreeBSD

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -510,6 +510,11 @@ module Omnibus
             "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
             "CFLAGS" => "-I#{install_dir}/embedded/include",
           }
+        when "freebsd"
+          {
+            "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "CFLAGS" => "-I#{install_dir}/embedded/include",
+          }
         else
           {
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",


### PR DESCRIPTION
in some cases -Wl,-rpath can be passed to the linker directly instead of
going through gcc (ncurses) and on FreeBSD this causes the linker to
throw an error.  since both gcc and ld on FreeBSD understand -R (directory)
to set the rpath use this instead.
