### PR TITLE
Ensure default package user and group are `root`

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -445,7 +445,8 @@ module Omnibus
     expose :mac_pkg_identifier
 
     #
-    # Set or retrieve the +{deb/rpm/solaris}-user+ fpm argument.
+    # Set or retrieve the +{deb/rpm/solaris}-user+ fpm argument. Defaults
+    # to +root+ if not otherwise set.
     #
     # @example
     #   package_user 'build'
@@ -457,7 +458,7 @@ module Omnibus
     #
     def package_user(val = NULL)
       if null?(val)
-        @package_user
+        @package_user ||= 'root'
       else
         @package_user = val
       end
@@ -487,7 +488,8 @@ module Omnibus
     expose :override
 
     #
-    # Set or retrieve the +{deb/rpm/solaris}+-group fpm argument.
+    # Set or retrieve the +{deb/rpm/solaris}+-group fpm argument. Defaults
+    # to +root+ if not otherwise set.
     #
     # @example
     #   package_group 'build'
@@ -499,7 +501,7 @@ module Omnibus
     #
     def package_group(val = NULL)
       if null?(val)
-        @package_group
+        @package_group ||= 'root'
       else
         @package_group = val
       end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -73,6 +73,20 @@ module Omnibus
       end
     end
 
+    describe '#package_user' do
+      it 'returns root by default' do
+        subject.instance_variable_set(:@package_user, nil)
+        expect(subject.package_user).to eq('root')
+      end
+    end
+
+    describe '#package_group' do
+      it 'returns root by default' do
+        subject.instance_variable_set(:@package_group, nil)
+        expect(subject.package_group).to eq('root')
+      end
+    end
+
     describe '#dirty!' do
       it 'dirties the cache' do
         subject.instance_variable_set(:@dirty, nil)


### PR DESCRIPTION
/cc @opscode/engineering-leads @opscode/release-engineers @lamont-granquist @irvingpop @pburkholder @stevendanna 

This change will also be applied to the 2.0-stable branch.
