### PR TITLE
Include /usr/ccs/lib for compilation libpath on aix

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -452,7 +452,7 @@ module Omnibus
             "CC" => "xlc_r -q64",
             "CXX" => "xlC_r -q64",
             "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -D_LARGE_FILES -O",
-            "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib",
+            "LDFLAGS" => "-q64 -L#{install_dir}/embedded/lib -Wl,-blibpath:#{install_dir}/embedded/lib:/usr/lib:/lib:/usr/ccs/lib",
             "LD" => "ld -b64",
             "OBJECT_MODE" => "64",
             "ARFLAGS" => "-X64 cru",


### PR DESCRIPTION
For whatever reason, I can't seem to get ncurses to produce a lib(n)curses.a with the shr42_64.o member. On a fresh intall of AIX 6.1 with default options, the member is present in `/usr/ccs/lib/libxcurses.a`

Without amending LDFLAGS's -blibpath option, "bash" produced within omnibus-toolchain dies with:
```
-bash-4.2$ /opt/omnibus-toolchain/embedded/bin/bash
exec(): 0509-036 Cannot load program /opt/omnibus-toolchain/embedded/bin/bash because of the following errors:
        0509-150   Dependent module /opt/omnibus-toolchain/embedded/lib/libcurses.a(shr42_64.o) could not be loaded.
        0509-153   File /opt/omnibus-toolchain/embedded/lib/libcurses.a is not an archive or
                   the file could not be read properly.
        0509-026 System error: Cannot run a file that does not have a valid format.
```
**unless** you `export LIBPATH="$LIBPATH:/usr/ccs/lib"` to slurp in IBM's libxcurses.a.

Digging deeper, I'm not convinced that the `./configure` flags as they are today produce libraries correctly (where I'd expect `/opt/bob/embedded/lib/libncursesw.a: archive (big format)`):
```
/opt/omnibus-toolchain/embedded/lib/libmenu.a: 64-bit XCOFF executable or object module not stripped
/opt/omnibus-toolchain/embedded/lib/libmenuw.a: 64-bit XCOFF executable or object module not stripped
/opt/omnibus-toolchain/embedded/lib/libncurses.a: 64-bit XCOFF executable or object module not stripped
/opt/omnibus-toolchain/embedded/lib/libncursesw.a: 64-bit XCOFF executable or object module not stripped
/opt/omnibus-toolchain/embedded/lib/libpanel.a: 64-bit XCOFF executable or object module not stripped
/opt/omnibus-toolchain/embedded/lib/libpanelw.a: 64-bit XCOFF executable or object module not stripped
```

/cc @scotthain @lamont-granquist 