### PR TITLE
Add to_s for software

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -862,5 +862,9 @@ module Omnibus
     def log_key
       @log_key ||= "#{super}: #{name}"
     end
+
+    def to_s
+      "#{name}[#{filepath}]"
+    end
   end
 end


### PR DESCRIPTION
Things rely on being able to print a software, so make its to_s useful

### Before
```
Software must specify a `source md5 checksum; to cache it in S3 (#<Omnibus::Software:0x007ff723425280>)!                                                   0% (0 KB/
```

### After
```
Software must specify a `source md5 checksum; to cache it in S3 (rubygems[/Users/jmundrawala/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/bundler/gems/omnibus-software-12909667bfb2/config/software/rubygems.rb])!
```

cc @schisamo @yzl 