### PR TITLE
Use local package dir and staging dir in solaris packager

### DIFF
--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -164,7 +164,7 @@ module Omnibus
     # @return [String]
     #
     def package_path
-      File.join(Config.package_dir, package_name)
+      File.expand_path(File.join(Config.package_dir, package_name))
     end
 
     #

--- a/lib/omnibus/packagers/solaris.rb
+++ b/lib/omnibus/packagers/solaris.rb
@@ -51,8 +51,8 @@ module Omnibus
       File.basename(project.install_dir)
     end
     
-    def staging_dir_path(fileName)
-      File.join(staging_dir,fileName)
+    def staging_dir_path(file_name)
+      File.join(staging_dir, file_name)
     end
 
     #

--- a/lib/omnibus/packagers/solaris.rb
+++ b/lib/omnibus/packagers/solaris.rb
@@ -35,11 +35,10 @@ module Omnibus
       copy_file("#{project.package_scripts_path}/postinst", '/tmp/pkgmk/postinstall')
       copy_file("#{project.package_scripts_path}/postrm", '/tmp/pkgmk/postremove')
 
-      Dir.chdir(staging_dir) do
-        shellout! "pkgmk -o -r #{install_dirname} -d /tmp/pkgmk -f /tmp/pkgmk/Prototype"
-        shellout! "pkgchk -vd /tmp/pkgmk #{project.package_name}"
-        shellout! "pkgtrans /tmp/pkgmk /var/cache/omnibus/pkg/#{package_name} #{project.package_name}"
-      end
+      shellout! "pkgmk -o -r #{install_dirname} -d /tmp/pkgmk -f /tmp/pkgmk/Prototype"
+      shellout! "pkgchk -vd /tmp/pkgmk #{project.package_name}"
+      abs_package_path = File.absolute_path(package_path) 
+      shellout! "pkgtrans /tmp/pkgmk #{abs_package_path} #{project.package_name}"
     end
 
     # @see Base#package_name


### PR DESCRIPTION
Solaris packager does not use 'base_dir' variable in omnibus.rb. It hard codes '/var/cache/omnibus' directory while packaging. 
Health of solaris package fails due to solaris system libraries not being whilelisted.

This pull request fixes the above two issues. These were exposed while building omnibus packages for collectd (https://github.com/collectd/collectd)

