### PR TITLE
Replace "generate" command with "new" in docs

### DIFF
--- a/docs/Building on Debian.md
+++ b/docs/Building on Debian.md
@@ -13,9 +13,9 @@ A number of project configuration values are taken into consideration for buildi
 
 These values are interpolated and evaluated using Omnibus' internal DEB templates. For 99% of users, these templates should be satisfactory. If you encounter an instance where Omnibus' ERB templates do not satisfy a use case, please open an issue.
 
-Because of the unlikelihood of their necessity, Omnibus does not generate deb-related assets. If you find yourself in a situation where you need to generate highly-customized DEB assets, run the Omnibus generator command with the `--deb-assets` flag:
+Because of the unlikelihood of their necessity, Omnibus does not generate deb-related assets. If you find yourself in a situation where you need to generate highly-customized DEB assets, run the Omnibus new command with the `--deb-assets` flag:
 
-    $ omnibus generate NAME --deb-assets
+    $ omnibus new NAME --deb-assets
 
 **If this is an existing project, be sure to answer "NO" when asked if you want to overwrite existing files!**
 

--- a/docs/Building on OSX.md
+++ b/docs/Building on OSX.md
@@ -8,9 +8,9 @@ Building a .pkg
 In Mac OS X, a `.pkg` is a special file that is read by Installer.app that contains the set of instructions for installating a piece of software on a target system.
 
 ### Requirements
-By default, Omnibus does not generate pkg-related assets. To generate the pkg assets, run the Omnibus generator command with the `--pkg-assets` flag:
+By default, Omnibus does not generate pkg-related assets. To generate the pkg assets, run the Omnibus new command with the `--pkg-assets` flag:
 
-    $ omnibus generate NAME --pkg-assets
+    $ omnibus new NAME --pkg-assets
 
 **If this is an existing project, be sure to answer "NO" when asked if you want to overwrite existing files!**
 
@@ -53,9 +53,9 @@ Building a .dmg
 In Mac OSX, a `.dmg` is a compressed wrapper around a collection of resources, often including a `.pkg`. The possibilities for creating and customizing a DMG are endless, but Omnibus provides a"basic starter case that will generate a pretty DMG that contains the `.pkg` file it creates.
 
 ### Requirements
-By default, Omnibus does not generate dmg-related assets. To generate the dmg assets, run the Omnibus generator with the `--dmg-assets` flag:
+By default, Omnibus does not generate dmg-related assets. To generate the dmg assets, run the Omnibus new with the `--dmg-assets` flag:
 
-    $ omnibus generate NAME --dmg-assets
+    $ omnibus new NAME --dmg-assets
 
 **If this is an existing project, be sure to answer "NO" when asked if you want to overwrite existing files!**
 

--- a/docs/Building on RHEL.md
+++ b/docs/Building on RHEL.md
@@ -31,9 +31,9 @@ These options are further described in the [`Project` documentation](http://ruby
 
 These values are interpolated and evaluated using Omnibus' internal RPM templates. For 99% of users, these templates should be satisfactory. If you encounter an instance where Omnibus' RPM templates do not satisfy a use case, please open an issue.
 
-Because of the unlikelihood of their necessity, Omnibus does not generate rpm-related assets. If you find yourself in a situation where you need to generate highly-customized RPM assets, run the Omnibus generator command with the `--rpm-assets` flag:
+Because of the unlikelihood of their necessity, Omnibus does not generate rpm-related assets. If you find yourself in a situation where you need to generate highly-customized RPM assets, run the Omnibus new command with the `--rpm-assets` flag:
 
-    $ omnibus generate NAME --rpm-assets
+    $ omnibus new NAME --rpm-assets
 
 **If this is an existing project, be sure to answer "NO" when asked if you want to overwrite existing files!**
 

--- a/docs/Building on Windows.md
+++ b/docs/Building on Windows.md
@@ -8,9 +8,9 @@ Building an .msi
 In Windows, an `.msi` is a special executable that contains the set of instructions for installating a piece of software on a target system. Please note, Omnibus does not support the creation of `.exe` files.
 
 ### Requirements
-By default, Omnibus does not generate msi-related assets. To generate the msi assets, run the Omnibus generator command with the `--msi-assets` flag:
+By default, Omnibus does not generate msi-related assets. To generate the msi assets, run the Omnibus new command with the `--msi-assets` flag:
 
-    $ omnibus generate NAME --msi-assets
+    $ omnibus new NAME --msi-assets
 
 **If this is an existing project, be sure to answer "NO" when asked if you want to overwrite existing files!**
 


### PR DESCRIPTION
Pretty trivial change, just noticed that the docs seem to refer to an older version of the subcommand name.
