### PR TITLE
replace dashes (-) with tildes (~) in deb package version numbers

### DIFF
--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -282,6 +282,18 @@ module Omnibus
         end
       end
 
+      context 'when the project build_version has dashes' do
+        before { project.build_version('1.2-rc.1') }
+
+        it 'returns the value while logging a message' do
+          output = capture_logging do
+            expect(subject.safe_version).to eq('1.2~rc.1')
+          end
+
+          expect(output).to include("Dashes hold special significance in the Debian package versions.")
+        end
+      end
+
       context 'when the project build_version has invalid characters' do
         before { project.build_version("1.2$alpha.~##__2") }
 
@@ -290,7 +302,7 @@ module Omnibus
             expect(subject.safe_version).to eq('1.2_alpha.~_2')
           end
 
-          expect(output).to include("The `version' compontent of Debian package names can only include")
+          expect(output).to include("The `version' component of Debian package names can only include")
         end
       end
     end


### PR DESCRIPTION
Dashes hold special significance in the Debian package versions. Versions that contain a dash and should be considered an earlier version (e.g. pre-releases) may actually be ordered as later (e.g. 12.0.0-rc.6 > 12.0.0). We'll work around this by replacing dashes (`-`) with tildes (`~`). We'll also move to replacing invalid characters with underscores (`_`).

Fixes #396

/cc @opscode/release-engineers @juliandunn @psychonaut
