### PR TITLE
Create an Artifactory build for published packages

### DIFF
--- a/features/commands/publish.feature
+++ b/features/commands/publish.feature
@@ -1,13 +1,8 @@
 Feature: omnibus publish
-  Scenario: Overriding publishing platform
-    * I run `omnibus publish artifactory fake * --platform debian`
+  Scenario: Providing platform mappings file
+    * I have a platform mappings file named "platform_mappings.json"
+    * I run `omnibus publish artifactory fake * --platform-mappings platform_mappings.json`
     * the output should contain:
       """
-      Publishing platform has been overriden to 'debian'
-      """
-  Scenario: Overriding publishing platform version
-    * I run `omnibus publish artifactory fake * --platform-version 7`
-    * the output should contain:
-      """
-      Publishing platform version has been overriden to '7'
+      Publishing will be performed using provided platform mappings.
       """

--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -1,7 +1,7 @@
 require 'aruba/api'
 
 Given(/^I have an omnibus project named "(.+)"$/) do |name|
-  create_dir(name)
+  create_directory(name)
   cd(name)
 
   write_file("config/projects/#{name}.rb", <<-EOH.gsub(/^ {4}/, ''))

--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -27,3 +27,15 @@ Given(/^I have an omnibus project named "(.+)"$/) do |name|
     package_tmp   './local/omnibus/pkg-tmp'
   EOH
 end
+
+Given(/^I have a platform mappings file named "(.+)"$/) do |name|
+  write_file(name, <<-EOH.gsub(/^ {4}/, ''))
+    {
+      "ubuntu-10.04": [
+        "ubuntu-10.04",
+        "ubuntu-12.04",
+        "ubuntu-14.04"
+      ]
+    }
+  EOH
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,10 +4,12 @@ require 'aruba/in_process'
 
 require 'omnibus/cli'
 
+Aruba.configure do |config|
+  config.command_launcher = :in_process
+  config.main_class = Omnibus::CLI::Runner
+end
+
 Before do
   # Reset anything that might have been cached in the Omnibus project
   Omnibus.reset!(true)
-
-  Aruba::InProcess.main_class = Omnibus::CLI::Runner
-  Aruba.process = Aruba::InProcess
 end

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -85,7 +85,7 @@ module Omnibus
       if @options[:output_manifest]
         FileUtils.mkdir_p('pkg')
         File.open(::File.join('pkg', 'version-manifest.json'), 'w') do |f|
-          f.write(JSON.pretty_generate(project.built_manifest.to_hash))
+          f.write(project.built_manifest.to_json)
         end
       end
     end

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -18,19 +18,23 @@ module Omnibus
   class Command::Publish < Command::Base
     namespace :publish
 
-    # These options are useful for publish packages that were built for a
-    # paticluar platform/version and tested on another platform/version.
+    # This option is useful for publish packages that were built for a
+    # particular platform/version but tested on other platform/versions.
     #
     # For example, one might build on Ubuntu 10.04 and test/publish on
-    # Ubuntu 11.04, 12.04 and Debian 7.
+    # Ubuntu 10.04, 12.04, and 14.04.
     #
-    # If these options are used with the glob pattern support all packages
-    # will be published to the same platform/version.
-    class_option :platform,
-      desc: 'The platform to publish for',
-      type: :string
-    class_option :platform_version,
-      desc: 'The platform version to publish for',
+    # @example JSON
+    #   {
+    #     "ubuntu-10.04": [
+    #       "ubuntu-10.04",
+    #       "ubuntu-12.04",
+    #       "ubuntu-14.04"
+    #     ]
+    #   }
+    #
+    class_option :platform_mappings,
+      desc: 'The optional platform mappings JSON file to publish with',
       type: :string
 
     class_option :version_manifest,
@@ -72,8 +76,12 @@ module Omnibus
     # @return [void]
     #
     def publish(klass, pattern, options)
+      if options[:platform_mappings]
+        options[:platform_mappings] = JSON.parse(File.read(File.expand_path(options[:platform_mappings])))
+      end
+
       klass.publish(pattern, options) do |package|
-        say("Uploaded '#{package.name}'", :green)
+        say("Published '#{package.name}' for #{package.metadata[:platform]}-#{package.metadata[:platform_version]}", :green)
       end
     end
   end

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -33,6 +33,10 @@ module Omnibus
       desc: 'The platform version to publish for',
       type: :string
 
+    class_option :version_manifest,
+      desc: 'Path to the version-manifest.json file to publish with',
+      type: :string
+
     #
     # Publish to S3.
     #

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -45,6 +45,24 @@ EOH
     end
   end
 
+  class InvalidBuildPlatform < Error
+    def initialize(build_platform, pattern)
+      @build_platform, @pattern = build_platform, pattern
+    end
+
+    def to_s
+      <<-EOH
+Could not locate a package for build platform:
+
+    #{@build_platform}
+
+using pattern of:
+
+    #{@pattern}
+EOH
+    end
+  end
+
   class MissingRequiredAttribute < Error
     def initialize(instance, name, sample = '<VALUE>')
       @instance, @name, @sample = instance, name, sample

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -101,7 +101,7 @@ module Omnibus
     end
 
     def self.from_hash_v1(manifest_data)
-      m = Omnibus::Manifest.new
+      m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'])
       manifest_data['software'].each do |name, entry_data|
         m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
       end

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -79,6 +79,15 @@ module Omnibus
     end
 
     #
+    # The JSON representation of this build manifest.
+    #
+    # @return [String]
+    #
+    def to_json
+      JSON.pretty_generate(to_hash)
+    end
+
+    #
     # Class Methods
     #
 

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -254,6 +254,15 @@ module Omnibus
     end
 
     #
+    # Hash representation of this metadata.
+    #
+    # @return [Hash]
+    #
+    def to_hash
+      @data.dup
+    end
+
+    #
     # The JSON representation of this metadata.
     #
     # @return [String]

--- a/lib/omnibus/package.rb
+++ b/lib/omnibus/package.rb
@@ -104,6 +104,15 @@ module Omnibus
     end
 
     #
+    # Set the metadata for this package
+    #
+    # @param [Metadata] metadata
+    #
+    def metadata=(metadata)
+      @metadata = metadata
+    end
+
+    #
     # Validate the presence of the required components for the package.
     #
     # @raise [NoPackageFile] if the package is not present

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -174,8 +174,8 @@ module Omnibus
     def metadata_for(package)
       {
         'omnibus.project'          => package.metadata[:name],
-        'omnibus.platform'         => publish_platform(package),
-        'omnibus.platform_version' => publish_platform_version(package),
+        'omnibus.platform'         => package.metadata[:platform],
+        'omnibus.platform_version' => package.metadata[:platform_version],
         'omnibus.architecture'     => package.metadata[:arch],
         'omnibus.version'          => package.metadata[:version],
         'omnibus.iteration'        => package.metadata[:iteration],
@@ -222,8 +222,8 @@ module Omnibus
         Config.artifactory_base_path,
         package.metadata[:name],
         package.metadata[:version],
-        publish_platform(package),
-        publish_platform_version(package),
+        package.metadata[:platform],
+        package.metadata[:platform_version],
         package.metadata[:basename],
       )
     end

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -38,7 +38,10 @@ module Omnibus
             artifact_for(package).upload(
               repository,
               remote_path_for(package),
-              metadata_for(package),
+              metadata_for(package).merge(
+                'build.name'   => package.metadata[:name],
+                'build.number' => package.metadata[:version],
+              ),
             )
           end
         rescue Artifactory::Error::HTTPError => e
@@ -55,6 +58,12 @@ module Omnibus
 
         # If a block was given, "yield" the package to the caller
         block.call(package) if block
+      end
+
+      if packages.empty?
+         log.warn(log_key) { "No packages were uploaded, build object will not be created." }
+      else
+        build_for(packages).save
       end
     end
 
@@ -76,6 +85,62 @@ module Omnibus
           'md5'  => package.metadata[:md5],
           'sha1' => package.metadata[:sha1],
         }
+      )
+    end
+
+    #
+    # The build object that corresponds to this package.
+    #
+    # @param [Array<Package>] packages
+    #   the packages to create the build from
+    #
+    # @return [Artifactory::Resource::Build]
+    #
+    def build_for(packages)
+      name = packages.first.metadata[:name]
+      # Attempt to load the version-manifest.json file which represents
+      # the build.
+      manifest = if File.exist?(version_manifest)
+                   Manifest.from_file(version_manifest)
+                 else
+                   Manifest.new(packages.first.metadata[:version])
+                 end
+
+      # Upload the actual package
+      log.info(log_key) { "Saving build info for #{name}, Build ##{manifest.build_version}" }
+
+      Artifactory::Resource::Build.new(
+        client: client,
+        name:   name,
+        number: manifest.build_version,
+        vcs_revision: manifest.build_git_revision,
+        build_agent: {
+          name: 'omnibus',
+          version: Omnibus::VERSION,
+        },
+        properties: {
+          'omnibus.project' => name,
+          'omnibus.version' => manifest.build_version,
+          'omnibus.version_manifest' => manifest.to_json,
+        },
+        modules: [
+          {
+            # com.getchef:chef-server:12.0.0
+            id: [
+              Config.artifactory_base_path.gsub('/', '.'),
+              name,
+              manifest.build_version,
+            ].join(':'),
+            artifacts: packages.map do |package|
+              {
+                type: File.extname(package.path).split('.').last,
+                sha1: package.metadata[:sha1],
+                md5:  package.metadata[:md5],
+                name: package.metadata[:basename],
+              }
+            end
+          }
+        ]
       )
     end
 
@@ -128,6 +193,15 @@ module Omnibus
     #
     def repository
       @options[:repository]
+    end
+
+    #
+    # The path to the builds version-manfest.json file (as supplied as an option).
+    #
+    # @return [String]
+    #
+    def version_manifest
+      @options[:version_manifest] || ''
     end
 
     #

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -72,8 +72,8 @@ module Omnibus
     #
     def key_for(package, *stuff)
       File.join(
-        publish_platform(package),
-        publish_platform_version(package),
+        package.metadata[:platform],
+        package.metadata[:platform_version],
         package.metadata[:arch],
         package.name,
         *stuff,

--- a/spec/unit/build_version_dsl_spec.rb
+++ b/spec/unit/build_version_dsl_spec.rb
@@ -14,7 +14,7 @@ module Omnibus
 
     describe "when given nil" do
       it "fails" do
-        expect { subject.build_version }.to raise_error
+        expect { subject.build_version }.to raise_error(RuntimeError)
       end
     end
 
@@ -128,7 +128,7 @@ module Omnibus
         end
 
         it "fails" do
-          expect { subject_with_description.build_version }.to raise_error
+          expect { subject_with_description.build_version }.to raise_error(RuntimeError)
         end
       end
     end
@@ -141,7 +141,7 @@ module Omnibus
       end
 
       it "fails" do
-        expect { subject_with_description.build_version }.to raise_error
+        expect { subject_with_description.build_version }.to raise_error(RuntimeError)
       end
     end
   end

--- a/spec/unit/git_repository_spec.rb
+++ b/spec/unit/git_repository_spec.rb
@@ -21,7 +21,7 @@ module Omnibus
       end
 
       it "returns an error if the tags don't exist" do
-        expect{git_repo.authors("1.0", "WUT")}.to raise_error
+        expect{git_repo.authors("1.0", "WUT")}.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -76,6 +76,8 @@ module Omnibus
     describe "#from_hash" do
       let(:manifest) {
         { "manifest_format" => 1,
+          "build_version" => "12.4.0+20150629082811",
+          "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
           "software" => {
             "zlib" => {
               "locked_source" => {
@@ -89,6 +91,14 @@ module Omnibus
       let(:v2_manifest) {
         {"manifest_format" => 2}
       }
+
+      it "has a build_version" do
+        expect(Manifest.from_hash(manifest).build_version).to eq('12.4.0+20150629082811')
+      end
+
+      it "has a build_git_revision" do
+        expect(Manifest.from_hash(manifest).build_git_revision).to eq('2e763ac957b308ba95cef256c2491a5a55a163cc')
+      end
 
       it "returns a manifest from a hash" do
         expect(Manifest.from_hash(manifest)).to be_a(Manifest)

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -42,6 +42,70 @@ module Omnibus
       it 'returns an array of Package objects' do
         expect(subject.packages.first).to be_a(Package)
       end
+
+      context 'a platform mappings matrix is provided' do
+        let(:options) do
+          {
+            platform_mappings: {
+              'ubuntu-12.04' => [
+                'ubuntu-12.04',
+                'ubuntu-14.04',
+              ],
+            },
+          }
+        end
+
+        let(:package) do
+          Package.new('/path/to/files/chef.deb')
+        end
+
+        let(:metadata) do
+          Metadata.new(package,
+            name: 'chef',
+            friendly_name: 'Chef',
+            homepage: 'https://www.getchef.com',
+            version: '11.0.6',
+            iteration: 1,
+            basename: 'chef.deb',
+            platform: 'ubuntu',
+            platform_version: '12.04',
+            arch: 'x86_64',
+            sha1: 'SHA1',
+            md5: 'ABCDEF123456',
+          )
+        end
+
+        before do
+          allow(package).to receive(:metadata).and_return(metadata)
+          allow(FileSyncer).to receive_message_chain(:glob, :map).and_return([package])
+        end
+
+        it 'creates a package for each publish platform' do
+          expect(subject.packages.size).to eq(2)
+          expect(
+            subject.packages.map do |p|
+              p.metadata[:platform_version]
+            end
+          ).to include('12.04', '14.04')
+        end
+
+        context 'the build platform does not exist' do
+          let(:options) do
+            {
+              platform_mappings: {
+                'ubuntu-10.04' => [
+                  'ubuntu-12.04',
+                  'ubuntu-14.04',
+                ],
+              },
+            }
+          end
+
+          it 'raises an error' do
+            expect { subject.packages }.to raise_error(InvalidBuildPlatform)
+          end
+        end
+      end
     end
 
     describe '#publish' do

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -34,11 +34,14 @@ module Omnibus
     let(:packages) { [package] }
     let(:client)   { double('Artifactory::Client') }
     let(:artifact) { double('Artifactory::Resource::Artifact', upload: nil) }
+    let(:build)    { double('Artifactory::Resource::Build') }
 
     before do
       allow(subject).to receive(:client).and_return(client)
       allow(subject).to receive(:artifact_for).and_return(artifact)
+      allow(subject).to receive(:build_for).and_return(build)
       allow(package).to receive(:metadata).and_return(metadata)
+      allow(build).to   receive(:save)
     end
 
     subject { described_class.new(path, repository: repository) }
@@ -63,6 +66,20 @@ module Omnibus
         ).once
 
         subject.publish
+      end
+
+      it 'it creates a build object for all packages' do
+        expect(build).to receive(:save).once
+        subject.publish
+      end
+
+      context 'when no packages exist' do
+        let(:packages) { [] }
+
+        it 'does nothing' do
+          expect(artifact).to_not receive(:upload)
+          expect(build).to_not    receive(:save)
+        end
       end
 
       context 'when upload fails' do

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -102,26 +102,6 @@ module Omnibus
 
       end
 
-      context 'when an alternate platform and platform version are provided' do
-        subject do
-          described_class.new(path,
-            repository: repository,
-            platform: 'debian',
-            platform_version: '7',
-          )
-        end
-
-        it 'overrides the platform and platform version used for publishing' do
-          expect(artifact).to receive(:upload).with(
-            repository,
-            'com/getchef/chef/11.0.6/debian/7/chef.deb',
-            an_instance_of(Hash),
-          ).once
-
-          subject.publish
-        end
-      end
-
       context 'when a block is given' do
         it 'yields the package to the block' do
           block = ->(package) { package.do_something! }

--- a/spec/unit/publishers/s3_publisher_spec.rb
+++ b/spec/unit/publishers/s3_publisher_spec.rb
@@ -96,26 +96,6 @@ module Omnibus
         end
       end
 
-      context 'when an alternate platform and platform version are provided' do
-        subject do
-          described_class.new(path,
-            platform: 'debian',
-            platform_version: '7',
-          )
-        end
-
-        it 'overrides the platform and platform version used for publishing' do
-          expect(client).to receive(:store).with(
-            'debian/7/x86_64/chef.deb/chef.deb',
-            package.content,
-            access: :private,
-            content_md5: package.metadata[:md5],
-          ).once
-
-          subject.publish
-        end
-      end
-
       context 'when a block is given' do
         it 'yields the package to the block' do
           block = ->(package) { package.do_something! }

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -376,7 +376,7 @@ module Omnibus
       end
 
       it "raises an error if it was given a manifest but can't find it's entry" do
-        expect{another_project.manifest_entry}.to raise_error
+        expect{another_project.manifest_entry}.to raise_error(Manifest::MissingManifestEntry)
       end
     end
 


### PR DESCRIPTION
An Artifactory build gives us a top level object that groups a set of packages together.

* This build object is the object we use to drive promotions and cleanup tasks.
* This build object is where we can attach build-wide metadata, things like the build’s version-manifest.json.

See the following for more details on what 'build' means in the Artifactory world:
https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-BUILDS
https://www.jfrog.com/confluence/display/RTF/Build+Integration
https://github.com/JFrogDev/build-info

Some shots of what is produced:

![artifactory_chef_s_preprod_artifactory_instance____build_browser](https://cloud.githubusercontent.com/assets/6164/8485888/ec8a978e-20ce-11e5-9cef-5cfe19265219.png)

![artifactory_chef_s_preprod_artifactory_instance____build_browser](https://cloud.githubusercontent.com/assets/6164/8485856/b3e08e2a-20ce-11e5-9f36-ec7418d2ef48.png)

![artifactory_chef_s_preprod_artifactory_instance____build_browser](https://cloud.githubusercontent.com/assets/6164/8485914/14ec1842-20cf-11e5-83c6-bf4f53a2b6e6.png)

![artifactory_chef_s_preprod_artifactory_instance____repository_browser](https://cloud.githubusercontent.com/assets/6164/8485872/d0ca5976-20ce-11e5-8f12-51f3b30fc2d6.png)

/cc @chef/engineering-services @chef/omnibus-maintainers