### PR TITLE
This patch allows netfetcher unit tests to run on windows

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -207,19 +207,18 @@ module Omnibus
     # @return [String, nil]
     #
     def extract_command
-      downloaded_file_safe = Ohai['platform'] == 'windows' ? windows_safe_path(downloaded_file) : downloaded_file
       if Ohai['platform'] == 'windows' && downloaded_file.end_with?(*WIN_7Z_EXTENSIONS)
-        "7z.exe x #{downloaded_file_safe} -o#{Config.source_dir} -r -y"
+        "7z.exe x #{windows_safe_path(downloaded_file)} -o#{Config.source_dir} -r -y"
       elsif Ohai['platform'] != 'windows' && downloaded_file.end_with?('.7z')
-        "7z x #{downloaded_file_safe} -o#{Config.source_dir} -r -y"
+        "7z x #{windows_safe_path(downloaded_file)} -o#{Config.source_dir} -r -y"
       elsif Ohai['platform'] != 'windows' && downloaded_file.end_with?('.zip')
-        "unzip #{downloaded_file_safe} -d #{Config.source_dir}"
+        "unzip #{windows_safe_path(downloaded_file)} -d #{Config.source_dir}"
       elsif downloaded_file.end_with?(*TAR_EXTENSIONS)
         compression_switch = 'z' if downloaded_file.end_with?('gz')
         compression_switch = 'j' if downloaded_file.end_with?('bz2')
         compression_switch = 'J' if downloaded_file.end_with?('xz')
         compression_switch = ''  if downloaded_file.end_with?('tar')
-        "tar #{compression_switch}xf #{downloaded_file_safe} -C#{Config.source_dir}"
+        "tar #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C#{Config.source_dir}"
       end
     end
 

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -187,6 +187,7 @@ module Omnibus
         before do
           Config.cache_dir('/')
           stub_ohai(platform: 'ubuntu', version: '12.04')
+          stub_const('File::ALT_SEPARATOR', nil)
         end
 
         it_behaves_like 'an extractor', '7z',      '7z x /file.7z -o/tmp/out -r -y'


### PR DESCRIPTION
Tests were failing on windows because the paths were being changed for the linux part of the unit tests.
