### PR TITLE
Fix to deb md5sums format for 'dpkg --verify'

### DIFF
--- a/resources/deb/md5sums.erb
+++ b/resources/deb/md5sums.erb
@@ -1,3 +1,3 @@
 <% md5sums.each do |path, checksum| -%>
-<%= checksum %> <%= path %>
+<%= checksum %>  <%= path %>
 <% end -%>


### PR DESCRIPTION
In the dpkg md5sums file, the hash and filename must be separated from
the filename by two spaces, otherwise the `dpkg --verify` command will
fail with the following error:

  dpkg: error: control file 'md5sums' missing value separator

This change modifies the md5sums template to increase the separator from
a single space to the required two spaces.