### PR TITLE
Respect append_timestamp config when constructing a version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Omnibus CHANGELOG
 =================
+v4.1.0 (Unreleased)
+### Bug Fixes
+- Config.append_timestamp is now properly handled by the build_version
+  DSL.  For some users, this may introduce a change in behavior.  To
+  revert to the old behavior set append_timestamp to false in
+  `omnibus.rb` or use --override append_timestamp:false at the command
+  line.
+
 
 v4.0.0 (December 15, 2014)
 --------------------------

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Some DSL methods available include:
 | `package`         | Invoke a packager-specific DSL              |
 | `compress`        | Invoke a compressor-specific DSL            |
 
+By default a timestamp is appended to the build_version.  You can turn
+this behavior off by setting `append_timestamp` to `false` in your
+configuration file or using `--override append_timestamp:false` at the
+command line.
+
 For more information, please see the [`Project` documentation](http://rubydoc.info/github/opscode/omnibus/Omnibus/Project).
 
 ### Software

--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -18,6 +18,7 @@ Given(/^I have an omnibus project named "(.+)"$/) do |name|
 
   write_file('omnibus.rb', <<-EOH.gsub(/^ {4}/, ''))
     # Build configuration
+    append_timestamp false
     cache_dir     './local/omnibus/cache'
     git_cache_dir './local/omnibus/cache/git_cache'
     source_dir    './local/omnibus/src'

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -46,6 +46,10 @@ module Omnibus
       def semver
         new.semver
       end
+
+      def build_start_time
+        new.build_start_time
+      end
     end
 
     # Create a new BuildVersion
@@ -102,7 +106,7 @@ module Omnibus
       #
       # format: YYYYMMDDHHMMSS example: 20130131123345
       if Config.append_timestamp
-        build_version_items << build_start_time.strftime(TIMESTAMP_FORMAT)
+        build_version_items << build_start_time
       end
 
       # We'll append the git describe information unless we are sitting right
@@ -118,6 +122,26 @@ module Omnibus
       end
 
       build_tag
+    end
+
+    # We'll attempt to retrive the timestamp from the Jenkin's set BUILD_ID
+    # environment variable. This will ensure platform specfic packages for the
+    # same build will share the same timestamp.
+    def build_start_time
+      @build_start_time ||= begin
+                              if ENV['BUILD_ID']
+                                begin
+                                  Time.strptime(ENV['BUILD_ID'], '%Y-%m-%d_%H-%M-%S')
+                                rescue ArgumentError
+                                  error_message =  'BUILD_ID environment variable '
+                                  error_message << 'should be in YYYY-MM-DD_hh-mm-ss '
+                                  error_message << 'format.'
+                                  raise ArgumentError, error_message
+                                end
+                              else
+                                Time.now.utc
+                              end
+                            end.strftime(TIMESTAMP_FORMAT)
     end
 
     # Generates a version string by running
@@ -236,26 +260,6 @@ module Omnibus
     end
 
     private
-
-    # We'll attempt to retrive the timestamp from the Jenkin's set BUILD_ID
-    # environment variable. This will ensure platform specfic packages for the
-    # same build will share the same timestamp.
-    def build_start_time
-      @build_start_time ||= begin
-                              if ENV['BUILD_ID']
-                                begin
-                                  Time.strptime(ENV['BUILD_ID'], '%Y-%m-%d_%H-%M-%S')
-                                rescue ArgumentError
-                                  error_message =  'BUILD_ID environment variable '
-                                  error_message << 'should be in YYYY-MM-DD_hh-mm-ss '
-                                  error_message << 'format.'
-                                  raise ArgumentError, error_message
-                                end
-                              else
-                                Time.now.utc
-                              end
-                            end
-    end
 
     # Pulls out the major, minor, and patch components from the output
     # of {#git_describe}.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
 
     # Reset config
     Omnibus.reset!
+    Omnibus::Config.append_timestamp(false)
 
     # Clear the tmp_path on each run
     FileUtils.rm_rf(tmp_path)

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -9,6 +9,7 @@ module Omnibus
     subject(:build_version) { described_class.new }
 
     before do
+      Config.append_timestamp(true)
       allow_any_instance_of(described_class).to receive(:shellout)
         .and_return(double('ouput', stdout: git_describe, exitstatus: 0))
     end
@@ -139,7 +140,6 @@ module Omnibus
 
       describe 'appending a timestamp' do
         let(:git_describe) { '11.0.0-alpha-3-207-g694b062' }
-
         context 'by default' do
           it 'appends a timestamp' do
             expect(build_version.semver).to match(/11.0.0-alpha.3\+#{today_string}[0-9]+.git.207.694b062/)
@@ -147,8 +147,6 @@ module Omnibus
         end
 
         context 'when Config.append_timestamp is true' do
-          before { Config.append_timestamp(true) }
-
           it 'appends a timestamp' do
             expect(build_version.semver).to match(/11.0.0-alpha.3\+#{today_string}[0-9]+.git.207.694b062/)
           end
@@ -156,7 +154,6 @@ module Omnibus
 
         context 'when Config.append_timestamp is false' do
           before { Config.append_timestamp(false) }
-
           it 'does not append a timestamp' do
             expect(build_version.semver).to match(/11.0.0-alpha.3\+git.207.694b062/)
           end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -9,6 +9,7 @@ module Omnibus
     end
 
     before do
+      Config.reset!
       # Don't expand paths on the build system. Otherwise, you will end up with
       # paths like +\\Users\\you\\Development\\omnibus-ruby\\C:/omnibus-ruby+
       # when testing on "other" operating systems


### PR DESCRIPTION
This helper method allows users to specify a version as:

build_version Omnibus::BuildVersion.static_with_timestamp("1.3.4")

which will append a timestamp to the build version.  This may be
helpful for build pipelines in which you may have multiple builds with
the same, unreleased, user-supplied version.