### PR TITLE
Force `Kernel#open` to always return a `Tempfile`

### DIFF
--- a/lib/omnibus/core_extensions/open_uri.rb
+++ b/lib/omnibus/core_extensions/open_uri.rb
@@ -55,4 +55,17 @@ module OpenURI
       end
     end
   end
+
+  #
+  # Force Kernel#open to always return a Tempfile. This works around the fact
+  # that the OpenURI-provided Kernel#open returns a StringIO OR a Tempfile
+  # instances depending on the size of the data being downloaded. In the case
+  # of Omnibus we always want a Tempfile.
+  #
+  # @see http://winstonyw.com/2013/10/02/openuris_open_tempfile_and_stringio/
+  #
+  class Buffer
+    remove_const :StringMax
+    StringMax = 0
+  end
 end

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -93,6 +93,16 @@ module Omnibus
         subject.fetch
         expect(extracted).to be_a_directory
       end
+
+      context 'when the file is less than 10240 bytes' do
+        let(:source_url) { 'https://downloads.chef.io/chef.gpg.key' }
+        let(:source_md5) { 'c8f49b137b190707a0c5f5702a147155' }
+
+        it 'downloads the file' do
+          subject.fetch
+          expect(downloaded_file).to be_a_file
+        end
+      end
     end
 
     describe '#version_for_cache' do


### PR DESCRIPTION
This works around the fact that the OpenURI-provided `Kernel#open` returns a `StringIO` OR a `Tempfile` instances depending on the size of the data being downloaded. In the case of Omnibus we always want a `Tempfile`.

Fixes #381

/cc @opscode/release-engineers @danielsdeleo 
