### PR TITLE
Bump fauxhai to 2.3, required for current rspec tests

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 2.0'
   gem.add_development_dependency 'aruba',       '~> 0.5'
-  gem.add_development_dependency 'fauxhai',     '~> 2.1'
+  gem.add_development_dependency 'fauxhai',     '~> 2.3'
   gem.add_development_dependency 'rspec',       '~> 3.0'
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Omnibus's spec tests requires fauxhai platform data from SuSE 12.0 and
Debian 7.6, which is only available in a newer version.