### PR TITLE
Add minimal metadata for modern publishers

### DIFF
--- a/lib/omnibus/artifact.rb
+++ b/lib/omnibus/artifact.rb
@@ -97,7 +97,9 @@ module Omnibus
         'version' => build_version,
         'basename' => File.basename(path),
         'md5' => md5,
+        'sha1' => sha1,
         'sha256' => sha256,
+        'sha512' => sha512,
       }
     end
 
@@ -129,9 +131,19 @@ module Omnibus
       @md5 ||= digest(Digest::MD5)
     end
 
-    # @return [String] hex encoded SHA2-256 of the package
+    # @return [String] hex encoded SHA1 of the package
+    def sha1
+      @sha1 ||= digest(Digest::SHA1)
+    end
+
+    # @return [String] hex encoded SHA-256 of the package
     def sha256
       @sha256 ||= digest(Digest::SHA256)
+    end
+
+    # @return [String] hex encoded SHA-512 of the package
+    def sha512
+      @sha512 ||= digest(Digest::SHA512)
     end
 
     private

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -561,6 +561,8 @@ module Omnibus
       pkg_path = "#{config.package_dir}/#{basename}"
       artifact = Artifact.new(pkg_path, [platform_tuple], version: build_version)
       metadata = artifact.flat_metadata
+      metadata['name'] = name
+      metadata['homepage'] = homepage
       File.open("#{pkg_path}.metadata.json", 'w+') do |f|
         f.print(JSON.pretty_generate(metadata))
       end


### PR DESCRIPTION
The publishers from modern Omnibus expect a minimal set of metadata in
order to properly publish artifacts. This commit adds the missing
metadata values.

/cc @opscode/release-engineers 

This build has successfully passed CI testing also:
http://wilson.ci.opscode.us/job/chef-server-trigger-ad_hoc/11/downstreambuildview/
