### PR TITLE
Override equality operator for ManifestEntry

### DIFF
--- a/lib/omnibus/manifest_entry.rb
+++ b/lib/omnibus/manifest_entry.rb
@@ -33,5 +33,11 @@ module Omnibus
         "described_version" => @described_version
       }
     end
+
+    def ==(other)
+      if other.is_a?(ManifestEntry)
+        (self.to_hash == other.to_hash) && (self.name == other.name)
+      end
+    end
   end
 end

--- a/spec/unit/manifest_diff_spec.rb
+++ b/spec/unit/manifest_diff_spec.rb
@@ -16,6 +16,7 @@ module Omnibus
       m = Omnibus::Manifest.new()
       m.add("foo", manifest_entry_for("foo", "1.2.4", "deadbeef"))
       m.add("bar", manifest_entry_for("bar", "1.2.4", "deadbeef"))
+      m.add("baz", manifest_entry_for("baz", "1.2.4", "deadbeef"))
       m
     end
 
@@ -23,6 +24,7 @@ module Omnibus
       m = Omnibus::Manifest.new()
       m.add("foo", manifest_entry_for("foo", "1.2.5", "deadbea0"))
       m.add("baz", manifest_entry_for("baz", "1.2.4", "deadbeef"))
+      m.add("quux", manifest_entry_for("quux", "1.2.4", "deadbeef"))
       m
     end
 
@@ -50,10 +52,10 @@ module Omnibus
 
       describe "#added" do
         it "returns items that did not exist in the first manifest but do exist in the second" do
-          expect(subject.added).to eq([{ :name => "baz",
+          expect(subject.added).to eq([{ :name => "quux",
                                          :new_version => "deadbeef",
                                          :source_type => :git,
-                                         :source => {:git => "git://baz@example.com"}
+                                         :source => {:git => "git://quux@example.com"}
                                        }])
         end
       end


### PR DESCRIPTION
Prior to this, we simply tested basic object identity, which would
result in many "updated" dependencies like this:

```
* libossp-uuid (1.6.2 -> 1.6.2)
* postgresql (9.3.5 -> 9.3.5)
* popt (1.16 -> 1.16)
* cpanminus (1.7004 -> 1.7004)
* rsync (3.0.9 -> 3.0.9)
* libyaml (0.1.6 -> 0.1.6)
```

Now, equality of `ManifestEntry` objects is in terms of their
data. This will remove the spurious "updates" above

With tests!