### PR TITLE
Fix reading of build_version from manifest files.

### DIFF
--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -92,7 +92,7 @@ module Omnibus
     end
 
     def self.from_hash_v1(manifest_data)
-      m = Omnibus::Manifest.new
+      m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'])
       manifest_data['software'].each do |name, entry_data|
         m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
       end


### PR DESCRIPTION
When generating a changelog like so the build_version is nil.

`omnibus changelog generate --starting_manifest start.json --ending_manifest current.json --minor false`

I tracked this down to the parser not populating the fields.

/cc @schisamo @stevendanna 