### PR TITLE
Ensure permissions are preserved when copying package

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -920,8 +920,8 @@ module Omnibus
 
       # Copy the generated package and metadata back into the workspace
       package_path = File.join(Config.package_dir, packager.package_name)
-      FileUtils.cp(package_path, destination)
-      FileUtils.cp("#{package_path}.metadata.json", destination)
+      FileUtils.cp(package_path, destination, preserve: true)
+      FileUtils.cp("#{package_path}.metadata.json", destination, preserve: true)
     end
 
     #


### PR DESCRIPTION
`FileUtils.cp` on Ruby 1.9 has a fun bug where permissions are not  preserved unless the `preserve` option is set to true:
https://bugs.ruby-lang.org/issues/4507

This has the nasty side affects of removing the executable bit on makeself-generated self-extracting tarballs!

/cc @opscode/release-engineers @opscode/client-engineers 

This fix will also need to be ported to the 3.0-stable branch.
