### PR TITLE
The post install script does not work.

### DIFF
--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -53,9 +53,9 @@ Obsoletes: <%= name %>
 %clean
 # noop
 
-<% scripts.each do |script| -%>
-%<%= File.basename(script) %>
-<%= script %>
+<% scripts.each do |name, contents| -%>
+%<%= name %>
+<%= contents %>
 <% end -%>
 
 %files

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -93,13 +93,11 @@ module Omnibus
 
       context 'when scripts are given' do
         before do
-          create_file("#{project_root}/package-scripts/project/pre")
-          create_file("#{project_root}/package-scripts/project/post")
-          create_file("#{project_root}/package-scripts/project/preun")
-          create_file("#{project_root}/package-scripts/project/postun")
-          create_file("#{project_root}/package-scripts/project/verifyscript")
-          create_file("#{project_root}/package-scripts/project/pretans")
-          create_file("#{project_root}/package-scripts/project/posttrans")
+          Packager::RPM::SCRIPTS.each do |name|
+            create_file("#{project_root}/package-scripts/project/#{name}") do
+              "Contents of #{name}"
+            end
+          end
         end
 
         it 'writes the scripts into the spec' do
@@ -107,19 +105,19 @@ module Omnibus
           contents = File.read(spec_file)
 
           expect(contents).to include("%pre")
-          expect(contents).to include("#{project_root}/package-scripts/project/pre")
+          expect(contents).to include("Contents of pre")
           expect(contents).to include("%post")
-          expect(contents).to include("#{project_root}/package-scripts/project/post")
+          expect(contents).to include("Contents of post")
           expect(contents).to include("%preun")
-          expect(contents).to include("#{project_root}/package-scripts/project/preun")
+          expect(contents).to include("Contents of preun")
           expect(contents).to include("%postun")
-          expect(contents).to include("#{project_root}/package-scripts/project/postun")
+          expect(contents).to include("Contents of postun")
           expect(contents).to include("%verifyscript")
-          expect(contents).to include("#{project_root}/package-scripts/project/verifyscript")
+          expect(contents).to include("Contents of verifyscript")
           expect(contents).to include("%pretans")
-          expect(contents).to include("#{project_root}/package-scripts/project/pretans")
+          expect(contents).to include("Contents of pretans")
           expect(contents).to include("%posttrans")
-          expect(contents).to include("#{project_root}/package-scripts/project/posttrans")
+          expect(contents).to include("Contents of posttrans")
         end
       end
 


### PR DESCRIPTION
Hi,

I found that there is something wrong with the file omnibus/resources/rpm/spec.erb.

``` erb
<% scripts.each do |script| -%>
%<%= File.basename(script) %>
<%= script %>
<% end -%>
```

The above code will just append the name of the post install script in place of <%= script %> and when you will try to install rpm then will give an error: NO such file or directory as it would look for the postinst script on your device which may be different than the one you used to build chef rpm.

So I think so that it should be like:

``` erb
<% scripts.each do |script| -%>
%<%= File.basename(script) %>
<%= File.read(script) %>
<% end -%>
```

That shall copy the contents of  the post install script file after %post and then the installation would be successful.  

Is this an issue that needs to be fixed?
