### PR TITLE
Add code from omnibus 3 to retry failed downloads

### DIFF
--- a/docs/Building on RHEL.md
+++ b/docs/Building on RHEL.md
@@ -65,7 +65,7 @@ Some DSL methods available include:
 | `vendor`             | The name of the package producer            |
 | `license`            | The default license for the package         |
 | `priority`           | The priority for the package                |
-| `catetory`           | The catetory for this package               |
+| `category`           | The category for this package               |
 
 If you are unfamilar with any of these terms, you should just accept the defaults. For more information on the purpose of any of these configuration options, please see the RPM spec.
 

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -488,6 +488,11 @@ module Omnibus
     # @return [Integer]
     default(:fetcher_read_timeout, 60)
 
+    # The number of retries before marking a download as failed
+    #
+    # @return [Integer]
+    default(:fetcher_retries, 5)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -149,8 +149,6 @@ module Omnibus
 
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
 
-      log.debug(log_key) { "Downloading #{download_url}" }
-
       file = open(download_url, options)
       FileUtils.cp(file.path, downloaded_file)
       file.close

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -137,7 +137,6 @@ module Omnibus
     # @return [void]
     #
     def download
-      tries = 5
       log.warn(log_key) { source[:warning] } if source.key?(:warning)
 
       options = download_headers
@@ -148,6 +147,7 @@ module Omnibus
       end
 
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
+      fetcher_retries = Omnibus::Config.fetcher_retries
 
       file = open(download_url, options)
       FileUtils.cp(file.path, downloaded_file)
@@ -158,8 +158,8 @@ module Omnibus
            Errno::ENETUNREACH,
            Timeout::Error,
            OpenURI::HTTPError => e
-      tries -= 1
-      if tries != 0
+      fetcher_retries -= 1
+      if fetcher_retries != 0
         log.debug(log_key) { "Retrying failed download (#{tries})..." }
         retry
       else

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -148,7 +148,7 @@ module Omnibus
       end
 
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
-      fetcher_retries = Omnibus::Config.fetcher_retries
+      fetcher_retries ||= Omnibus::Config.fetcher_retries
 
       progress_bar = ProgressBar.create(
         output: $stdout,
@@ -167,9 +167,9 @@ module Omnibus
            Errno::ENETUNREACH,
            Timeout::Error,
            OpenURI::HTTPError => e
-      fetcher_retries -= 1
       if fetcher_retries != 0
-        log.debug(log_key) { "Retrying failed download (#{tries})..." }
+        log.debug(log_key) { "Retrying failed download (#{fetcher_retries})..." }
+        fetcher_retries -= 1
         retry
       else
         log.error(log_key) { "Download failed - #{e.class}!" }

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -156,6 +156,7 @@ module Omnibus
            Errno::ECONNREFUSED,
            Errno::ECONNRESET,
            Errno::ENETUNREACH,
+           Timeout::Error,
            OpenURI::HTTPError => e
       tries -= 1
       if tries != 0

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -149,6 +149,8 @@ module Omnibus
 
       options[:read_timeout] = Omnibus::Config.fetcher_read_timeout
 
+      log.debug(log_key) { "Downloading #{download_url}" }
+
       file = open(download_url, options)
       FileUtils.cp(file.path, downloaded_file)
       file.close

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -137,6 +137,7 @@ module Omnibus
     # @return [void]
     #
     def download
+      tries = 5
       log.warn(log_key) { source[:warning] } if source.key?(:warning)
 
       options = download_headers
@@ -156,8 +157,14 @@ module Omnibus
            Errno::ECONNRESET,
            Errno::ENETUNREACH,
            OpenURI::HTTPError => e
-      log.error(log_key) { "Download failed - #{e.class}!" }
-      raise
+      tries -= 1
+      if tries != 0
+        log.debug(log_key) { "Retrying failed download (#{tries})..." }
+        retry
+      else
+        log.error(log_key) { "Download failed - #{e.class}!" }
+        raise
+      end
     end
 
     #

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -40,6 +40,7 @@
 # solaris_compiler 'gcc'
 # build_retries 5
 # fetcher_read_timeout 120
+# fetcher_retries 120
 
 # Load additional software
 # ------------------------------

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -40,7 +40,7 @@
 # solaris_compiler 'gcc'
 # build_retries 5
 # fetcher_read_timeout 120
-# fetcher_retries 120
+# fetcher_retries 5
 
 # Load additional software
 # ------------------------------

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'fauxhai',     '~> 2.1'
   gem.add_development_dependency 'rspec',       '~> 3.0'
   gem.add_development_dependency 'rspec-its'
+  gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'appbundler'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'rspec/its'
+require 'webmock/rspec'
 
 require 'cleanroom/rspec'
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -42,6 +42,7 @@ module Omnibus
     include_examples 'a configurable', :build_retries, 0
     include_examples 'a configurable', :use_git_caching, true
     include_examples 'a configurable', :fetcher_read_timeout, 60
+    include_examples 'a configurable', :fetcher_retries, 5
 
     describe '#workers' do
       context 'when the Ohai data is not present' do

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -46,19 +46,6 @@ module Omnibus
           end
         end
 
-        it 'when the download times out' do
-          stub_request(:get, "https://get.example.com/file.tar.gz").to_timeout
-          output = capture_logging do
-            expect { subject.send(:download) }.to raise_error(Timeout::Error)
-          end
-
-          expect(output).to include('Retrying failed download')
-          expect(output).to include('Download failed')
-
-          retry_count = output.scan('Retrying failed download').count
-          expect(retry_count).to eq(Omnibus::Config.fetcher_retries)
-        end
-
         context 'when the shasums are the same' do
           before do
             allow(subject).to receive(:digest).and_return('abcd1234')

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -46,6 +46,19 @@ module Omnibus
           end
         end
 
+        it 'when the download times out' do
+          stub_request(:get, "https://get.example.com/file.tar.gz").to_timeout
+          output = capture_logging do
+            expect { subject.send(:download) }.to raise_error(Timeout::Error)
+          end
+
+          expect(output).to include('Retrying failed download')
+          expect(output).to include('Download failed')
+
+          retry_count = output.scan('Retrying failed download').count
+          expect(retry_count).to eq(Omnibus::Config.fetcher_retries)
+        end
+
         context 'when the shasums are the same' do
           before do
             allow(subject).to receive(:digest).and_return('abcd1234')

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -19,6 +19,8 @@ module Omnibus
 
     let(:data) { { foo: 'bar' } }
 
+    WebMock.allow_net_connect!
+
     subject { described_class.new(package, data) }
 
     describe '.arch' do


### PR DESCRIPTION
The omnibus-3 branch has retry code for failing downloads.  This is very helpful for imperfect networks, and it would be great to have this in version 4 as well.