### PR TITLE
Use an expanded with_clean_env method

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'bundler'
   gem.add_dependency 'chef-sugar',      '~> 1.2'
   gem.add_dependency 'mixlib-shellout', '~> 1.4'
   gem.add_dependency 'ohai',            '~> 7.2.0.rc'
@@ -29,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'uber-s3'
   gem.add_dependency 'thor',            '~> 0.18'
 
+  gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 1.2'
   gem.add_development_dependency 'aruba',       '~> 0.5'
   gem.add_development_dependency 'fauxhai',     '~> 2.1'


### PR DESCRIPTION
Bundler's `with_clean_env` method only resets Bundler-specific environment variables. Omnibus needs to reset Bundler + Rubygems + Ruby.
