### PR TITLE
Update debian name, version as per Debian Packaging Policy, fix a couple of typos along the way

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -323,14 +323,14 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
-      if project.package_name =~ /\A[a-zA-Z0-9\.\+\-]+\z/
+      if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else
-        converted = project.package_name.gsub(/[^a-zA-Z0-9\.\+\-]+/, '-')
+        converted = project.package_name.downcase.gsub(/[^a-z0-9\.\+\-]+/, '-')
 
         log.warn(log_key) do
           "The `name' compontent of Debian package names can only include " \
-          "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
+          "lower case alphabetical characters (a-z), numbers (0-9), dots (.), " \
           "plus signs (+), and dashes (-). Converting `#{project.package_name}' to " \
           "`#{converted}'."
         end
@@ -340,7 +340,7 @@ module Omnibus
     end
 
     #
-    # This is actually just the regular build_iternation, but it felt lonely
+    # This is actually just the regular build_iteration, but it felt lonely
     # among all the other +safe_*+ methods.
     #
     # @return [String]
@@ -356,15 +356,15 @@ module Omnibus
     # @return [String]
     #
     def safe_version
-      if project.build_version =~ /\A[a-zA-Z0-9\.\+\-\:]+\z/
+      if project.build_version =~ /\A[a-zA-Z0-9\.\+\-\:\~]+\z/
         project.build_version.dup
       else
-        converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-\:]+/, '-')
+        converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-\:\~]+/, '-')
 
         log.warn(log_key) do
           "The `version' compontent of Debian package names can only include " \
           "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
-          "plus signs (+), dashes (-), and colons (:). Converting " \
+          "plus signs (+), dashes (-), tildes (~) and colons (:). Converting " \
           "`#{project.build_version}' to `#{converted}'."
         end
 

--- a/spec/unit/omnibus_spec.rb
+++ b/spec/unit/omnibus_spec.rb
@@ -24,7 +24,7 @@ describe Omnibus do
       expect(subject.which('not_a_real_executable')).to be nil
     end
 
-    it 'retusnt the path when the file exists' do
+    it 'returns the path when the file exists' do
       ruby = Bundler.which('ruby')
       expect(subject.which(ruby)).to eq(ruby)
     end

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -260,7 +260,7 @@ module Omnibus
 
         it 'returns the value while logging a message' do
           output = capture_logging do
-            expect(subject.safe_base_package_name).to eq('Pro-ject123.for-realz-2')
+            expect(subject.safe_base_package_name).to eq('pro-ject123.for-realz-2')
           end
 
           expect(output).to include("The `name' compontent of Debian package names can only include")
@@ -269,7 +269,7 @@ module Omnibus
     end
 
     describe '#safe_build_iteration' do
-      it 'returns the build iternation' do
+      it 'returns the build iteration' do
         expect(subject.safe_build_iteration).to eq(project.build_iteration)
       end
     end
@@ -283,11 +283,11 @@ module Omnibus
       end
 
       context 'when the project build_version has invalid characters' do
-        before { project.build_version("1.2$alpha.##__2") }
+        before { project.build_version("1.2$alpha.~##__2") }
 
         it 'returns the value while logging a message' do
           output = capture_logging do
-            expect(subject.safe_version).to eq('1.2-alpha.-2')
+            expect(subject.safe_version).to eq('1.2-alpha.~-2')
           end
 
           expect(output).to include("The `version' compontent of Debian package names can only include")


### PR DESCRIPTION
Closes #390 
- Debian package names are converted to lower case
- Debian package versions now allow ~
