### PR TITLE
Prepare for 2.0.2 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Omnibus Ruby CHANGELOG
 ======================
 
+v2.0.2 (September 16, 2014)
+-----------------------
+- Ensure default package user and group are `root`.
+- Fix S3 bucket retrieval.
+- Add metadata to support modern publishers.
+- Downgrade FPM to ~> 0.4 
+
 v2.0.1 (March 18, 2014)
 -----------------------
 - Fix the name of the `pkg` artifact created on OSX

--- a/lib/omnibus/version.rb
+++ b/lib/omnibus/version.rb
@@ -16,5 +16,5 @@
 #
 
 module Omnibus
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
- Ensure default package user and group are `root`.
- Fix S3 bucket retrieval.
- Add metadata to support modern publishers.
- Downgrade FPM to ~> 0.4 
