### PR TITLE
[bugfix] extra_pkg_file DSL allows directories

### DIFF
--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -164,7 +164,7 @@ module Omnibus
     #
     def copy_file(source, destination)
       log.debug(log_key) { "Copying `#{source}' to `#{destination}'" }
-      FileUtils.cp(source, destination)
+      FileUtils.cp_r(source, destination)
       destination
     end
 


### PR DESCRIPTION
Since omnibus 4, the extra_package_file Project DSL wasn't allowing
directories anymore, which is kind of annoying when you're copying a dir
with a whole bunch of configuration files/examples files. Using
`FileUtils.cp_r` instead of `FileUtils.cp` in the `copy_file` util
method solves the issue.

It fixes https://github.com/chef/omnibus/issues/464

Obvious fix.