### PR TITLE
Place packager assets into correct location when creating new project

### DIFF
--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -106,53 +106,53 @@ module Omnibus
     def create_bff_assets
       return unless options[:bff_assets]
 
-      copy_file(resource_path('bff/gen.template.erb'), "#{target}/resources/bff/gen.template.erb")
+      copy_file(resource_path('bff/gen.template.erb'), "#{target}/resources/#{name}/bff/gen.template.erb")
     end
 
     def create_deb_assets
       return unless options[:deb_assets]
 
-      copy_file(resource_path('deb/conffiles.erb'), "#{target}/resources/deb/conffiles.erb")
-      copy_file(resource_path('deb/control.erb'), "#{target}/resources/deb/control.erb")
-      copy_file(resource_path('deb/md5sums.erb'), "#{target}/resources/deb/md5sums.erb")
+      copy_file(resource_path('deb/conffiles.erb'), "#{target}/resources/#{name}/deb/conffiles.erb")
+      copy_file(resource_path('deb/control.erb'), "#{target}/resources/#{name}/deb/control.erb")
+      copy_file(resource_path('deb/md5sums.erb'), "#{target}/resources/#{name}/deb/md5sums.erb")
     end
 
     def create_dmg_assets
       return unless options[:dmg_assets]
 
-      copy_file(resource_path('dmg/background.png'), "#{target}/resources/dmg/background.png")
-      copy_file(resource_path('dmg/icon.png'), "#{target}/resources/dmg/icon.png")
+      copy_file(resource_path('dmg/background.png'), "#{target}/resources/#{name}/dmg/background.png")
+      copy_file(resource_path('dmg/icon.png'), "#{target}/resources/#{name}/dmg/icon.png")
     end
 
     def create_msi_assets
       return unless options[:msi_assets]
 
-      copy_file(resource_path('msi/localization-en-us.wxl.erb'), "#{target}/resources/msi/localization-en-us.wxl.erb")
-      copy_file(resource_path('msi/parameters.wxi.erb'), "#{target}/resources/msi/parameters.wxi.erb")
-      copy_file(resource_path('msi/source.wxs.erb'), "#{target}/resources/msi/source.wxs.erb")
+      copy_file(resource_path('msi/localization-en-us.wxl.erb'), "#{target}/resources/#{name}/msi/localization-en-us.wxl.erb")
+      copy_file(resource_path('msi/parameters.wxi.erb'), "#{target}/resources/#{name}/msi/parameters.wxi.erb")
+      copy_file(resource_path('msi/source.wxs.erb'), "#{target}/resources/#{name}/msi/source.wxs.erb")
 
-      copy_file(resource_path('msi/assets/LICENSE.rtf'), "#{target}/resources/msi/assets/LICENSE.rtf")
-      copy_file(resource_path('msi/assets/banner_background.bmp'), "#{target}/resources/msi/assets/banner_background.bmp")
-      copy_file(resource_path('msi/assets/dialog_background.bmp'), "#{target}/resources/msi/assets/dialog_background.bmp")
-      copy_file(resource_path('msi/assets/project.ico'), "#{target}/resources/msi/assets/project.ico")
-      copy_file(resource_path('msi/assets/project_16x16.ico'), "#{target}/resources/msi/assets/project_16x16.ico")
-      copy_file(resource_path('msi/assets/project_32x32.ico'), "#{target}/resources/msi/assets/project_32x32.ico")
+      copy_file(resource_path('msi/assets/LICENSE.rtf'), "#{target}/resources/#{name}/msi/assets/LICENSE.rtf")
+      copy_file(resource_path('msi/assets/banner_background.bmp'), "#{target}/resources/#{name}/msi/assets/banner_background.bmp")
+      copy_file(resource_path('msi/assets/dialog_background.bmp'), "#{target}/resources/#{name}/msi/assets/dialog_background.bmp")
+      copy_file(resource_path('msi/assets/project.ico'), "#{target}/resources/#{name}/msi/assets/project.ico")
+      copy_file(resource_path('msi/assets/project_16x16.ico'), "#{target}/resources/#{name}/msi/assets/project_16x16.ico")
+      copy_file(resource_path('msi/assets/project_32x32.ico'), "#{target}/resources/#{name}/msi/assets/project_32x32.ico")
     end
 
     def create_pkg_assets
       return unless options[:pkg_assets]
 
-      copy_file(resource_path('pkg/background.png'), "#{target}/resources/pkg/background.png")
-      copy_file(resource_path('pkg/license.html.erb'), "#{target}/resources/pkg/license.html.erb")
-      copy_file(resource_path('pkg/welcome.html.erb'), "#{target}/resources/pkg/welcome.html.erb")
+      copy_file(resource_path('pkg/background.png'), "#{target}/resources/#{name}/pkg/background.png")
+      copy_file(resource_path('pkg/license.html.erb'), "#{target}/resources/#{name}/pkg/license.html.erb")
+      copy_file(resource_path('pkg/welcome.html.erb'), "#{target}/resources/#{name}/pkg/welcome.html.erb")
     end
 
     def create_rpm_assets
       return unless options[:rpm_assets]
 
-      copy_file(resource_path('rpm/rpmmacros.erb'), "#{target}/resources/rpm/rpmmacros.erb")
-      copy_file(resource_path('rpm/signing.erb'), "#{target}/resources/rpm/signing.erb")
-      copy_file(resource_path('rpm/spec.erb'), "#{target}/resources/rpm/spec.erb")
+      copy_file(resource_path('rpm/rpmmacros.erb'), "#{target}/resources/#{name}/rpm/rpmmacros.erb")
+      copy_file(resource_path('rpm/signing.erb'), "#{target}/resources/#{name}/rpm/signing.erb")
+      copy_file(resource_path('rpm/spec.erb'), "#{target}/resources/#{name}/rpm/spec.erb")
     end
     private
 

--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -145,6 +145,7 @@ module Omnibus
       copy_file(resource_path('pkg/background.png'), "#{target}/resources/#{name}/pkg/background.png")
       copy_file(resource_path('pkg/license.html.erb'), "#{target}/resources/#{name}/pkg/license.html.erb")
       copy_file(resource_path('pkg/welcome.html.erb'), "#{target}/resources/#{name}/pkg/welcome.html.erb")
+      copy_file(resource_path('pkg/distribution.xml.erb'), "#{target}/resources/#{name}/pkg/distribution.xml.erb")
     end
 
     def create_rpm_assets

--- a/spec/unit/generator_spec.rb
+++ b/spec/unit/generator_spec.rb
@@ -52,7 +52,7 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, bff_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/bff/gen.template.erb
+          omnibus-name/resources/name/bff/gen.template.erb
         ))
       end
     end
@@ -62,9 +62,9 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, deb_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/deb/conffiles.erb
-          omnibus-name/resources/deb/control.erb
-          omnibus-name/resources/deb/md5sums.erb
+          omnibus-name/resources/name/deb/conffiles.erb
+          omnibus-name/resources/name/deb/control.erb
+          omnibus-name/resources/name/deb/md5sums.erb
         ))
       end
     end
@@ -74,8 +74,8 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, dmg_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/dmg/background.png
-          omnibus-name/resources/dmg/icon.png
+          omnibus-name/resources/name/dmg/background.png
+          omnibus-name/resources/name/dmg/icon.png
         ))
       end
     end
@@ -85,15 +85,15 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, msi_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/msi/assets/LICENSE.rtf
-          omnibus-name/resources/msi/assets/banner_background.bmp
-          omnibus-name/resources/msi/assets/dialog_background.bmp
-          omnibus-name/resources/msi/assets/project.ico
-          omnibus-name/resources/msi/assets/project_16x16.ico
-          omnibus-name/resources/msi/assets/project_32x32.ico
-          omnibus-name/resources/msi/localization-en-us.wxl.erb
-          omnibus-name/resources/msi/parameters.wxi.erb
-          omnibus-name/resources/msi/source.wxs.erb
+          omnibus-name/resources/name/msi/assets/LICENSE.rtf
+          omnibus-name/resources/name/msi/assets/banner_background.bmp
+          omnibus-name/resources/name/msi/assets/dialog_background.bmp
+          omnibus-name/resources/name/msi/assets/project.ico
+          omnibus-name/resources/name/msi/assets/project_16x16.ico
+          omnibus-name/resources/name/msi/assets/project_32x32.ico
+          omnibus-name/resources/name/msi/localization-en-us.wxl.erb
+          omnibus-name/resources/name/msi/parameters.wxi.erb
+          omnibus-name/resources/name/msi/source.wxs.erb
         ))
       end
     end
@@ -103,9 +103,10 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, pkg_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/pkg/background.png
-          omnibus-name/resources/pkg/license.html.erb
-          omnibus-name/resources/pkg/welcome.html.erb
+          omnibus-name/resources/name/pkg/background.png
+          omnibus-name/resources/name/pkg/license.html.erb
+          omnibus-name/resources/name/pkg/welcome.html.erb
+          omnibus-name/resources/name/pkg/distribution.xml.erb
         ))
       end
     end
@@ -115,9 +116,9 @@ module Omnibus
         Generator.new(['name'], path: tmp_path, rpm_assets: true).invoke_all
 
         expect(structure).to include(*%w(
-          omnibus-name/resources/rpm/rpmmacros.erb
-          omnibus-name/resources/rpm/signing.erb
-          omnibus-name/resources/rpm/spec.erb
+          omnibus-name/resources/name/rpm/rpmmacros.erb
+          omnibus-name/resources/name/rpm/signing.erb
+          omnibus-name/resources/name/rpm/spec.erb
         ))
       end
     end


### PR DESCRIPTION
I noticed that when I created a new project on OSX and edited the resource files in ./resources/pkg my changes were not showing up and omnibus was still using the default included resources. I found that when I moved those resources into ./resources/{my_project_name}/pkg that it picked them up correctly. This pull request correctly generates assets for new projects.

This copies the assets into ./resource/#{name}/ instead of just ./resources. I have also added distribution.xml.erb to be copied on new projects for OSX pkg.

NOTE: I changed the asset paths for all other packagers too as I figured it would be needed for all of them. I have only tested this on OSX when generating a pkg.