### PR TITLE
Use 'i386' for package names of 32-bit EL packages.

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -512,6 +512,8 @@ module Omnibus
     #
     def safe_architecture
       case Ohai['kernel']['machine']
+      when 'i686'
+        'i386'
       when 'armv6l'
         if Ohai['platform'] == 'pidora'
           'armv6hl'

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -374,6 +374,18 @@ module Omnibus
         expect(subject.safe_architecture).to eq('i386')
       end
 
+      context 'when i686' do
+        before do
+          stub_ohai(platform: 'redhat', version: '6.5') do |data|
+            data['kernel']['machine'] = 'i686'
+          end
+        end
+
+        it 'returns i386' do
+          expect(subject.safe_architecture).to eq('i386')
+        end
+      end
+
       context 'on Pidora' do
         before do
           # There's no Pidora in Fauxhai :(


### PR DESCRIPTION
cc @chef/omnibus-maintainers @pburkholder 