### PR TITLE
Fix spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Additionally, there are a number of DSL methods avaiable inside the `build` bloc
 
 For more DSL methods, please consult the [`Builder` documentation](http://rubydoc.info/github/opscode/omnibus/Omnibus/Builder).
 
-You can support building multiple verisons of the same software in the same software definition file using the `version` method and giving a block:
+You can support building multiple versions of the same software in the same software definition file using the `version` method and giving a block:
 
 ```ruby
 name "ruby"


### PR DESCRIPTION
Noticed a simple spelling error when reading through the readme. Fixed in this pr.

"verisons" => "versions"