### PR TITLE
Update to pick up latest chef-sugar release

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'chef-sugar',       '~> 3.0'
+  gem.add_dependency 'chef-sugar',       '~> 3.1'
   gem.add_dependency 'cleanroom',        '~> 1.0'
   gem.add_dependency 'mixlib-shellout',  '~> 1.4'
   gem.add_dependency 'mixlib-versioning'


### PR DESCRIPTION
This will resolve https://github.com/chef/omnibus-software/issues/413 - the new software defs require a version of chef-sugar a minor vers above the current pinning.