### PR TITLE
Forcibly remove a non-empty project dir before cloning

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -67,6 +67,7 @@ E
       if existing_git_clone?
         fetch_updates unless current_rev_matches_target_rev?
       else
+        force_recreate_project_dir! unless dir_empty?(project_dir)
         clone
         checkout
       end
@@ -85,6 +86,24 @@ E
     end
 
     private
+
+    #
+    # Determine if a directory is empty
+    #
+    # @return [true, false]
+    #
+    def dir_empty?(dir)
+      Dir.entries(dir).reject { |d| ['.', '..'].include?(d) }.empty?
+    end
+
+    #
+    # Forcibly remove and recreate the project directory
+    #
+    def force_recreate_project_dir!
+      log "Removing exisitng directory #{project_dir} before cloning"
+      FileUtils.rm_rf(project_dir)
+      Dir.mkdir(project_dir)
+    end
 
     def clone
       puts 'cloning the source from git'


### PR DESCRIPTION
Adapted from commit 3635f816b2df2bc52cb8493084c8ff878e8b54d8

If multiple projects are using the same maching for building, they
might have two different software definitions that share the same name
but a different source. For example, the old omnibus-chef-server
repository uses a git-based source for bookhself. However, the new
chef-server repository uses a path-based source. If the new
chef-server project builds before the omnibus-chef-server project, the
build will fail with an error message from git complaining about a
non-empty directory.

NB: This clearly doesn't solve all the problems with having two
projects building on the same machine with different fetchers for a
given software. For example the two software definitions could both
use git but via different git upstreams.