### PR TITLE
Add missing json gem when running test.

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'json'
   gem.add_development_dependency 'appbundler'
 end


### PR DESCRIPTION
Unable to run test on master branch as json was missing.
```
[X@sdev] ~/dev/omnibus-ruby (master<>)$ ruby -v
ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-linux]
[X@sdev] ~/dev/omnibus-ruby (master<>)$ bundle exec rake
/usr/bin/ruby -I/home/X/.gem/ruby/gems/rspec-core-3.2.3/lib:/home/X/.gem/ruby/gems/rspec-support-3.2.2/lib /home/X/.gem/ruby/gems/rspec-core-3.2.3/exe/rspec --pattern spec/unit/\*\*/\*_spec.rb --color --format progress
/home/X/dev/omnibus-ruby/lib/omnibus.rb:21:in `require': cannot load such file -- json (LoadError)
from /home/X/dev/omnibus-ruby/lib/omnibus.rb:21:in `<top (required)>'
from /home/X/dev/omnibus-ruby/spec/spec_helper.rb:7:in `require'
from /home/X/dev/omnibus-ruby/spec/spec_helper.rb:7:in `<top (required)>'
from /home/X/dev/omnibus-ruby/spec/unit/build_version_dsl_spec.rb:1:in `require'
from /home/X/dev/omnibus-ruby/spec/unit/build_version_dsl_spec.rb:1:in `<top (required)>'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in `load'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in `block in load_spec_files'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in `each'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in `load_spec_files'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:97:in `setup'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:85:in `run'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:70:in `run'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:38:in `invoke'
from /home/X/.gem/ruby/gems/rspec-core-3.2.3/exe/rspec:4:in `<main>'
/usr/bin/ruby -I/home/X/.gem/ruby/gems/rspec-core-3.2.3/lib:/home/X/.gem/ruby/gems/rspec-support-3.2.2/lib /home/X/.gem/ruby/gems/rspec-core-3.2.3/exe/rspec --pattern spec/unit/\*\*/\*_spec.rb --color --format progress failed
```