### PR TITLE
accomidate hardlinks properly

### DIFF
--- a/spec/functional/file_syncer_spec.rb
+++ b/spec/functional/file_syncer_spec.rb
@@ -101,6 +101,30 @@ module Omnibus
         end
       end
 
+      context 'when target files are hard links' do
+        let(:source) do
+          source = File.join(tmp_path, 'source')
+          FileUtils.mkdir_p(source)
+
+          create_directory(source, 'bin')
+               create_file(source, 'bin', 'git')
+               FileUtils.ln("#{source}/bin/git", "#{source}/bin/git-tag")
+               FileUtils.ln("#{source}/bin/git", "#{source}/bin/git-write-tree")
+
+          source
+        end
+
+        it 'copies the first instance and links to that instance thereafter' do
+          FileUtils.mkdir_p("#{destination}/bin")
+
+          described_class.sync(source, destination)
+
+          expect("#{destination}/bin/git").to be_a_file
+          expect("#{destination}/bin/git-tag").to be_a_hardlink
+          expect("#{destination}/bin/git-write-tree").to be_a_hardlink
+        end
+      end
+
       context 'with deeply nested paths and symlinks' do
         let(:source) do
           source = File.join(tmp_path, 'source')

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -34,3 +34,10 @@ RSpec::Matchers.define :be_an_executable do
     File.executable?(actual)
   end
 end
+
+# expect('/path/to/file').to be_a_hardlink
+RSpec::Matchers.define :be_a_hardlink do |path|
+  match do |actual|
+    File.stat(actual).nlink > 2
+  end
+end


### PR DESCRIPTION
Address https://github.com/chef/omnibus/issues/459 by building/checking a list of hard link sources that have already been copied into the build directory ala https://github.com/jordansissel/fpm/blob/master/lib/fpm/util.rb#L160-L183

Discovered the hard way the `File.stat.ftype` != `File.ftype` ("File.stat.ftype" returns 'file' for both regular files and symlinks).