### PR TITLE
Replace dashes with underscores in RPM version names.

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -410,15 +410,15 @@ module Omnibus
     # @return [String]
     #
     def safe_version
-      if project.build_version =~ /\A[a-zA-Z0-9\.\+\-]+\z/
+      if project.build_version =~ /\A[a-zA-Z0-9\.\+\_]+\z/
         project.build_version.dup
       else
-        converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-]+/, '-')
+        converted = project.build_version.gsub('-', '_')
 
         log.warn(log_key) do
-          "The `version' compontent of RPM package names can only include " \
+          "The `version' component of RPM package names can only include " \
           "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
-          "plus signs (+), and dashes (-). Converting " \
+          "plus signs (+), and underscores (_). Converting " \
           "`#{project.build_version}' to `#{converted}'."
         end
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -301,14 +301,14 @@ module Omnibus
       end
 
       context 'when the project build_version has invalid characters' do
-        before { project.build_version("1.2$alpha.##__2") }
+        before { project.build_version("1.2-pre$alpha.##__2") }
 
         it 'returns the value while logging a message' do
           output = capture_logging do
-            expect(subject.safe_version).to eq('1.2-alpha.-2')
+            expect(subject.safe_version).to eq('1.2_pre$alpha.##__2')
           end
 
-          expect(output).to include("The `version' compontent of RPM package names can only include")
+          expect(output).to include("The `version' component of RPM package names can only include")
         end
       end
     end


### PR DESCRIPTION
cc @opscode/release-engineers 
