### PR TITLE
FileSyncer test for copying over read only file

### DIFF
--- a/spec/functional/file_syncer_spec.rb
+++ b/spec/functional/file_syncer_spec.rb
@@ -75,6 +75,30 @@ module Omnibus
         end
       end
 
+      context 'when destination file exists' do
+
+        let(:source) {
+          s = File.join(tmp_path, 'source')
+          FileUtils.mkdir_p(s)
+          p = create_file(s, 'read-only-file') { 'new' }
+          FileUtils.chmod(0400, p)
+          s
+        }
+
+        let(:destination) {
+          dest = File.join(tmp_path, 'destination')
+          FileUtils.mkdir_p(dest)
+          create_file(dest, 'read-only-file') { 'old' }
+          FileUtils.chmod(0400, File.join(dest, 'read-only-file'))
+          dest
+        }
+
+        it 'copies over a read-only file' do
+          described_class.sync(source, destination)
+          expect("#{destination}/read-only-file").to have_content "new"
+        end
+      end
+
       context 'when the directory exists' do
         before { FileUtils.mkdir_p(destination) }
 

--- a/spec/support/file_helpers.rb
+++ b/spec/support/file_helpers.rb
@@ -28,6 +28,7 @@ module Omnibus
         path = File.join(*paths)
 
         FileUtils.mkdir_p(File.dirname(path))
+        FileUtils.rm(path) if File.exist?(path)
 
         if block
           File.open(path, 'wb') { |f| f.write(block.call) }

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -14,6 +14,13 @@ RSpec::Matchers.define :be_a_file do
   end
 end
 
+# expect('/path/to/file').to have_content
+RSpec::Matchers.define :have_content do |content|
+  match do |actual|
+    IO.read(actual) == content
+  end
+end
+
 # expect('/path/to/directory').to be_a_symlink
 RSpec::Matchers.define :be_a_symlink do
   match do |actual|


### PR DESCRIPTION
In 4aa3116bb9, functionality was added to allow FileSyncer to copy over
a destination file with read-only mode. This patch adds an explicit test
case for this behavior.