### PR TITLE
Use File.expand_path in the pkg packagers

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -179,7 +179,7 @@ module Omnibus
       if null?(val)
         @install_dir || raise(MissingRequiredAttribute.new(self, :install_dir, "/opt/chef"))
       else
-        @install_dir = val.tr('\\', "/").squeeze("/").chomp("/")
+        @install_dir = File.expand_path(val.tr('\\', "/").squeeze("/").chomp("/"))
       end
     end
     expose :install_dir

--- a/spec/support/ohai_helpers.rb
+++ b/spec/support/ohai_helpers.rb
@@ -11,10 +11,18 @@ module Omnibus
         ohai = Mash.from_hash(Fauxhai.mock(options, &block).data)
         allow(Ohai).to receive(:ohai).and_return(ohai)
 
-        # If we asked for Windows, we should also specify that magical
-        # +File::ALT_SEPARATOR+ variable
         if options[:platform] && options[:platform] == "windows"
+          # If we asked for Windows, we should also specify that magical
+          # +File::ALT_SEPARATOR+ variable
           stub_const("File::ALT_SEPARATOR", '\\')
+          # And don't actually perform expand_path because otherwise,
+          # C:/foo will turn into "/Users/foo/bar/baz/C:/foo" on non-windows
+          # and /foo will turn into "C:/foo" on windows.
+          # Since most paths in our tests are unixy-paths, we'll turn off
+          # expand_path just on windows by default.
+          if windows? && options[:enable_expand_path] != false
+            allow(File).to receive(:expand_path) { |arg| arg }
+          end
         end
       end
     end

--- a/spec/unit/packagers/msi_spec.rb
+++ b/spec/unit/packagers/msi_spec.rb
@@ -18,7 +18,7 @@ module Omnibus
     let(:project_root) { File.join(tmp_path, "project/root") }
     let(:package_dir)  { File.join(tmp_path, "package/dir") }
     let(:staging_dir)  { File.join(tmp_path, "staging/dir") }
-    let(:install_dir)  { "C:/project" }
+    let(:install_dir) { "/project" }
 
     before do
       Config.project_root(project_root)
@@ -154,7 +154,7 @@ module Omnibus
       end
 
       it "has the correct content" do
-        project.install_dir("C:/foo/bar/blip")
+        project.install_dir("/foo/bar/blip")
         subject.write_source_file
         contents = File.read("#{staging_dir}/source.wxs")
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -93,7 +93,10 @@ module Omnibus
         expect(subject.install_dir).to eq("/opt/chef")
       end
 
-      it "converts Windows slashes to Ruby ones" do
+      # Project#install_dir calls File.expand_path which will
+      # cause this test to fail on unix-like systems where Ruby
+      # doesn't handle the drive-letter in expand_path
+      it "converts Windows slashes to Ruby ones", :windows_only => true do
         subject.install_dir('C:\\chef\\chefdk')
         expect(subject.install_dir).to eq("C:/chef/chefdk")
       end
@@ -101,6 +104,11 @@ module Omnibus
       it "removes trailing slashes" do
         subject.install_dir("/opt/chef//")
         expect(subject.install_dir).to eq("/opt/chef")
+      end
+
+      it "expands relative paths" do
+        subject.install_dir("./local")
+        expect(subject.install_dir).to eq("#{Dir.pwd}/local")
       end
 
       it "is a DSL method" do


### PR DESCRIPTION
When building a project with the base_dir set to "./local" for test
builds, the pkg packager will fail since the underlying command
doesn't understand relative paths.
