### PR TITLE
Introduce version-manifest to omnibus

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -72,6 +72,9 @@ module Omnibus
   autoload :NullPublisher,        'omnibus/publishers/null_publisher'
   autoload :S3Publisher,          'omnibus/publishers/s3_publisher'
 
+  autoload :Manifest,      'omnibus/manifest'
+  autoload :ManifestEntry, 'omnibus/manifest_entry'
+
   module Command
     autoload :Base,    'omnibus/cli/base'
     autoload :Cache,   'omnibus/cli/cache'

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -71,20 +71,20 @@ module Omnibus
       default: nil
     desc 'build PROJECT', 'Build the given Omnibus project'
     def build(name)
-      project = Project.load(name)
+      manifest = if @options[:use_manifest]
+                   Omnibus::Manifest.from_file(@options[:use_manifest])
+                 else
+                   nil
+                 end
 
+      project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
-
-      if @options[:use_manifest]
-        project.manifest(Omnibus::Manifest.from_file(@options[:use_manifest]))
-      end
-
       project.download
       project.build
 
       if @options[:output_manifest]
         File.open('version-manifest.json', 'w') do |f|
-          f.write(JSON.pretty_generate(project.manifest.to_hash))
+          f.write(JSON.pretty_generate(project.built_manifest.to_hash))
         end
       end
     end

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -61,12 +61,32 @@ module Omnibus
     #
     #   $ omnibus build chefdk
     #
+    method_option :output_manifest,
+      desc: "Create version-manifest.json in current directory at the end of the build",
+      type: :boolean,
+      default: false
+    method_option :use_manifest,
+      desc: "Use the given manifest when downloading software sources.",
+      type: :string,
+      default: nil
     desc 'build PROJECT', 'Build the given Omnibus project'
     def build(name)
       project = Project.load(name)
 
       say("Building #{project.name} #{project.build_version}...")
-      project.build_me
+
+      if @options[:use_manifest]
+        project.manifest(Omnibus::Manifest.from_file(@options[:use_manifest]))
+      end
+
+      project.download
+      project.build
+
+      if @options[:output_manifest]
+        File.open('version-manifest.json', 'w') do |f|
+          f.write(JSON.pretty_generate(project.manifest.to_hash))
+        end
+      end
     end
 
     #

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -92,6 +92,17 @@ module Omnibus
     end
 
     #
+    # Returned the resolved version for the manifest.  Since this is a
+    # remote URL, there is no resolution, the version is what we said
+    # it is.
+    #
+    # @return [String]
+    #
+    def resolve_version
+      version
+    end
+
+    #
     # The path on disk to the downloaded asset. This method requires the
     # presence of a +source_uri+.
     #
@@ -124,7 +135,7 @@ module Omnibus
     #
     def download_url
       if Config.use_s3_caching
-        "http://#{Config.s3_bucket}.s3.amazonaws.com/#{S3Cache.key_for(software)}"
+        "http://#{Config.s3_bucket}.s3.amazonaws.com/#{S3Cache.key_for(self)}"
       else
         source[:url]
       end
@@ -208,7 +219,7 @@ module Omnibus
       actual   = digest(downloaded_file, :md5)
 
       if expected != actual
-        raise ChecksumMismatch.new(software, expected, actual)
+        raise ChecksumMismatch.new(self, expected, actual)
       end
     end
 

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -98,7 +98,7 @@ module Omnibus
     #
     # @return [String]
     #
-    def resolve_version
+    def self.resolve_version(version, source)
       version
     end
 

--- a/lib/omnibus/fetchers/null_fetcher.rb
+++ b/lib/omnibus/fetchers/null_fetcher.rb
@@ -33,7 +33,7 @@ module Omnibus
     #
     # @return [String, nil]
     #
-    def resolve_version
+    def self.resolve_version(version, source)
       version
     end
 

--- a/lib/omnibus/fetchers/null_fetcher.rb
+++ b/lib/omnibus/fetchers/null_fetcher.rb
@@ -31,6 +31,13 @@ module Omnibus
     end
 
     #
+    # @return [String, nil]
+    #
+    def resolve_version
+      version
+    end
+
+    #
     # @return [false]
     #
     def clean
@@ -41,7 +48,7 @@ module Omnibus
     # @return [void]
     #
     def fetch
-      log.info(log_key) { "Fetching `#{software.name}' (nothing to fetch)" }
+      log.info(log_key) { "Fetching `#{name}' (nothing to fetch)" }
 
       create_required_directories
       nil

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -80,6 +80,13 @@ module Omnibus
       "path:#{source_path}|shasum:#{target_shasum}"
     end
 
+    #
+    # @return [String, nil]
+    #
+    def resolve_version
+      version
+    end
+
     private
 
     #

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -83,7 +83,7 @@ module Omnibus
     #
     # @return [String, nil]
     #
-    def resolve_version
+    def self.resolve_version(version, source)
       version
     end
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -177,7 +177,7 @@ module Omnibus
         log.warn(log_key) { 'Skipping health check on Windows' }
         return true
       end
-
+      log.info(log_key) {"Running health on #{project.name}"}
       bad_libs =  case Ohai['platform']
                   when 'mac_os_x'
                     health_check_otool

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -1,0 +1,109 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'json'
+
+module Omnibus
+  class Manifest
+    class InvalidManifestFormat < Exception; end
+    class NotAManifestEntry < Exception; end
+    class MissingManifestEntry < Exception; end
+
+    include Logging
+
+    LATEST_MANIFEST_FORMAT = 1
+
+    def initialize
+      @data = {}
+    end
+
+    def entry_for(name)
+      if @data.key?(name)
+        @data[name]
+      else
+        raise MissingManifestEntry, "No manifest entry found for #{name}"
+      end
+    end
+
+    def add(name, entry)
+      if ! entry.is_a? Omnibus::ManifestEntry
+        raise NotAManifestEntry, "#{entry} is not an Omnibus:ManifestEntry"
+      end
+
+      if @data.key?(name)
+        log.warn(log_key) { "Overritting existing manifest entry for #{name}" }
+      end
+
+      @data[name] = entry
+      self
+    end
+
+    def to_hash
+      software_hash = @data.inject({}) do |memo, (k,v)|
+        memo[k] = v.to_hash
+        memo
+      end
+      {
+        'manifest_format' => LATEST_MANIFEST_FORMAT,
+        'software' => software_hash
+      }
+    end
+
+    #
+    # Class Methods
+    #
+
+    def self.from_hash(manifest_data)
+      case manifest_data['manifest_format'].to_i
+      when 1
+        from_hash_v1(manifest_data)
+      else
+        raise InvalidManifestFormat, "Unknown manifest fromat version: #{manifest_data['manifest_format']}"
+      end
+    end
+
+    def self.from_hash_v1(manifest_data)
+      m = Omnibus::Manifest.new
+      manifest_data['software'].each do |name, entry_data|
+        m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
+      end
+      m
+    end
+
+    def self.from_file(filename)
+      from_hash(JSON.parse(File.read(File.expand_path(filename))))
+    end
+
+    private
+
+    #
+    # Utility function to convert a Hash with String keys to a Hash
+    # with Symbol keys, recursively.
+    #
+    # @returns [Hash]
+    #
+    def self.keys_to_syms(h)
+      h.inject({}) do |memo, (k, v)|
+        memo[k.to_sym] = if v.is_a? Hash
+                           keys_to_syms(v)
+                         else
+                           v
+                         end
+        memo
+      end
+    end
+  end
+end

--- a/lib/omnibus/manifest_entry.rb
+++ b/lib/omnibus/manifest_entry.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Omnibus
+  class ManifestEntry
+    attr_reader :locked_version, :locked_source, :source_type, :described_version, :name
+    def initialize(name, manifest_data)
+      @name = name
+      @locked_version = manifest_data[:locked_version]
+      @locked_source = manifest_data[:locked_source]
+      @source_type = manifest_data[:source_type]
+      @described_version = manifest_data[:described_version]
+    end
+
+    def to_hash
+      {
+        "locked_version" => @locked_version,
+        "locked_source" => @locked_source,
+        "source_type" => @source_type,
+        "described_version" => @described_version
+      }
+    end
+  end
+end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -674,38 +674,44 @@ module Omnibus
     expose :ohai
 
     #
-    # Write a json-format version manifest to the specified location
-    # at the end of the build. If no path is specified
+    # Location of json-formated version manifest, written at at the
+    # end of the build. If no path is specified
     # +install_dir+/version-manifest.json is used.
     #
     # @example
-    #   with_json_manifest
+    #   json_manifest_path
     #
     # @return [String]
     #
-    def with_json_manifest(path=File.join(install_dir, "version-manifest.json"))
-      @write_json_manifest=true
-      @json_manifest_path=path
+    def json_manifest_path(path = NULL)
+      if null?(path)
+        @json_manifest_path || File.join(install_dir, "version-manifest.json")
+      else
+        @json_manifest_path=path
+      end
     end
-    expose :with_json_manifest
+    expose :json_manifest_path
 
     #
-    # Write a text-formatted manifest to the specified location
-    #(+install_dir+/version-manifest.txt if none is provided).
+    # Location of text-formatted manifest.
+    # (+install_dir+/version-manifest.txt if none is provided)
     #
     # This manifest uses the same format used by the
     # 'version-manifest' software definition in omnibus-software.
     #
     # @example
-    #   with_text_manifest
+    #   text_manifest_path
     #
     # @return [String]
     #
-    def with_text_manifest(path=File.join(install_dir, "version-manifest.txt"))
-      @write_text_manifest=true
-      @text_manifest_path=path
+    def text_manifest_path(path = NULL)
+      if null?(path)
+        @test_manifest_path || File.join(install_dir, "version-manifest.txt")
+      else
+        @text_manifest_path = path
+      end
     end
-    expose :with_text_manifest
+    expose :text_manifest_path
 
     #
     # @!endgroup
@@ -982,15 +988,15 @@ module Omnibus
         software.build_me
       end
 
-      write_json_manifest if @write_json_manifest
-      write_text_manifest if @write_text_manifest
+      write_json_manifest
+      write_text_manifest
       HealthCheck.run!(self)
       package_me
       compress_me
     end
 
     def write_json_manifest
-      File.open(@json_manifest_path, 'w') do |f|
+      File.open(json_manifest_path, 'w') do |f|
         f.write(JSON.pretty_generate(built_manifest.to_hash))
       end
     end
@@ -1001,7 +1007,7 @@ module Omnibus
     # omnibus-software.
     #
     def write_text_manifest
-      File.open(@text_manifest_path, 'w') do |f|
+      File.open(text_manifest_path, 'w') do |f|
         f.puts "#{name} #{build_version}"
         f.puts ""
         f.puts Omnibus::Reports.pretty_version_map(self)

--- a/spec/functional/fetchers/git_fetcher_spec.rb
+++ b/spec/functional/fetchers/git_fetcher_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'omnibus/manifest_entry'
 
 module Omnibus
   describe GitFetcher do
@@ -144,6 +145,22 @@ module Omnibus
 
         it 'raise an exception' do
           expect { subject.fetch }.to raise_error(UnresolvableGitReference)
+        end
+      end
+
+      context 'when a manifest entry locks a version' do
+        let(:version)  { 'v1.2.4' }
+        let(:remote)   { remote_git_repo('zlib', annotated_tags: [version]) }
+        let (:a_manifest) {
+          Omnibus::ManifestEntry.new("zlib",
+                                     { :locked_version => 'efde208366abd0f91419d8a54b45e3f6e0540105',
+                                       :locked_source => {:git => remote}})
+        }
+
+        it 'fetches the locked version' do
+          subject.use_manifest_entry(a_manifest)
+          subject.fetch
+          expect(revision).to eq('efde208366abd0f91419d8a54b45e3f6e0540105')
         end
       end
     end

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -15,7 +15,14 @@ module Omnibus
 
     let(:fetch!) { capture_stdout { subject.fetch } }
 
-    subject { described_class.new(software) }
+    let(:manifest_entry) do
+      double(ManifestEntry,
+             name: 'software',
+             locked_version: '1.2.8',
+             locked_source: source)
+    end
+
+    subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
     describe '#fetch_required?' do
       context 'when the file is not downloaded' do

--- a/spec/functional/fetchers/path_fetcher_spec.rb
+++ b/spec/functional/fetchers/path_fetcher_spec.rb
@@ -10,11 +10,19 @@ module Omnibus
       { path: source_path }
     end
 
+    let(:manifest_entry) do
+      double(Omnibus::ManifestEntry,
+             name: 'pathelogical',
+             locked_version: nil,
+             locked_source: source)
+    end
+
     before do
       create_directory(source_path)
     end
 
-    subject { described_class.new(software) }
+    subject { described_class.new(manifest_entry, project_dir, build_dir) }
+
 
     describe '#fetch_required?' do
       context 'when the directories have different files' do
@@ -91,6 +99,12 @@ module Omnibus
 
       it 'includes the source_path and shasum' do
         expect(subject.version_for_cache).to eq("path:#{source_path}|shasum:#{sha}")
+      end
+    end
+
+    describe "#resolve_version" do
+      it "just returns the version" do
+        expect(NetFetcher.resolve_version("1.2.3", source)).to eq("1.2.3")
       end
     end
   end

--- a/spec/unit/fetcher_spec.rb
+++ b/spec/unit/fetcher_spec.rb
@@ -7,37 +7,23 @@ module Omnibus
     let(:project_dir) { '/project/dir' }
     let(:build_dir) { '/build/dir' }
 
-    let(:software) do
+    let(:manifest_entry) do
       double(Software,
         name: 'software',
-        version: 'master',
-        source: { path: source_path },
-        project_dir: project_dir,
-        build_dir: project_dir,
-      )
+        locked_version: '31aedfs',
+        locked_source: { path: source_path })
     end
 
-    subject { described_class.new(software) }
+    subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
 
-    describe "#use_manifest_entry" do
-      let(:source) {{:git => "git://git.example.com/important/stuff"}}
-      let(:version) { 'efde208366abd0f91419d8a54b45e3f6e0540105' }
-      let(:manifest_entry) {
-        Omnibus::ManifestEntry.new("zlib",
-                                   { :locked_version => version,
-                                     :locked_source => source})
-
-      }
-
+    describe "#initialize" do
       it "sets the resovled_version to the locked_version" do
-        subject.use_manifest_entry(manifest_entry)
-        expect(subject.resolved_version).to eq(version)
+        expect(subject.resolved_version).to eq("31aedfs")
       end
 
       it "sets the source to the locked_source" do
-        subject.use_manifest_entry(manifest_entry)
-        expect(subject.source).to eq(source)
+        expect(subject.source).to eq({ path: source_path})
       end
     end
   end

--- a/spec/unit/fetcher_spec.rb
+++ b/spec/unit/fetcher_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'omnibus/manifest_entry'
+
+module Omnibus
+  describe Fetcher do
+        let(:source_path) { '/local/path' }
+    let(:project_dir) { '/project/dir' }
+    let(:build_dir) { '/build/dir' }
+
+    let(:software) do
+      double(Software,
+        name: 'software',
+        version: 'master',
+        source: { path: source_path },
+        project_dir: project_dir,
+        build_dir: project_dir,
+      )
+    end
+
+    subject { described_class.new(software) }
+
+
+    describe "#use_manifest_entry" do
+      let(:source) {{:git => "git://git.example.com/important/stuff"}}
+      let(:version) { 'efde208366abd0f91419d8a54b45e3f6e0540105' }
+      let(:manifest_entry) {
+        Omnibus::ManifestEntry.new("zlib",
+                                   { :locked_version => version,
+                                     :locked_source => source})
+
+      }
+
+      it "sets the resovled_version to the locked_version" do
+        subject.use_manifest_entry(manifest_entry)
+        expect(subject.resolved_version).to eq(version)
+      end
+
+      it "sets the source to the locked_source" do
+        subject.use_manifest_entry(manifest_entry)
+        expect(subject.source).to eq(source)
+      end
+    end
+  end
+end

--- a/spec/unit/fetchers/git_fetcher_spec.rb
+++ b/spec/unit/fetchers/git_fetcher_spec.rb
@@ -6,17 +6,14 @@ module Omnibus
     let(:project_dir) { '/project/dir' }
     let(:build_dir) { '/build/dir' }
 
-    let(:software) do
-      double(Software,
+    let(:manifest_entry) do
+      double(ManifestEntry,
         name: 'software',
-        version: 'master',
-        source: { path: source_path },
-        project_dir: project_dir,
-        build_dir: project_dir,
-      )
+        locked_version: '123lasd1234',
+        locked_source: { path: source_path })
     end
 
-    subject { described_class.new(software) }
+    subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
     describe '#fetch_required?' do
 

--- a/spec/unit/fetchers/git_fetcher_spec.rb
+++ b/spec/unit/fetchers/git_fetcher_spec.rb
@@ -4,18 +4,22 @@ module Omnibus
   describe GitFetcher do
     let(:source_path) { '/local/path' }
     let(:project_dir) { '/project/dir' }
+    let(:build_dir) { '/build/dir' }
 
     let(:software) do
       double(Software,
         name: 'software',
+        version: 'master',
         source: { path: source_path },
         project_dir: project_dir,
+        build_dir: project_dir,
       )
     end
 
     subject { described_class.new(software) }
 
     describe '#fetch_required?' do
+
       context 'when the repository is not cloned' do
         before { allow(subject).to receive(:cloned?).and_return(false) }
 
@@ -26,7 +30,7 @@ module Omnibus
 
       context 'when the repository is cloned' do
         before { allow(subject).to receive(:cloned?).and_return(true) }
-
+        before { allow(subject).to receive(:resolved_version).and_return("12341235")}
         context 'when the revision is difference' do
           before { allow(subject).to receive(:same_revision?).and_return(false) }
 
@@ -97,6 +101,7 @@ module Omnibus
         allow(subject).to receive(:git_fetch)
         allow(subject).to receive(:git_clone)
         allow(subject).to receive(:git_checkout)
+        allow(subject).to receive(:resolved_version).and_return("134aeba31234")
       end
 
       context 'when the repository is cloned' do
@@ -105,8 +110,8 @@ module Omnibus
         context 'when the revision is different' do
           before { allow(subject).to receive(:same_revision?).and_return(false) }
 
-          it 'fetches and resets' do
-            expect(subject).to receive(:git_fetch)
+          it 'fetches and resets to the resolved_version' do
+            expect(subject).to receive(:git_fetch).with("134aeba31234")
             subject.fetch
           end
         end
@@ -130,7 +135,7 @@ module Omnibus
         end
 
         it 'checks out the correct revision' do
-          expect(subject).to receive(:git_checkout).once
+          expect(subject).to receive(:git_checkout).with("134aeba31234")
           subject.fetch
         end
       end

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -3,15 +3,18 @@ require 'spec_helper'
 module Omnibus
   describe NetFetcher do
     let(:project_dir) { '/tmp/project' }
+    let(:build_dir) { '/tmp/build' }
 
     let(:software) do
       double(Software,
         downloaded_file: 'file.tar.gz',
         name: 'file',
+        version: nil,
         source: { url: 'https://get.example.com/file.tar.gz', md5: 'abcd1234' },
         checksum: 'abc123',
         source_uri: 'http://example.com/file.tar.gz',
         project_dir: project_dir,
+        build_dir: build_dir,
       )
     end
 

--- a/spec/unit/fetchers/path_fetcher_spec.rb
+++ b/spec/unit/fetchers/path_fetcher_spec.rb
@@ -6,17 +6,14 @@ module Omnibus
     let(:project_dir) { '/project/dir' }
     let(:build_dir) { '/build/dir' }
 
-    let(:software) do
-      double(Software,
+    let(:manifest_entry) do
+      double(ManifestEntry,
         name: 'software',
-        version: nil,
-        source: { path: source_path },
-        project_dir: project_dir,
-        build_dir: build_dir
-      )
+        locked_version: nil,
+        locked_source: { path: source_path })
     end
 
-    subject { described_class.new(software) }
+    subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
     describe '#fetch_required?' do
       context 'when the SHAs match' do

--- a/spec/unit/fetchers/path_fetcher_spec.rb
+++ b/spec/unit/fetchers/path_fetcher_spec.rb
@@ -4,12 +4,15 @@ module Omnibus
   describe PathFetcher do
     let(:source_path) { '/local/path' }
     let(:project_dir) { '/project/dir' }
+    let(:build_dir) { '/build/dir' }
 
     let(:software) do
       double(Software,
         name: 'software',
+        version: nil,
         source: { path: source_path },
         project_dir: project_dir,
+        build_dir: build_dir
       )
     end
 

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+require 'omnibus/manifest'
+require 'omnibus/manifest_entry'
+
+module Omnibus
+  describe Manifest do
+    subject { described_class.new }
+
+    describe "#add" do
+      it "stores manifest entries" do
+        me = ManifestEntry.new("womabt", {})
+        expect {subject.add("wombat", me)}.to_not raise_error
+      end
+
+      it "raises an error if it isn't given a ManifestEntry" do
+        expect {subject.add("foobar", {})}.to raise_error Manifest::NotAManifestEntry
+      end
+    end
+
+    describe "#entry_for" do
+      it "returns a ManifestEntry for the requested software" do
+        me = ManifestEntry.new("foobar", {})
+        subject.add("foobar", me)
+        expect(subject.entry_for("foobar")).to eq(me)
+      end
+
+      it "raises an error if no such manifest entry exists" do
+        expect {subject.entry_for("non-existant-entry")}.to raise_error Manifest::MissingManifestEntry
+      end
+    end
+
+    describe "#to_hash" do
+      it "returns a Hash containg the current manifest format" do
+        expect(subject.to_hash['manifest_format']).to eq(Manifest::LATEST_MANIFEST_FORMAT)
+      end
+
+      it "includes entries for software in the manifest" do
+        subject.add("foobar", ManifestEntry.new("foobar", {}))
+        expect(subject.to_hash['software']).to have_key("foobar")
+      end
+
+      it "converts the manifest entries to hashes" do
+        subject.add("foobar", ManifestEntry.new("foobar", {}))
+        expect(subject.to_hash['software']['foobar']).to be_a(Hash)
+      end
+    end
+
+    describe "#from_hash" do
+      let(:manifest) {
+        { "manifest_format" => 1,
+          "software" => {
+            "zlib" => {
+              "locked_source" => {
+                "url" => "an_url"
+              },
+              "locked_version" => "new.newer",
+              "source_type" => "url",
+              "described_version" => "new.newer"}}}
+      }
+
+      let(:v2_manifest) {
+        {"manifest_format" => 2}
+      }
+
+      it "returns a manifest from a hash" do
+        expect(Manifest.from_hash(manifest)).to be_a(Manifest)
+      end
+
+      it "normalizes the source to use symbols" do
+        expect(Manifest.from_hash(manifest).entry_for("zlib").locked_source).to eq({:url => "an_url"})
+      end
+
+      it "raises an error if it doesn't recognize the manifest version" do
+        expect{Manifest.from_hash(v2_manifest)}.to raise_error Manifest::InvalidManifestFormat
+      end
+    end
+  end
+end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -41,7 +41,8 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :exclude, %|exclude 'hamlet'|
     it_behaves_like 'a cleanroom setter', :config_file, %|config_file '/path/to/config.rb'|
     it_behaves_like 'a cleanroom setter', :extra_package_file, %|extra_package_file '/path/to/asset'|
-
+    it_behaves_like 'a cleanroom setter', :with_text_manifest, %|with_text_manifest '/path/to/manifest.txt'|
+    it_behaves_like 'a cleanroom setter', :with_json_manifest, %|with_text_manifest '/path/to/manifest.txt'|
     it_behaves_like 'a cleanroom getter', :files_path
 
     describe 'basics' do

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -41,8 +41,8 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :exclude, %|exclude 'hamlet'|
     it_behaves_like 'a cleanroom setter', :config_file, %|config_file '/path/to/config.rb'|
     it_behaves_like 'a cleanroom setter', :extra_package_file, %|extra_package_file '/path/to/asset'|
-    it_behaves_like 'a cleanroom setter', :with_text_manifest, %|with_text_manifest '/path/to/manifest.txt'|
-    it_behaves_like 'a cleanroom setter', :with_json_manifest, %|with_text_manifest '/path/to/manifest.txt'|
+    it_behaves_like 'a cleanroom setter', :text_manifest_path, %|text_manifest_path '/path/to/manifest.txt'|
+    it_behaves_like 'a cleanroom setter', :json_manifest_path, %|json_manifest_path '/path/to/manifest.txt'|
     it_behaves_like 'a cleanroom getter', :files_path
 
     describe 'basics' do


### PR DESCRIPTION
This changeset introduces the following features:

  - Omnibus creates a version manifest in a text format (intended
    for humans) without depending on omnibus-software. 

  - Omnibus creates a version manifest in a JSON format (intended
    for machines). 

  - Omnibus can ingest a user-provided, JSON-formatted version
    manifest during the build process. The JSON manifest will be
    used to lock the software sources and version used when
    fetching. Please see the following sections for more details.

* Manifest Ingestion

Ingesting an externally created manifest is NOT intended to be the
standard mode of operation for an omnibus built project. Most projects
should continue to use the `default_version` method of software
definitions and the `override` method of project definition to control
which version of a software get built.

This feature is included to support improvements to the build
pipelines for opscode-omnibus (Chef Server) and other Chef Software,
Inc managed projects by:

  - allowing the opscode-omnibus software to use floating constraints,
    ensuring new features in API services are immediately integrated
    into the Chef Server package.

while still

  - allowing users to rebuild a specific version of an omnibus built
    project from source.

  - ensuring all versions of all software in a given build are captured
    in a format that can be commited to source control.

  - providing a possible base for automated generation of other
    release-related artifacts such as change logs.

Chef Software, Inc reviewers should note that the manifest will NOT be
ingested at any point in the standard build pipeline.

* Text Manifest Format

For backwards compatibility, the text version manifest is produced in
exactly the same manner as the previous version manifest produced by
omnibus-software.

* JSON Manifest Format v1

The first version of the manifest format takes the following form:

```json
{
    "manifest_format" : MANIFEST_FORMAT_NUMBER,
    "software" : {
    "SOFTWARE_NAME" : {
      "described_version": STRING(see below)
      "locked_version": STRING(see below)
      "locked_source": HASH(see below)
      "source_type": "path"|"url"|"git"|"project_local"
    }
}
```

  - `described_version` is the user-specified version of the software
    (via default_version or an override) at the time of the build.

  - `locked_version` is the calculated version of the source artifact
    that was fetched. For git sources this will be a git ref and may
    differ from the described_version.

  - `locked_source` is the source parameters used to fetch the source
    artifact.

  - `source_type` specifies the type of source fetcher that was used.

Only non-null fields are present in the manifest.  Software with a
`project_local` source type may not have a source or either version
field. Software with a `path` source type may not have a either
version field.

* Build Reproducibility

When ingesting a manifest, omnibus will do the following:

- Use the `locked_version` and `locked_source` when fetching the build
artifact.

- Proceed with the usual omnibus build procedures

This procedure does NOT guarantee that a given build will produce a
functionally equivalent artifact.  This is especially true for

- projects using path or project_local based software

- projects using software where the build steps also pull down new
software (bundle install)

- projects using software where the build steps produce different
output depending on environmental factors (time, state of the build
machine, etc)