### PR TITLE
Use underscores instead of dashes in RPM

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -413,12 +413,12 @@ module Omnibus
       if project.build_version =~ /\A[a-zA-Z0-9\.\+\-]+\z/
         project.build_version.dup
       else
-        converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-]+/, '-')
+        converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-]+/, '_')
 
         log.warn(log_key) do
           "The `version' compontent of RPM package names can only include " \
           "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
-          "plus signs (+), and dashes (-). Converting " \
+          "plus signs (+), and underscores (_). Converting " \
           "`#{project.build_version}' to `#{converted}'."
         end
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -42,7 +42,6 @@ module Omnibus
       end
     end
 
-
     describe '#vendor' do
       it 'is a DSL method' do
         expect(subject).to have_exposed_method(:vendor)
@@ -305,7 +304,7 @@ module Omnibus
 
         it 'returns the value while logging a message' do
           output = capture_logging do
-            expect(subject.safe_version).to eq('1.2-alpha.-2')
+            expect(subject.safe_version).to eq('1.2_alpha._2')
           end
 
           expect(output).to include("The `version' compontent of RPM package names can only include")


### PR DESCRIPTION
:construction: This is just a POC for what we would need to change once we figure out what RPM allows or doesn't /cc @yzl
