### PR TITLE
Forcibly remove a non-empty project dir before cloning

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -64,6 +64,7 @@ module Omnibus
       if cloned?
         git_fetch(resolved_version) unless same_revision?(resolved_version)
       else
+        force_recreate_project_dir! unless dir_empty?(project_dir)
         git_clone
         git_checkout(resolved_version)
       end
@@ -88,6 +89,24 @@ module Omnibus
     #
     def source_url
       source[:git]
+    end
+
+    #
+    # Determine if a directory is empty
+    #
+    # @return [true, false]
+    #
+    def dir_empty?(dir)
+      Dir.entries(dir).reject {|d| ['.', '..'].include?(d) }.empty?
+    end
+
+    #
+    # Forcibly remove and recreate the project directory
+    #
+    def force_recreate_project_dir!
+      log.warn(log_key) { "Removing exisitng directory #{project_dir} before cloning" }
+      FileUtils.rm_rf(project_dir)
+      Dir.mkdir(project_dir)
     end
 
     #

--- a/spec/unit/fetchers/git_fetcher_spec.rb
+++ b/spec/unit/fetchers/git_fetcher_spec.rb
@@ -98,6 +98,7 @@ module Omnibus
         allow(subject).to receive(:git_fetch)
         allow(subject).to receive(:git_clone)
         allow(subject).to receive(:git_checkout)
+        allow(subject).to receive(:dir_empty?).and_return(true)
         allow(subject).to receive(:resolved_version).and_return("134aeba31234")
       end
 
@@ -125,6 +126,16 @@ module Omnibus
 
       context 'when the repository is not cloned' do
         before { allow(subject).to receive(:cloned?).and_return(false) }
+
+        context "but a directory does exist" do
+          before { expect(subject).to receive(:dir_empty?).with(project_dir).and_return(false)}
+
+          it "forcefully removes and recreateds the directory" do
+            expect(FileUtils).to receive(:rm_rf).with(project_dir).and_return(project_dir)
+            expect(Dir).to receive(:mkdir).with(project_dir).and_return(0)
+            subject.fetch
+          end
+        end
 
         it 'clones the repository' do
           expect(subject).to receive(:git_clone).once


### PR DESCRIPTION
If multiple projects are using the same maching for building, they
might have two different software definitions that share the same name
but a different source. For example, the old omnibus-chef-server
repository uses a git-based source for bookhself. However, the new
chef-server repository uses a path-based source. If the new
chef-server project builds before the omnibus-chef-server project, the
build will fail with an error message from git complaining about a
non-empty directory.

NB: This clearly doesn't solve all the problems with having two
projects building on the same machine with different fetchers for a
given software. For example the two software definitions could both
use git but via different git upstreams.