### PR TITLE
Improvements for path based builds

### DIFF
--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -63,7 +63,7 @@ module Omnibus
     #
     def digest_directory(path, type = :md5)
       digest = digest_from_type(type)
-
+      log.info(log_key) { "Digesting #{path} with #{type}" } if defined?(log) && defined?(log_key)
       FileSyncer.glob("#{path}/**/*").each do |filename|
         # Calculate the filename relative to the given path. Since directories
         # are SHAed according to their filepath, two difference directories on

--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -16,9 +16,14 @@
 
 require 'openssl'
 require 'pathname'
+require 'omnibus/logging'
 
 module Omnibus
   module Digestable
+
+    def self.included(other)
+      other.send(:include, Logging)
+    end
     #
     # Calculate the digest of the file at the given path. Files are read in
     # binary chunks to prevent Ruby from exploding.
@@ -63,7 +68,7 @@ module Omnibus
     #
     def digest_directory(path, type = :md5)
       digest = digest_from_type(type)
-      log.info(log_key) { "Digesting #{path} with #{type}" } if defined?(log) && defined?(log_key)
+      log.info(log_key) { "Digesting #{path} with #{type}" }
       FileSyncer.glob("#{path}/**/*").each do |filename|
         # Calculate the filename relative to the given path. Since directories
         # are SHAed according to their filepath, two difference directories on

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -65,6 +65,9 @@ module Omnibus
 
       create_required_directories
       FileSyncer.sync(source_path, project_dir, source_options)
+      # Reset target shasum on every fetch
+      @target_shasum = nil
+      target_shasum
     end
 
     #

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -64,7 +64,7 @@ module Omnibus
       log.info(log_key) { "Copying from `#{source_path}'" }
 
       create_required_directories
-      FileSyncer.sync(source_path, project_dir)
+      FileSyncer.sync(source_path, project_dir, source_options)
     end
 
     #
@@ -86,6 +86,19 @@ module Omnibus
     #
     def source_path
       source[:path]
+    end
+
+    #
+    # Options to pass to the underlying FileSyncer
+    #
+    # @return [Hash]
+    #
+    def source_options
+      if source[:options] && source[:options].is_a?(Hash)
+        source[:options]
+      else
+        {}
+      end
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -219,7 +219,7 @@ module Omnibus
             "be a kind of `Hash', but was `#{val.class.inspect}'")
         end
 
-        extra_keys = val.keys - [:git, :path, :url, :md5, :cookie, :warning, :unsafe]
+        extra_keys = val.keys - [:git, :path, :url, :md5, :cookie, :warning, :unsafe, :options]
         unless extra_keys.empty?
           raise InvalidValue.new(:source,
             "only include valid keys. Invalid keys: #{extra_keys.inspect}")

--- a/spec/unit/fetchers/path_fetcher_spec.rb
+++ b/spec/unit/fetchers/path_fetcher_spec.rb
@@ -89,7 +89,7 @@ module Omnibus
       end
 
       it 'copies the new files over' do
-        expect(FileSyncer).to receive(:sync).with(source_path, project_dir)
+        expect(FileSyncer).to receive(:sync).with(source_path, project_dir, {})
         subject.fetch
       end
     end


### PR DESCRIPTION
This changeset includes improvements to Digestable, FileSyncer, and PathFetcher.  Most importantly:

- Reset target_shasum in PathFetcher after every fetch, preventing erroneous GitCache misses for builds that produced local artifacts during the previous omnibus run.

More minor improvements:

- Log when an entire directory is being digested.
- Avoid failing when re-syncing read-only files
- Allow users to specify options to the underlying FileSyncer in a Software definition