### PR TITLE
The 32bit deb architecture is i386, not i686

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -381,6 +381,8 @@ module Omnibus
       case Ohai['kernel']['machine']
       when 'x86_64'
         'amd64'
+      when 'i686'
+        'i386'
       else
         Ohai['kernel']['machine']
       end

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -319,6 +319,18 @@ module Omnibus
           expect(subject.safe_architecture).to eq('i386')
         end
       end
+
+      context 'when i686' do
+        before do
+          stub_ohai(platform: 'ubuntu', version: '12.04') do |data|
+            data['kernel']['machine'] = 'i686'
+          end
+        end
+
+        it 'returns i386' do
+          expect(subject.safe_architecture).to eq('i386')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
i686 architecture is not allowed. For example,
'dpkg-architecture -L' shows only i386 architectures.
repropro rejects i686 so we should convert i686 to i386.
