### PR TITLE
Remove `always_build` and specify project culprits

### DIFF
--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -288,4 +288,17 @@ user input.
 EOH
     end
   end
+
+  class ProjectAlreadyDirty < Error
+    def initialize(project)
+      name = project.name
+      culprit = project.culprit.name
+
+      super <<-EOH
+The project `#{name}' was already marked as dirty by `#{culprit}'. You cannot
+mark a project as dirty twice. This is probably a bug in Omnibus and should be
+reported.
+EOH
+    end
+  end
 end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -830,10 +830,23 @@ module Omnibus
     # install path cache, or software definitions to invalidate the cache for
     # this project.
     #
+    # @param [Software] software
+    #   the software that dirtied the cache
+    #
     # @return [true, false]
     #
-    def dirty!
-      @dirty = true
+    def dirty!(software)
+      raise ProjectAlreadyDirty.new(self) if culprit
+      @culprit = software
+    end
+
+    #
+    # The software definition which dirtied this project.
+    #
+    # @return [Software, nil]
+    #
+    def culprit
+      @culprit
     end
 
     #
@@ -842,7 +855,7 @@ module Omnibus
     # @return [true, false]
     #
     def dirty?
-      !!@dirty
+      !!culprit
     end
 
     #

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -123,26 +123,34 @@ module Omnibus
     end
 
     describe '#dirty!' do
+      let(:software) { double(Omnibus::Software) }
+
       it 'dirties the cache' do
-        subject.instance_variable_set(:@dirty, nil)
-        subject.dirty!
+        subject.instance_variable_set(:@culprit, nil)
+        subject.dirty!(software)
         expect(subject).to be_dirty
+      end
+
+      it 'sets the culprit' do
+        subject.instance_variable_set(:@culprit, nil)
+        subject.dirty!(software)
+        expect(subject.culprit).to be(software)
       end
     end
 
     describe '#dirty?' do
       it 'returns true by default' do
-        subject.instance_variable_set(:@dirty, nil)
+        subject.instance_variable_set(:@culprit, nil)
         expect(subject).to_not be_dirty
       end
 
       it 'returns true when the cache is dirty' do
-        subject.instance_variable_set(:@dirty, true)
+        subject.instance_variable_set(:@culprit, true)
         expect(subject).to be_dirty
       end
 
       it 'returns false when the cache is not dirty' do
-        subject.instance_variable_set(:@dirty, false)
+        subject.instance_variable_set(:@culprit, false)
         expect(subject).to_not be_dirty
       end
     end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -22,7 +22,6 @@ module Omnibus
     it_behaves_like 'a cleanroom getter', :project
     it_behaves_like 'a cleanroom setter', :name, %|name 'libxml2'|
     it_behaves_like 'a cleanroom setter', :description, %|description 'The XML magician'|
-    it_behaves_like 'a cleanroom setter', :always_build, %|always_build true|
     it_behaves_like 'a cleanroom setter', :dependency, %|dependency 'libxslt'|
     it_behaves_like 'a cleanroom setter', :source, %|source url: 'https://source.example.com'|
     it_behaves_like 'a cleanroom setter', :default_version, %|default_version '1.2.3'|


### PR DESCRIPTION
With this patch, when the cache is dirtied, Omnibus now keeps a record of which software definition dirtied the cache. This is used in log and debugging output for tracing git caching issues more easily.

/cc @seth @opscode/release-engineers 
