### PR TITLE
Added functionality to influence enabled extensions for candle and light

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -58,6 +58,7 @@ module Omnibus
         shellout! <<-EOH.split.join(' ').squeeze(' ').strip
           candle.exe
             -nologo
+            #{wix_extension_switches(wix_candle_extensions)}
             -dProjectSourceDir="#{windows_safe_path(project.install_dir)}" "project-files.wxs"
             "#{windows_safe_path(staging_dir, 'source.wxs')}"
         EOH
@@ -68,6 +69,7 @@ module Omnibus
           light.exe
             -nologo
             -ext WixUIExtension
+            #{wix_extension_switches(wix_light_extensions)}
             -cultures:en-us
             -loc "#{windows_safe_path(staging_dir, 'localization-en-us.wxl')}"
             project-files.wixobj source.wixobj
@@ -131,6 +133,48 @@ module Omnibus
       end
     end
     expose :parameters
+
+    #
+    # Set the wix light extensions to load
+    #
+    # @example
+    #   wix_light_extension 'WixUtilExtension'
+    #
+    # @param [String] extension
+    #   A list of extensions to load
+    #
+    # @return [Array]
+    #   The list of extensions that will be loaded
+    #
+    def wix_light_extension(extension)
+      unless extension.is_a?(String)
+        raise InvalidValue.new(:wix_light_extension, 'be an String')
+      end
+
+      wix_light_extensions << extension
+    end
+    expose :wix_light_extension
+
+    #
+    # Set the wix candle extensions to load
+    #
+    # @example
+    #   wix_candle_extension 'WixUtilExtension'
+    #
+    # @param [String] extension
+    #   A list of extensions to load
+    #
+    # @return [Array]
+    #   The list of extensions that will be loaded
+    #
+    def wix_candle_extension(extension)
+      unless extension.is_a?(String)
+        raise InvalidValue.new(:wix_candle_extension, 'be an String')
+      end
+
+      wix_candle_extensions << extension
+    end
+    expose :wix_candle_extension
 
     #
     # @!endgroup
@@ -264,6 +308,39 @@ module Omnibus
     def msi_display_version
       versions = project.build_version.split(/[.+-]/)
       "#{versions[0]}.#{versions[1]}.#{versions[2]}"
+    end
+
+    #
+    # Returns the extensions to use for light
+    #
+    # @return [Array]
+    #   the extensions that will be loaded for light
+    #
+    def wix_light_extensions
+      @wix_light_extensions ||= []
+    end
+
+    #
+    # Returns the extensions to use for candle
+    #
+    # @return [Array]
+    #   the extensions that will be loaded for candle
+    #
+    def wix_candle_extensions
+      @wix_candle_extensions ||= []
+    end
+
+    #
+    # Takes an array of wix extension names and creates a string
+    # that can be passed to wix to load those.
+    #
+    # for example,
+    # ['a', 'b'] => "-ext 'a' -ext 'b'"
+    #
+    # @return [String]
+    #
+    def wix_extension_switches(arr)
+      "#{arr.map {|e| "-ext '#{e}'"}.join(' ')}"
     end
   end
 end

--- a/spec/unit/packagers/msi_spec.rb
+++ b/spec/unit/packagers/msi_spec.rb
@@ -199,5 +199,69 @@ module Omnibus
         end
       end
     end
+
+    describe '#wix_candle_extensions' do
+      it 'defaults to an empty Array' do
+        expect(subject.wix_candle_extensions).to be_an(Array)
+        expect(subject.wix_candle_extensions).to be_empty
+      end
+    end
+
+    describe '#wix_light_extensions' do
+      it 'defaults to an empty Array' do
+        expect(subject.wix_light_extensions).to be_an(Array)
+        expect(subject.wix_light_extensions).to be_empty
+      end
+    end
+
+    describe '#wix_candle_extension' do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:wix_candle_extension)
+      end
+
+      it 'requires the value to be an String' do
+        expect {
+          subject.wix_candle_extension(Object.new)
+        }.to raise_error(InvalidValue)
+      end
+
+      it 'returns the given value' do
+        extensions = ['a']
+        subject.wix_candle_extension(extensions[0])
+        expect(subject.wix_candle_extensions).to match_array(extensions)
+      end
+    end
+
+    describe '#wix_light_extension' do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:wix_light_extension)
+      end
+
+      it 'requires the value to be an String' do
+        expect {
+          subject.wix_light_extension(Object.new)
+        }.to raise_error(InvalidValue)
+      end
+
+      it 'returns the given value' do
+        extensions = ['a']
+        subject.wix_light_extension(extensions[0])
+        expect(subject.wix_light_extensions).to match_array(extensions)
+      end
+    end
+
+    describe '#wix_extension_switches' do
+      it 'returns an empty string for an empty array' do
+        expect(subject.wix_extension_switches([])).to eq('')
+      end
+
+      it 'returns the correct value for one extension' do
+        expect(subject.wix_extension_switches(['a'])).to eq("-ext 'a'")
+      end
+
+      it 'returns the correct value for many extensions' do
+        expect(subject.wix_extension_switches(['a', 'b'])).to eq("-ext 'a' -ext 'b'")
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows loading of wix extensions, such as WixUtilExtension, which we need to register an event source
