### PR TITLE
Update gemspec to depend on chef-sugar ~> 2.4

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'chef-sugar',      '~> 2.2'
+  gem.add_dependency 'chef-sugar',      '~> 2.4'
   gem.add_dependency 'cleanroom',       '~> 1.0'
   gem.add_dependency 'mixlib-shellout', '~> 1.4'
   gem.add_dependency 'ohai',            '~> 7.2'


### PR DESCRIPTION
Needed to pick up fix for _64_bit? in chef-sugar (to support ppc64 and s390x)
