### PR TITLE
Add Project#default_root

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -159,6 +159,26 @@ module Omnibus
     expose :install_dir
 
     #
+    # The default root where a project should be installed. On Windows-based
+    # systems, this value defaults to +C:+. On non-Windows systems, this value
+    # defaults to +/opt+.
+    #
+    # @example
+    #   install_dir "#{default_root}/chef" #=> Produces +C:/chef+ on Windows and
+    #                                      #=> +/opt/chef+ on Linux
+    #
+    # @return [String]
+    #
+    def default_root
+      if windows?
+        'C:'
+      else
+        '/opt'
+      end
+    end
+    expose :default_root
+
+    #
     # **[Required]** Set or retrieve the the package maintainer.
     #
     # @example

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -100,6 +100,28 @@ module Omnibus
       end
     end
 
+    describe '#default_root' do
+      context 'on Windows' do
+        before { stub_ohai(platform: 'windows', version: '2012') }
+
+        it 'returns C:/' do
+          expect(subject.default_root).to eq('C:')
+        end
+      end
+
+      context 'on non-Windows' do
+        before { stub_ohai(platform: 'ubuntu', version: '12.04') }
+
+        it 'returns /opt' do
+          expect(subject.default_root).to eq('/opt')
+        end
+      end
+
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:default_root)
+      end
+    end
+
     describe '#dirty!' do
       it 'dirties the cache' do
         subject.instance_variable_set(:@dirty, nil)


### PR DESCRIPTION
On Windows-based systems, this value defaults to +C:+. On non-Windows systems, this value defaults to /opt. In this way, the user can transparently define an install_dir without the need to use branching logic on different platforms:

``` ruby
install_dir "#{default_root}/#{name}"
```

Fixes #308 

/cc @jmink @opscode/release-engineers 
