### PR TITLE
Leaky Ruby ENV fix

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -218,7 +218,8 @@ module Omnibus
     #
     def ruby(command, options = {})
       build_commands << BuildCommand.new("ruby `#{command}'") do
-        _ruby(command, options)
+        bin = windows_safe_path("#{install_dir}/embedded/bin/ruby")
+        shellout!("#{bin} #{command}", options)
       end
     end
     expose :ruby
@@ -235,7 +236,7 @@ module Omnibus
     def gem(command, options = {})
       build_commands << BuildCommand.new("gem `#{command}'") do
         bin = windows_safe_path("#{install_dir}/embedded/bin/gem")
-        _ruby("#{bin} #{command}", options)
+        shellout!("#{bin} #{command}", options)
       end
     end
     expose :gem
@@ -255,7 +256,7 @@ module Omnibus
     def bundle(command, options = {})
       build_commands << BuildCommand.new("bundle `#{command}'") do
         bin = windows_safe_path("#{install_dir}/embedded/bin/bundle")
-        _ruby("#{bin} #{command}", options)
+        shellout!("#{bin} #{command}", options)
       end
     end
     expose :bundle
@@ -295,7 +296,7 @@ module Omnibus
         env["BUNDLE_GEMFILE"] = gemfile_lock
         options[:env].merge!(env)
 
-        _ruby("#{appbundler_bin} '#{embedded_app_dir}' '#{bin_dir}'", options)
+        shellout!("#{appbundler_bin} '#{embedded_app_dir}' '#{bin_dir}'", options)
       end
     end
     expose :appbundle
@@ -313,7 +314,7 @@ module Omnibus
     def rake(command, options = {})
       build_commands << BuildCommand.new("rake `#{command}'") do
         bin = windows_safe_path("#{install_dir}/embedded/bin/rake")
-        _ruby("#{bin} #{command}", options)
+        shellout!("#{bin} #{command}", options)
       end
     end
     expose :rake
@@ -831,20 +832,6 @@ module Omnibus
       when /^rsync /i
         log.warn(log_key) { "Detected command `rsync'. Consider using the `sync' DSL method." }
       end
-    end
-
-    #
-    # Execute the given Ruby command or script against the embedded Ruby.
-    #
-    # @example
-    #   ruby 'setup.rb'
-    #
-    # @param (see #command)
-    # @return (see #command)
-    #
-    def _ruby(command, options)
-      bin = windows_safe_path("#{install_dir}/embedded/bin/ruby")
-      shellout!("#{bin} #{command}", options)
     end
 
     #

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -95,7 +95,6 @@ module Omnibus
           EOH
         end
 
-        fake_embedded_bin('ruby')
         fake_embedded_bin('gem')
 
         subject.gem("build #{gemspec}")
@@ -130,7 +129,6 @@ module Omnibus
           EOH
         end
 
-        fake_embedded_bin('ruby')
         fake_embedded_bin('bundle')
 
         # Pass GEM_HOME and GEM_PATH to subprocess so our fake bin works
@@ -196,7 +194,6 @@ module Omnibus
           EOH
         end
 
-        fake_embedded_bin('ruby')
         fake_embedded_bin('appbundler')
 
         # Pass GEM_HOME and GEM_PATH to subprocess so our fake bin works
@@ -222,7 +219,6 @@ module Omnibus
           EOH
         end
 
-        fake_embedded_bin('ruby')
         fake_embedded_bin('rake')
 
         subject.rake('-T')


### PR DESCRIPTION
We experienced some strange build failures while working on the ChefDK 0.2.2 release which seemed directly related to the build slave's Ruby environment. After digging deeper I discovered the EL6 builder which was failing had a different version of Bundler (1.5.3 vs 1.7.2). This shouldn't be that big of a deal as the [ChefDK project installs Bundler 1.7.2](https://github.com/opscode/omnibus-chef/blob/release/chefdk-0.2.2/config/projects/chefdk.rb#L40) and this is the version which should be used by the `bundle` function in the Omnibus::Builder DSL. After some well-placed debug statements I realized [`Omnibus::Builder#with_clean_env`](https://github.com/opscode/omnibus/blob/v4.0.0.beta.1/lib/omnibus/builder.rb#L701-L728) wasn't cleaning enough of the Ruby environment.

This change also allows us to revert 697560d which was partially treating the symptoms of this ENV leaking.

/cc @opscode/release-engineers @opscode/client-engineers 
