### PR TITLE
Allow overrides definitions using strings instead of symbols

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -481,9 +481,9 @@ module Omnibus
     #
     def override(name, val = NULL)
       if null?(val)
-        overrides[name]
+        overrides[name.to_sym]
       else
-        overrides[name] = val
+        overrides[name.to_sym] = val
       end
     end
     expose :override

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -223,6 +223,14 @@ module Omnibus
         subject.override(:thing, version: '6.6.6')
         expect(subject.override(:thing)[:version]).to eq('6.6.6')
       end
+
+      it 'symbolizes #overrides' do
+        subject.override('thing', version: '6.6.6')
+        [:thing, 'thing'].each do |thing|
+          expect(subject.override(thing)).not_to be_nil
+        end
+        expect(subject.override(:thing)[:version]).to eq('6.6.6')
+      end
     end
 
     describe '#ohai' do


### PR DESCRIPTION
As dependencies can be defined using strings (`dependency "ruby"`), one may also try to define an override using a string instead of a symbol to identify the software:

```
override 'ruby', version: '2.1.5'
```
