### PR TITLE
[makeself] generate default `makeselfinst` script

### DIFF
--- a/lib/omnibus/packagers/makeself.rb
+++ b/lib/omnibus/packagers/makeself.rb
@@ -19,9 +19,7 @@ module Omnibus
     # @return [Hash]
     SCRIPT_MAP = {
       # Default Omnibus naming
-      postinst: 'makeselfinst',
-      # Default Makeself naming
-      makeselfinst: 'makeselfinst',
+      postinst: 'postinst',
     }.freeze
 
     id :makeself
@@ -37,6 +35,9 @@ module Omnibus
     build do
       # Write the scripts
       write_scripts
+
+      # Write the makeselfinst file
+      write_makeselfinst
 
       # Create the makeself archive
       create_makeself_package
@@ -65,6 +66,24 @@ module Omnibus
     #
     def makeself_header
       resource_path('makeself-header.sh')
+    end
+
+    #
+    # Render a makeselfinst in the staging directory using the supplied ERB
+    # template. This file will be used to move the contents of the self-
+    # extracting archive into place following extraction.
+    #
+    # @return [void]
+    #
+    def write_makeselfinst
+      makeselfinst_staging_path = File.join(staging_dir, 'makeselfinst')
+      render_template(resource_path('makeselfinst.erb'),
+        destination: makeselfinst_staging_path,
+        variables: {
+          install_dir: project.install_dir,
+        }
+      )
+      FileUtils.chmod(0755, makeselfinst_staging_path)
     end
 
     #

--- a/resources/makeself/makeselfinst.erb
+++ b/resources/makeself/makeselfinst.erb
@@ -1,0 +1,35 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+#
+
+#########################################################################
+# HELPERS
+#########################################################################
+error_exit()
+{
+  echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
+  exit 1
+}
+
+PROGNAME=`basename $0`
+EXTRACT_DIR=`dirname $0`
+INSTALL_DIR=<%= install_dir %>
+
+#########################################################################
+# MOVE SELF-EXTRACTING ARCHIVE FILES INTO PLACE
+#########################################################################
+rm -rf $INSTALL_DIR/* || error_exit "Cannot remove contents of $INSTALL_DIR"
+mkdir -p $INSTALL_DIR || error_exit "Cannot create $INSTALL_DIR"
+cp -R $EXTRACT_DIR $INSTALL_DIR || error_exit "Cannot install to $INSTALL_DIR"
+rm -f $INSTALL_DIR/$PROGNAME
+
+# Execute the optional postinst script
+if test -f "$INSTALL_DIR/postinst"; then
+  $INSTALL_DIR/postinst
+fi

--- a/spec/unit/packagers/makeself_spec.rb
+++ b/spec/unit/packagers/makeself_spec.rb
@@ -43,65 +43,38 @@ module Omnibus
       end
     end
 
-    describe '#write_scripts' do
-      before do
-        create_file("#{project_root}/package-scripts/project/makeselfinst") { 'Contents of makeselfinst' }
-      end
-
-      it 'copies the scripts into the STAGING dir' do
-        subject.write_scripts
-        expect("#{staging_dir}/makeselfinst").to be_a_file
+    describe '#write_makeselfinst' do
+      it 'generates the executable file' do
+        subject.write_makeselfinst
+        expect("#{staging_dir}/makeselfinst").to be_an_executable
       end
 
       it 'has the correct content' do
-        subject.write_scripts
+        subject.write_makeselfinst
         contents = File.read("#{staging_dir}/makeselfinst")
 
-        expect(contents).to include('Contents of makeselfinst')
+        expect(contents).to include('INSTALL_DIR=/opt/project')
       end
     end
 
     describe '#write_scripts' do
-      context 'when scripts are given' do
-        let(:scripts) { %w( makeselfinst ) }
-        before do
-          scripts.each do |script_name|
-            create_file("#{project_root}/package-scripts/project/#{script_name}") do
-              "Contents of #{script_name}"
-            end
-          end
-        end
-
-        it 'writes the scripts into the staging dir' do
-          subject.write_scripts
-
-          scripts.each do |script_name|
-            script_file = "#{staging_dir}/#{script_name}"
-            contents = File.read(script_file)
-            expect(contents).to include("Contents of #{script_name}")
+      let(:default_scripts) { %w( postinst ) }
+      before do
+        default_scripts.each do |script_name|
+          create_file("#{project_root}/package-scripts/project/#{script_name}") do
+            "Contents of #{script_name}"
           end
         end
       end
 
-      context 'when scripts with default omnibus naming are given' do
-        let(:default_scripts) { %w( postinst ) }
-        before do
-          default_scripts.each do |script_name|
-            create_file("#{project_root}/package-scripts/project/#{script_name}") do
-              "Contents of #{script_name}"
-            end
-          end
-        end
+      it 'writes the scripts into the staging dir' do
+        subject.write_scripts
 
-        it 'writes the scripts into the staging dir' do
-          subject.write_scripts
-
-          default_scripts.each do |script_name|
-            mapped_name = Packager::Makeself::SCRIPT_MAP[script_name.to_sym]
-            script_file = "#{staging_dir}/#{mapped_name}"
-            contents = File.read(script_file)
-            expect(contents).to include("Contents of #{script_name}")
-          end
+        default_scripts.each do |script_name|
+          mapped_name = Packager::Makeself::SCRIPT_MAP[script_name.to_sym]
+          script_file = "#{staging_dir}/#{mapped_name}"
+          contents = File.read(script_file)
+          expect(contents).to include("Contents of #{script_name}")
         end
       end
     end


### PR DESCRIPTION
The logic to copy a self-extracting archive’s file into place is general enough to be shared among projects. Projects should also be able to leverage the same `postinst` script used by the DEB, RPM and other packagers.

/cc @opscode/release-engineers @opscode/client-engineers 
