### PR TITLE
Fix bucket retrieval for 2.0-stable

### DIFF
--- a/lib/omnibus/s3_cacher.rb
+++ b/lib/omnibus/s3_cacher.rb
@@ -122,11 +122,15 @@ module Omnibus
 
     def bucket
       @bucket ||= begin
-        b = UberS3::Bucket.new(@client, @client.bucket)
-        # creating the bucket is idempotent, make sure it's created:
-        @client.connection.put('/')
-        b
+        if @client.exists?('/')
+          @client.bucket
+        else
+          b = UberS3::Bucket.new(@client, @client.bucket)
+          @client.connection.put('/')
+          b
+        end
       end
     end
+
   end
 end


### PR DESCRIPTION
Due to a change in Amazon's API, creating a bucket is no longer
idempotent. If a bucket is created when it already exists
an error is now thrown. This broke omnibus cache commands in 2.0-stable.
The code that exists in new omnibus versions avoids this issue,
so the fix here is just to back port and retrofit that code into
the 2.0-stable branch.
