### PR TITLE
Add the option to inject CFLAGS, LDFLAGS

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -437,6 +437,17 @@ module Omnibus
     # @return [String, nil]
     default(:solaris_compiler, nil)
 
+    # Additional CFLAGS to inject into the environment. Note that
+    # e.g. CXXFLAGS inherits this, too.
+    #
+    # @return [String]
+    default(:inject_cflags, '')
+
+    # Additional LDFLAGS to inject into the environment.
+    #
+    # @return [String]
+    default(:inject_ldflags, '')
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -474,6 +474,15 @@ module Omnibus
           }
         end
 
+      # Add extra CFLAGS and LDFLAGS if required in the configuration
+      unless Config.inject_cflags.empty?
+        compiler_flags["CFLAGS"] = "#{compiler_flags["CFLAGS"]} #{Config.inject_cflags}"
+      end
+
+      unless Config.inject_ldflags.empty?
+        compiler_flags["LDFLAGS"] = "#{compiler_flags["LDFLAGS"]} #{Config.inject_ldflags}"
+      end
+
       # merge LD_RUN_PATH into the environment.  most unix distros will fall
       # back to this if there is no LDFLAGS passed to the linker that sets
       # the rpath.  the LDFLAGS -R or -Wl,-rpath will override this, but in

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -42,6 +42,8 @@ module Omnibus
     include_examples 'a configurable', :build_retries, 0
     include_examples 'a configurable', :use_git_caching, true
     include_examples 'a configurable', :fetcher_read_timeout, 60
+    include_examples 'a configurable', :inject_cflags, ''
+    include_examples 'a configurable', :inject_ldflags, ''
 
     describe '#workers' do
       context 'when the Ohai data is not present' do

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -95,6 +95,23 @@ module Omnibus
         end
       end
 
+      context 'with extra flags' do
+        before do
+          Omnibus::Config.inject_cflags('-pie')
+          Omnibus::Config.inject_ldflags('-Wl,-z,relro')
+        end
+
+        it 'includes extra flags' do
+          expect(subject.with_standard_compiler_flags).to eq(
+            'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib -Wl,-z,relro',
+            'CFLAGS'          => '-I/opt/project/embedded/include -pie',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -pie',
+            'LD_RUN_PATH'     => '/opt/project/embedded/lib',
+            'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
+          )
+        end
+      end
+
       context 'on solaris2' do
         before do
           stub_ohai(platform: 'solaris2', version: '5.11') do |data|


### PR DESCRIPTION
This PR adds the option to inject extra `CFLAGS` and `LDFLAGS` in the output of `with_standard_compiler_flags`. 

This allows to e.g. use what's provided by `dpkg-buildflags --cflags`, or inject `-O2` for everything you build.

This is of course fully backwards-compatible,

Thoughts?
