### PR TITLE
Ensure `GitFetcher` properly resolves remote refs

### DIFF
--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -301,4 +301,12 @@ reported.
 EOH
     end
   end
+
+  class UnresolvableGitReference < Error
+    def initialize(ref)
+      super <<-EOH
+Could not resolve `#{ref}' to a valid git SHA-1.
+EOH
+    end
+  end
 end

--- a/spec/functional/fetchers/git_fetcher_spec.rb
+++ b/spec/functional/fetchers/git_fetcher_spec.rb
@@ -98,6 +98,16 @@ module Omnibus
         end
       end
 
+      context 'when the version is an annnotated tag' do
+        let(:version)  { 'v1.2.4' }
+        let(:remote)   { remote_git_repo('zlib', annotated_tags: [version]) }
+
+        it 'it defererences and parses the annotated tag' do
+          subject.fetch
+          expect(revision).to eq('efde208366abd0f91419d8a54b45e3f6e0540105')
+        end
+      end
+
       context 'when the version is a branch' do
         let(:version) { 'sethvargo/magic_ponies' }
         let(:remote)  { remote_git_repo('zlib', branches: [version]) }
@@ -108,13 +118,32 @@ module Omnibus
         end
       end
 
-      context 'when the version is a ref' do
+      context 'when the version is a full SHA-1' do
+        let(:version) { '45ded6d3b1a35d66ed866b2c3eb418426e6382b0' }
+        let(:remote)  { remote_git_repo('zlib') }
+
+        it 'parses the full SHA-1' do
+          subject.fetch
+          expect(revision).to eq('45ded6d3b1a35d66ed866b2c3eb418426e6382b0')
+        end
+      end
+
+      context 'when the version is a abbreviated SHA-1' do
         let(:version) { '45ded6d' }
         let(:remote)  { remote_git_repo('zlib') }
 
-        it 'parses the ref' do
+        it 'parses the abbreviated SHA-1' do
           subject.fetch
           expect(revision).to eq('45ded6d3b1a35d66ed866b2c3eb418426e6382b0')
+        end
+      end
+
+      context 'when the version is a non-existent ref' do
+        let(:version) { 'fufufufufu' }
+        let(:remote)  { remote_git_repo('zlib') }
+
+        it 'raise an exception' do
+          expect { subject.fetch }.to raise_error(UnresolvableGitReference)
         end
       end
     end

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -33,6 +33,14 @@ module Omnibus
           git %|remote add origin "#{remote_url}"|
           git %|push origin master|
 
+          options[:annotated_tags].each do |tag|
+            File.open('tag', 'w') { |f| f.write(tag) }
+            git %|add tag|
+            git %|commit -am "Create tag #{tag}"|
+            git %|tag "#{tag}" -m "#{tag}"|
+            git %|push origin "#{tag}"|
+          end if options[:annotated_tags]
+
           options[:tags].each do |tag|
             File.open('tag', 'w') { |f| f.write(tag) }
             git %|add tag|


### PR DESCRIPTION
This fixes a regression introduced in: 2f240e4

/cc @opscode/release-engineers @opscode/client-engineers @tduffield @jamesc 
