### PR TITLE
Raise custom errors when a shell command fails

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -667,8 +667,8 @@ module Omnibus
     # Execute the given block with (n) reties defined by {Config#build_retries}.
     # This method will only retry for the following exceptions:
     #
-    #   - +Mixlib::ShellOut::ShellCommandFailed+
-    #   - +Mixlib::ShellOut::CommandTimeout+
+    #   - +CommandFailed+
+    #   - +CommandTimeout+
     #
     # @param [Proc] block
     #   the block to execute
@@ -676,10 +676,7 @@ module Omnibus
     def with_retries(&block)
       tries = Config.build_retries
       delay = 5
-      exceptions = [
-        Mixlib::ShellOut::ShellCommandFailed,
-        Mixlib::ShellOut::CommandTimeout,
-      ]
+      exceptions = [CommandFailed, CommandTimeout]
 
       begin
         block.call

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -229,4 +229,63 @@ software publisher's website.
 EOH
     end
   end
+
+  class CommandFailed < Error
+    def initialize(cmd)
+      status = cmd.exitstatus
+
+      if cmd.environment.nil? || cmd.environment.empty?
+        env = nil
+      else
+        env = cmd.environment.sort.map { |k,v| "#{k}=#{v}" }.join(' ')
+      end
+
+      command = cmd.command
+      command_with_env = [env, command].compact.join(' ')
+
+      stdout = cmd.stdout.empty? ? '(nothing)' : cmd.stdout.strip
+      stderr = cmd.stderr.empty? ? '(nothing)' : cmd.stderr.strip
+
+      super <<-EOH
+The following shell command exited with status #{status}:
+
+    $ #{command_with_env}
+
+Output:
+
+    #{stdout}
+
+Error:
+
+    #{stderr}
+EOH
+    end
+  end
+
+  class CommandTimeout < Error
+    def initialize(cmd)
+      status = cmd.exitstatus
+
+      if cmd.environment.nil? || cmd.environment.empty?
+        env = nil
+      else
+        env = cmd.environment.sort.map { |k,v| "#{k}=#{v}" }.join(' ')
+      end
+
+      command = cmd.command
+      command_with_env = [env, command].compact.join(' ')
+
+      timeout = cmd.timeout.to_s.reverse.gsub(/...(?=.)/,'\&,').reverse
+
+      super <<-EOH
+The following shell command timed out at #{timeout} seconds:
+
+    $ #{command_with_env}
+
+Please increase the `:timeout' value or run the command manually to make sure it
+is completing successfully. Sometimes it is common for a command to wait for
+user input.
+EOH
+    end
+  end
 end

--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -136,7 +136,7 @@ module Omnibus
     #
     def current_revision
       @current_revision ||= git('rev-parse HEAD').stdout.strip
-    rescue Mixlib::ShellOut::ShellCommandFailed
+    rescue CommandFailed
       nil
     end
 
@@ -147,7 +147,7 @@ module Omnibus
     #
     def target_revision
       @target_revision ||= git("rev-parse #{version}").stdout.strip
-    rescue Mixlib::ShellOut::ShellCommandFailed => e
+    rescue CommandFailed => e
       if e.message.include?('ambiguous argument')
         @target_revision = git("rev-parse origin/#{version}").stdout.strip
         @target_revision

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -117,7 +117,7 @@ module Omnibus
 
       begin
         shellout!(%Q(git --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{tag}"))
-      rescue Mixlib::ShellOut::ShellCommandFailed => e
+      rescue CommandFailed => e
         raise unless e.message.include?('nothing to commit')
       end
 

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -82,18 +82,25 @@ module Omnibus
       cmd
     end
 
+    #
     # Similar to +shellout+ method except it raises an exception if the
     # command fails.
     #
     # @see #shellout
     #
-    # @raise [Mixlib::ShellOut::ShellCommandFailed] if +exitstatus+ is not in
-    #   the list of +valid_exit_codes+.
+    # @raise [CommandFailed]
+    #   if +exitstatus+ is not in the list of +valid_exit_codes+
+    # @raise [CommandTimeout]
+    #   if execution time exceeds +timeout+
     #
     def shellout!(*args)
       cmd = shellout(*args)
       cmd.error!
       cmd
+    rescue Mixlib::ShellOut::ShellCommandFailed
+      raise CommandFailed.new(cmd)
+    rescue Mixlib::ShellOut::CommandTimeout
+      raise CommandTimeout.new(cmd)
     end
 
     #


### PR DESCRIPTION
Looks like this:

``` text
The following shell command exited with status 32:

    $ I_LOVE_YOU=barney TICKLE_ME=elmo evil command

Output:

    command failed

Error:

    The quick brown fox did not jump over the barn!
```

Fixes #322 

/cc @lamont-granquist @opscode/release-engineers 
