### PR TITLE
ignore ctag files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,14 @@ Gemfile.lock
 *.tmproject
 tmtags
 
+# avoid generic ctags files too
+tags
+gems.tags
+gemtags
+.tags
+.gem.tags
+.gemtags
+.tags_sorted_by_file
 
 ### SublimeText ###
 # workspace files are user-specific


### PR DESCRIPTION
ignore ctag files for gems
ignore hidden ctag files
names for the file aren't connonical
because: grammar