### PR TITLE
Updated bff packager to correctly change ownership before packaging

### DIFF
--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -169,7 +169,11 @@ module Omnibus
       # Unforunately, the owner of the file in the staging directory is what
       # will be on the target machine, and mkinstallp can't tell you if that
       # is a bad thing (it usually is).
-      shellout!("sudo chown -R 0:0 #{staging_dir}/#{project.install_dir}")
+      # The match is so we only pick the lowest level of the project dir.
+      # This implies that if we are in /tmp/staging/project/dir/things,
+      # we will chown from 'project' on, rather than 'project/dir', which leaves
+      # project owned by the build user (which is incorrect)
+      shellout!("sudo chown -R 0:0 #{staging_dir}/#{project.install_dir.match(/^\/?(\w+)/)}")
       log.info(log_key) { "Creating .bff file" }
 
       # Since we want the owner to be root, we need to sudo the mkinstallp


### PR DESCRIPTION
Reset root directory to be the 'lowest' level of the directory so installp will respect it.
