### PR TITLE
Correctly determine git repository when running in a subdirectory

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1153,12 +1153,11 @@ module Omnibus
     private
 
     def get_local_revision
-      if File.directory?(".git")
-        GitRepository.new("./").revision
-      else
-        "unknown"
-      end
+      GitRepository.new("./").revision
+    rescue StandardError
+      "unknown"
     end
+
     #
     # The log key for this project, overriden to include the name of the
     # project for build output.

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -127,6 +127,21 @@ module Omnibus
       end
     end
 
+    describe "build_git_revision" do
+      let(:git_repo_subdir_path) do
+        path = local_git_repo("foobar", annotated_tags: ["1.0", "2.0", "3.0"])
+        subdir_path = File.join(path, "asubdir")
+        Dir.mkdir(subdir_path)
+        subdir_path
+      end
+
+      it "returns a revision even when running in a subdir" do
+        Dir.chdir(git_repo_subdir_path) do
+          expect(subject.build_git_revision).to eq("632501dde2c41f3bdd988b818b4c008e2ff398dc")
+        end
+      end
+    end
+
     describe '#dirty!' do
       let(:software) { double(Omnibus::Software) }
 


### PR DESCRIPTION
When running in a subdirectory of a git repository, .git won't exist.
Instead of looking for ./.git specifically, attempt to get the
revision and rescue if we can't.