### PR TITLE
Expose an `ohai` method in the project and software DSLs

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -598,6 +598,19 @@ module Omnibus
     expose :extra_package_file
 
     #
+    # A proxy method to the underlying Ohai system.
+    #
+    # @example
+    #   ohai['platform_family']
+    #
+    # @return [Ohai]
+    #
+    def ohai
+      Ohai
+    end
+    expose :ohai
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -549,6 +549,19 @@ module Omnibus
     expose :prepend_path
 
     #
+    # A proxy method to the underlying Ohai system.
+    #
+    # @example
+    #   ohai['platform_family']
+    #
+    # @return [Ohai]
+    #
+    def ohai
+      Ohai
+    end
+    expose :ohai
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -214,6 +214,30 @@ module Omnibus
       end
     end
 
+    describe '#ohai' do
+      before { stub_ohai(platform: 'ubuntu', version: '12.04') }
+
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:ohai)
+      end
+
+      it 'delegates to the Ohai class' do
+        expect(subject.ohai).to be(Ohai)
+      end
+    end
+
+    describe '#packager' do
+      it 'returns a packager object' do
+        expect(subject.packager).to be_a(Packager::Base)
+      end
+
+      it 'calls Packager#for_current_system' do
+        expect(Packager).to receive(:for_current_system)
+          .and_call_original
+        subject.packager
+      end
+    end
+
     describe '#package' do
       it 'raises an exception when a block is not given' do
         expect { subject.package(:foo) }.to raise_error(InvalidValue)

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -236,6 +236,18 @@ module Omnibus
       end
     end
 
+    describe '#ohai' do
+      before { stub_ohai(platform: 'ubuntu', version: '12.04') }
+
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:ohai)
+      end
+
+      it 'delegates to the Ohai class' do
+        expect(subject.ohai).to be(Ohai)
+      end
+    end
+
     describe '#<=>' do
       let(:zlib)   { described_class.new(project).tap { |s| s.name('zlib') } }
       let(:erchef) { described_class.new(project).tap { |s| s.name('erchef') } }


### PR DESCRIPTION
With the enhanced Cleanroom, the top-level namespace is now `Object` instead of Omnibus, meaning the Ohai constant is no long available. This commit adds an `ohai` DSL method to both Project and Software for exposing Ohai data to the DSLs.
