### PR TITLE
Add build_version and build_git_revision to manifest

### DIFF
--- a/lib/omnibus/git_repository.rb
+++ b/lib/omnibus/git_repository.rb
@@ -16,6 +16,10 @@ module Omnibus
       formatted_log_between(start_ref, end_ref, '%B').lines.to_a
     end
 
+    def revision
+      git("rev-parse HEAD").strip
+    end
+
     def latest_tag
       git('describe --abbrev=0').chomp
     end

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -26,8 +26,11 @@ module Omnibus
 
     LATEST_MANIFEST_FORMAT = 1
 
-    def initialize
+    attr_reader :build_version, :build_git_revision
+    def initialize(version=nil, git_rev=nil)
       @data = {}
+      @build_version = version
+      @build_git_revision = git_rev
     end
 
     def entry_for(name)
@@ -66,10 +69,13 @@ module Omnibus
         memo[k] = v.to_hash
         memo
       end
-      {
+      ret = {
         'manifest_format' => LATEST_MANIFEST_FORMAT,
         'software' => software_hash
       }
+      ret['build_version'] = build_version if build_version
+      ret['build_git_revision'] = build_git_revision if build_git_revision
+      ret
     end
 
     #

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -376,6 +376,24 @@ module Omnibus
     end
     expose :build_version
 
+
+    #
+    # Set or retrieve the git revision of the omnibus
+    # project being built.
+    #
+    # If not set by the user, and the current workding directory is a
+    # git directory, it will return the revision of the current
+    # working directory.
+    #
+    def build_git_revision(val = NULL)
+      if null?(val)
+        @build_git_revision ||= get_local_revision
+      else
+        @build_git_revision = val
+      end
+    end
+    expose :build_git_revision
+
     #
     # Set or retrieve the build iteration of the project. Defaults to +1+ if not
     # otherwise set.
@@ -965,7 +983,7 @@ module Omnibus
     #
     def built_manifest
       log.info(log_key) { "Building version manifest" }
-      m = Omnibus::Manifest.new
+      m = Omnibus::Manifest.new(build_version, build_git_revision)
       softwares.each do |software|
         m.add(software.name, software.manifest_entry)
       end
@@ -1134,6 +1152,13 @@ module Omnibus
 
     private
 
+    def get_local_revision
+      if File.directory?(".git")
+        GitRepository.new("./").revision
+      else
+        "unknown"
+      end
+    end
     #
     # The log key for this project, overriden to include the name of the
     # project for build output.

--- a/spec/unit/git_repository_spec.rb
+++ b/spec/unit/git_repository_spec.rb
@@ -31,6 +31,12 @@ module Omnibus
       end
     end
 
+    describe "#revision" do
+      it "returns the current revision at HEAD" do
+        expect(git_repo.revision).to eq("632501dde2c41f3bdd988b818b4c008e2ff398dc")
+      end
+    end
+
     describe "#file_at_revision" do
       it "returns the text of the specified file in a repository at a given revision" do
         expect(git_repo.file_at_revision("configure", "1.0")).to eq("echo \"Done!\"")

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -63,6 +63,14 @@ module Omnibus
         subject.add("foobar", ManifestEntry.new("foobar", {}))
         expect(subject.to_hash['software']['foobar']).to be_a(Hash)
       end
+
+      it "returns a build_version if one was passed in" do
+        expect(Omnibus::Manifest.new("1.2.3").to_hash["build_version"]).to eq("1.2.3")
+      end
+
+      it "returns a build_git_revision if one was passed in" do
+        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8").to_hash["build_git_revision"]).to eq("e8e8e8")
+      end
     end
 
     describe "#from_hash" do

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -43,6 +43,7 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :extra_package_file, %|extra_package_file '/path/to/asset'|
     it_behaves_like 'a cleanroom setter', :text_manifest_path, %|text_manifest_path '/path/to/manifest.txt'|
     it_behaves_like 'a cleanroom setter', :json_manifest_path, %|json_manifest_path '/path/to/manifest.txt'|
+    it_behaves_like 'a cleanroom setter', :build_git_revision, %|build_git_revision 'wombats'|
     it_behaves_like 'a cleanroom getter', :files_path
 
     describe 'basics' do


### PR DESCRIPTION
This commit adds the build_version and the build_git_revision to the
version-manifest.  The goal of these additions is to make it possible
to tag and generate a changelog for a given build using two
version-manifest.json files and the omnibus project's source code
repository.