### PR TITLE
Add Seth Vargo as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,5 +21,6 @@ project lead.
 * [Jay Mundrawala](https://github.com/jdmundrawala)
 * [Lamont Granquist](https://github.com/lamont-granquist)
 * [Scott Hain](https://github.com/scotthain)
+* [Seth Vargo](http://github.com/sethvargo)
 * [Steven Danna](https://github.com/stevendanna)
 * [Yvonne Lam](http://github.com/yzl)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,14 +15,11 @@ project lead.
 
 * [Seth Chisamore](https://github.com/schisamo)
 
-## Lieutenants
-
-* [Scott Hain](https://github.com/scotthain)
-* [Steven Danna](https://github.com/stevendanna)
-* [Yvonne Lam](http://github.com/yzl)
-
 ## Maintainers
 
 * [Daniel DeLeo](https://github.com/danielsdeleo)
 * [Jay Mundrawala](https://github.com/jdmundrawala)
 * [Lamont Granquist](https://github.com/lamont-granquist)
+* [Scott Hain](https://github.com/scotthain)
+* [Steven Danna](https://github.com/stevendanna)
+* [Yvonne Lam](http://github.com/yzl)


### PR DESCRIPTION
I'm proposing @sethvargo be added as a maintainer. As he was responsible for the most recent refactor so he has a deep understanding of most subsystems. The company he works for, HashiCorp, is also experimenting with using Omnibus to package up their various products.

/cc @chef/omnibus-maintainers 