### PR TITLE
Add `omnibus manifest PROJ` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,22 @@ $PWD/config/software/foo.rb
 
 The first instance of `foo.rb` that is encountered will be used. Please note that **local** (vendored) softare definitions take precedence!
 
+Version Manifest
+----------------
+
+Git-based software definitions may specify branches as their
+default_version. In this case, the exact git revision to use will be
+determined at build-time unless a project override (see below) or
+external version manifest is used. To generate a version manifest use
+the `omnibus manifest` command:
+
+```
+omnibus manifest PROJECT -l warn
+```
+
+This will output a JSON-formatted manifest containing the resolved
+version of every software definition.
+
 
 Caveats
 -------

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -90,6 +90,16 @@ module Omnibus
     end
 
     #
+    # Generate a version manifest for the given project definition
+    #
+    #   $ omnibus manifest PROJECT
+    #
+    desc 'manifest PROJECT', 'Print a manifest for the given Omnibus project'
+    def manifest(name)
+      puts JSON.pretty_generate(Project.load(name).built_manifest.to_hash)
+    end
+
+    #
     # Perform cache management functions.
     #
     #   $ omnibus cache list

--- a/lib/omnibus/generator_files/README.md.erb
+++ b/lib/omnibus/generator_files/README.md.erb
@@ -63,6 +63,23 @@ Full help for the Omnibus command line interface can be accessed with the
 $ bin/omnibus help
 ```
 
+Version Manifest
+----------------
+
+Git-based software definitions may specify branches as their
+default_version. In this case, the exact git revision to use will be
+determined at build-time unless a project override (see below) or
+external version manifest is used.  To generate a version manifest use
+the `omnibus manifest` command:
+
+```
+omnibus manifest PROJECT -l warn
+```
+
+This will output a JSON-formatted manifest containing the resolved
+version of every software definition.
+
+
 Kitchen-based Build Environment
 -------------------------------
 Every Omnibus project ships will a project-specific


### PR DESCRIPTION
This command allows you to generate a manifest without doing a
complete build.  It can be useful for diagnostics or for getting a
sense of what is going to change on the next build.