### PR TITLE
Add libkvm and libprocstat to freebsd whitelist

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -138,6 +138,8 @@ module Omnibus
       /libthr\.so/,
       /libutil\.so/,
       /libelf\.so/,
+      /libkvm\.so/,
+      /libprocstat\.so/,
     ].freeze
 
     class << self


### PR DESCRIPTION
Ruby 2.2 wants these things on freebsd