### PR TITLE
Avoid progress bar errors when downloading

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,14 @@ RSpec.configure do |config|
   config.filter_run_excluding(windows_only: true) unless windows?
   config.filter_run_excluding(mac_only: true) unless mac?
 
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+    config.color = true
+  end
+
   config.before(:each) do
     # Suppress logging
     Omnibus.logger.level = :nothing


### PR DESCRIPTION
In Ci we randomly see errors from progress bar for trying to set the current progress higher than the total. My hunch is that this is the result of some computer arithmetic shenanigans and not a real problem with the downloaded file. Even if there's a real issue, we'll catch that in the next step when we verify the checksum of the downloaded thing, so there's no reason we need to put up with this error.

@chef/omnibus-maintainers 