### PR TITLE
dpkg uses arch name ppc64el (instead of ppc64le) for little endian.

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -406,6 +406,8 @@ module Omnibus
         else
           'armv6l'
         end
+      when 'ppc64le'
+        'ppc64el'  #dpkg --print-architecture = ppc64el
       else
         Ohai['kernel']['machine']
       end

--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -407,6 +407,9 @@ module Omnibus
           'armv6l'
         end
       when 'ppc64le'
+        # Debian prefers to use ppc64el for little endian architecture name 
+        # where as others like gnutools/rhel use ppc64le( note the last 2 chars)
+        # see http://linux.debian.ports.powerpc.narkive.com/8eeWSBtZ/switching-ppc64el-port-name-to-ppc64le
         'ppc64el'  #dpkg --print-architecture = ppc64el
       else
         Ohai['kernel']['machine']

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -344,6 +344,18 @@ module Omnibus
         end
       end
 
+      context 'when ppc64le' do
+        before do
+          stub_ohai(platform: 'ubuntu', version: '14.04') do |data|
+            data['kernel']['machine'] = 'ppc64le'
+          end
+        end
+
+        it 'returns ppc64el' do
+          expect(subject.safe_architecture).to eq('ppc64el')
+        end
+      end
+
       context 'on Raspbian' do
         before do
           # There's no Raspbian in Fauxhai :(


### PR DESCRIPTION
dpkg uses arch name ppc64el (instead of ppc64le) for little endian.
