### PR TITLE
Add disable_healthcheck option

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -481,6 +481,11 @@ module Omnibus
       end
     end
 
+    # Disable the healthcheck
+    #
+    # @return [true, false]
+    default(:disable_healthcheck, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -46,3 +46,7 @@
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+
+# Disable health check
+# ------------------------------
+# disable_healthcheck true

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -175,6 +175,9 @@ module Omnibus
     #   if the healthchecks pass
     #
     def run!
+      log.warn(log_key) { 'Health check is disabled' }
+      return true if Config.disable_healthcheck
+
       if Ohai['platform'] == 'windows'
         log.warn(log_key) { 'Skipping health check on Windows' }
         return true

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -175,8 +175,10 @@ module Omnibus
     #   if the healthchecks pass
     #
     def run!
-      log.warn(log_key) { 'Health check is disabled' }
-      return true if Config.disable_healthcheck
+      if Config.disable_healthcheck
+        log.warn(log_key) { 'Health check is disabled' }
+        return true
+      end
 
       if Ohai['platform'] == 'windows'
         log.warn(log_key) { 'Skipping health check on Windows' }


### PR DESCRIPTION
This option disables the healthcheck.

The rationale is for the case where we'd like to build an omnibus that depends on OS-provided lib like OpenSSL When I patch OpenSSL (happens quite often) on the OS I won't need to rebuild the Omnibus. Currently, I can't even build the Omnibus because the healthchecker detects OpenSSL as an external dependency and exits.

Of course this seems to go against the whole point of an omnibus so I wont be too offended if you drop this pull request. ;)