### PR TITLE
[RPM] replace dashes (-) with tildes (~) in version

### DIFF
--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -214,7 +214,7 @@ module Omnibus
         converted = project.package_name.downcase.gsub(/[^a-z0-9\.\+\-]+/, '-')
 
         log.warn(log_key) do
-          "The `name' compontent of BFF package names can only include " \
+          "The `name' component of BFF package names can only include " \
           "lowercase alphabetical characters (a-z), numbers (0-9), dots (.), " \
           "plus signs (+), and dashes (-). Converting `#{project.package_name}' to " \
           "`#{converted}'."

--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -329,7 +329,7 @@ module Omnibus
         converted = project.package_name.downcase.gsub(/[^a-z0-9\.\+\-]+/, '-')
 
         log.warn(log_key) do
-          "The `name' compontent of Debian package names can only include " \
+          "The `name' component of Debian package names can only include " \
           "lower case alphabetical characters (a-z), numbers (0-9), dots (.), " \
           "plus signs (+), and dashes (-). Converting `#{project.package_name}' to " \
           "`#{converted}'."

--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -268,7 +268,7 @@ module Omnibus
         converted = project.package_name.downcase.gsub(/[^[:alnum:]+]/, '')
 
         log.warn(log_key) do
-          "The `name' compontent of Mac package names can only include " \
+          "The `name' component of Mac package names can only include " \
           "alphabetical characters (a-z, A-Z), and numbers (0-9). Converting " \
           "`#{project.package_name}' to `#{converted}'."
         end
@@ -314,7 +314,7 @@ module Omnibus
         converted = project.build_version.gsub(/[^a-zA-Z0-9\.\+\-]+/, '-')
 
         log.warn(log_key) do
-          "The `version' compontent of Mac package names can only include " \
+          "The `version' component of Mac package names can only include " \
           "alphabetical characters (a-z, A-Z), numbers (0-9), dots (.), " \
           "plus signs (+), and dashes (-). Converting " \
           "`#{project.build_version}' to `#{converted}'."

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -406,7 +406,7 @@ module Omnibus
         converted = project.package_name.downcase.gsub(/[^a-z0-9\.\+\-]+/, '-')
 
         log.warn(log_key) do
-          "The `name' compontent of RPM package names can only include " \
+          "The `name' component of RPM package names can only include " \
           "lowercase alphabetical characters (a-z), numbers (0-9), dots (.), " \
           "plus signs (+), and dashes (-). Converting `#{project.package_name}' to " \
           "`#{converted}'."

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -44,7 +44,7 @@ module Omnibus
           instance.evaluate_file(filepath)
           instance.load_dependencies
 
-          # Add the loaded compontent to the library
+          # Add the loaded component to the library
           project.library.component_added(instance)
 
           instance

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -187,7 +187,7 @@ module Omnibus
             expect(subject.safe_base_package_name).to eq('pro-ject123.for-realz-2')
           end
 
-          expect(output).to include("The `name' compontent of BFF package names can only include")
+          expect(output).to include("The `name' component of BFF package names can only include")
         end
       end
     end

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -263,7 +263,7 @@ module Omnibus
             expect(subject.safe_base_package_name).to eq('pro-ject123.for-realz-2')
           end
 
-          expect(output).to include("The `name' compontent of Debian package names can only include")
+          expect(output).to include("The `name' component of Debian package names can only include")
         end
       end
     end

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -207,7 +207,7 @@ module Omnibus
             expect(subject.safe_base_package_name).to eq('project123forrealz2')
           end
 
-          expect(output).to include("The `name' compontent of Mac package names can only include")
+          expect(output).to include("The `name' component of Mac package names can only include")
         end
       end
     end
@@ -264,7 +264,7 @@ module Omnibus
             expect(subject.safe_version).to eq('1.2-alpha.-2')
           end
 
-          expect(output).to include("The `version' compontent of Mac package names can only include")
+          expect(output).to include("The `version' component of Mac package names can only include")
         end
       end
     end

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -311,7 +311,7 @@ module Omnibus
             expect(subject.safe_base_package_name).to eq('pro-ject123.for-realz-2')
           end
 
-          expect(output).to include("The `name' compontent of RPM package names can only include")
+          expect(output).to include("The `name' component of RPM package names can only include")
         end
       end
     end


### PR DESCRIPTION
RPM 4.10+ added support for using the tilde (~) as a way to mark versions as lower priority in comparisons. More details on this feature can be found here:

  http://rpm.org/ticket/56

Replacing dashes with tildes will ensure pre-release versions (e.g. `12.0.0-rc.1`) get sorted before final versions (e.g. `12.0.0`).

/cc @opscode/release-engineers 
