### PR TITLE
Change `makeself` package extension back to `.sh`

### DIFF
--- a/lib/omnibus/packagers/makeself.rb
+++ b/lib/omnibus/packagers/makeself.rb
@@ -44,7 +44,7 @@ module Omnibus
 
     # @see Base#package_name
     def package_name
-      "#{project.package_name}-#{project.build_version}_#{project.build_iteration}.#{safe_architecture}.run"
+      "#{project.package_name}-#{project.build_version}_#{project.build_iteration}.#{safe_architecture}.sh"
     end
 
     #
@@ -105,7 +105,7 @@ module Omnibus
         EOH
       end
 
-      FileSyncer.glob("#{staging_dir}/*.run").each do |makeself|
+      FileSyncer.glob("#{staging_dir}/*.sh").each do |makeself|
         copy_file(makeself, Config.package_dir)
       end
     end

--- a/spec/unit/packagers/makeself_spec.rb
+++ b/spec/unit/packagers/makeself_spec.rb
@@ -39,7 +39,7 @@ module Omnibus
       end
 
       it 'includes the name, version, and build iteration' do
-        expect(subject.package_name).to eq('project-1.2.3_2.x86_64.run')
+        expect(subject.package_name).to eq('project-1.2.3_2.x86_64.sh')
       end
     end
 


### PR DESCRIPTION
This follows the convention used by most all self-extracting shaballs 
for the last 25 years. If you doubt that go talk to @lamont-granquist 
and he’ll set you on the correct path.

/cc @opscode/release-engineers @lamont-granquist @sethvargo 
