### PR TITLE
Cache Builder#shasum before Builder#build to ensure consistent result

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -580,7 +580,8 @@ module Omnibus
     #
     def build
       log.info(log_key) { 'Starting build' }
-
+      shasum # ensure shashum is calculated before build since the build can alter the shasum
+      log.internal(log_key) { 'Cached builder checksum before build: #{shasum}'}
       if software.overridden?
         log.info(log_key) do
           "Version overridden from #{software.default_version} to "\

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -519,7 +519,7 @@ module Omnibus
           }
         )
       end
- 
+
       env.merge(compiler_flags).
         merge(extra_linker_flags).
         # always want to favor pkg-config from embedded location to not hose

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -180,5 +180,38 @@ module Omnibus
         subject.make(timeout: 3600)
       end
     end
+
+    describe "#shasum" do
+      let(:build_step) do
+        Proc.new {
+          block do
+            command("true")
+          end
+        }
+      end
+
+      let(:tmp_dir) { Dir.mktmpdir }
+      after { FileUtils.rmdir(tmp_dir) }
+
+      let(:software) do
+        double(Software,
+               name: 'chefdk',
+               install_dir: tmp_dir,
+               project_dir: tmp_dir,
+               overridden?: false)
+      end
+
+      let(:before_build_shasum) do
+        b = described_class.new(software)
+        b.evaluate(&build_step)
+        b.shasum
+      end
+
+      it "returns the same value when called before or after the build" do
+        subject.evaluate(&build_step)
+        subject.build
+        expect(subject.shasum).to eq(before_build_shasum)
+      end
+    end
   end
 end


### PR DESCRIPTION
The Builder#shasum is based, in-part, on the build_commands in the
instance of Builder. This is problematic because the `block` DSL
method allows users to use other Builder DSL methods inside of it, all
of which mutate the build_command array when #build is called. Thus, a
given builder will return a different shasum before and after build is
called.

Caching shashum at the beginning of build fixes this problem, but has
a major drawback. Namely, two builders with the same shashum might
execute different commands.

This problem is partially mitigated by the fact that the builder
shashum is just a part of the software shasum, which will typically
include the actual text of the software definition as part of its
digest.

This will not catch software definitions where the build steps can
produce different based on the system state, such as this:

```
  block do
    Dir.glob("#{install_dir}/embedded/apath/bin/*").sort.each do |f|
      link bin, "#{install_dir}/embedded/bin/#{File.basename(f)}"
    end
  end
```

However, that will always be a problem since we allow pure Ruby in our
build steps.

Fixes #450