### PR TITLE
When building spec file, handle path names that contain spaces.

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -352,6 +352,8 @@ module Omnibus
       filepath = rpm_safe('/' + path.gsub("#{build_dir}/", ''))
       return if config_files.include?(filepath) || filesystem_directories.include?(filepath)
       full_path = build_dir + filepath.gsub('[%]','%')
+      # FileSyncer.glob quotes pathnames that contain spaces, which is a problem on el7
+      full_path.gsub!('"', '')
       # Mark directories with the %dir directive to prevent rpmbuild from counting their contents twice.
       return "%dir #{filepath}" if !File.symlink?(full_path) && File.directory?(full_path)
       filepath

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -207,6 +207,7 @@ module Omnibus
           create_file("#{staging_dir}/BUILD/file2")
           create_directory("#{staging_dir}/BUILD/.dir1")
           create_directory("#{staging_dir}/BUILD/dir2")
+          create_directory("#{staging_dir}/BUILD/dir3 space")
         end
 
         it 'writes them into the spec' do
@@ -217,6 +218,7 @@ module Omnibus
           expect(contents).to include("/.file1")
           expect(contents).to include("%dir /dir2")
           expect(contents).to include("/file2")
+          expect(contents).to include("%dir \"/dir3 space\"")
         end
       end
 


### PR DESCRIPTION
cc @chef/ociv @danielsdeleo 

Fixes #428 