### PR TITLE
Add support for building on Cisco's Nexus platform.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+
+gem 'ohai', :path=>'/root/ohai'
+
 gemspec
 
 group :docs do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'ohai', :path=>'/root/ohai'
+gem 'ohai', :path '/root/ohai'
 
 gemspec
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -425,7 +425,7 @@ module Omnibus
       whitelist_libs = case Ohai['platform']
                        when 'arch'
                          ARCH_WHITELIST_LIBS
-                       when 'wrlinux'
+                       when 'nexus'
                          WRLINUX_WHITELIST_LIBS
                        when 'mac_os_x'
                          MAC_WHITELIST_LIBS

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -52,6 +52,17 @@ module Omnibus
     ].freeze
 
     WRLINUX_WHITELIST_LIBS = [
+      /libc\.so/,
+      /libcrypt\.so/,
+      /libdb-5\.3\.so/,
+      /libdl\.so/,
+      /libffi\.so/,
+      /libgdbm\.so/,
+      /libm\.so/,
+      /libnsl\.so/,
+      /libpthread\.so/,
+      /librt\.so/,
+      /libutil\.so/,
       /libffi\.so/,
     ].freeze
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -51,6 +51,10 @@ module Omnibus
       /libutil\.so/,
     ].freeze
 
+    WRLINUX_WHITELIST_LIBS = [
+      /libffi\.so/,
+    ].freeze
+
     AIX_WHITELIST_LIBS = [
       /libpthread\.a/,
       /libpthreads\.a/,
@@ -410,6 +414,8 @@ module Omnibus
       whitelist_libs = case Ohai['platform']
                        when 'arch'
                          ARCH_WHITELIST_LIBS
+                       when 'wrlinux'
+                         WRLINUX_WHITELIST_LIBS
                        when 'mac_os_x'
                          MAC_WHITELIST_LIBS
                        when 'solaris2'

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -153,7 +153,7 @@ module Omnibus
       #
       def truncate_platform_version(platform_version, platform)
         case platform
-        when 'centos', 'debian', 'el', 'fedora', 'freebsd', 'omnios', 'pidora', 'raspbian', 'rhel', 'sles', 'suse', 'smartos'
+        when 'centos', 'debian', 'el', 'fedora', 'freebsd', 'omnios', 'pidora', 'raspbian', 'rhel', 'sles', 'suse', 'smartos', 'wrlinux'
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split('.').first
         when 'aix', 'gentoo', 'mac_os_x', 'openbsd', 'slackware', 'solaris2', 'opensuse', 'ubuntu'

--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -37,6 +37,7 @@ module Omnibus
       'debian'   => DEB,
       'fedora'   => RPM,
       'rhel'     => RPM,
+      'wrlinux'  => RPM,
       'aix'      => BFF,
       'solaris2' => Solaris,
       'windows'  => MSI,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -303,6 +303,7 @@ module Omnibus
           config_files:   config_files,
           files:          files,
           build_dir:      build_dir,
+          platform:       Omnibus::Metadata.platform_shortname
         }
       )
     end

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cleanroom',        '~> 1.0'
   gem.add_dependency 'mixlib-shellout',  '~> 2.0'
   gem.add_dependency 'mixlib-versioning'
-  gem.add_dependency 'ohai',             '~> 8.5.2'
+  gem.add_dependency 'ohai'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'uber-s3',          '~> 0.2.4'
   gem.add_dependency 'thor',             '~> 0.18'

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mixlib-versioning'
   gem.add_dependency 'ohai'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
-  gem.add_dependency 'uber-s3',          '~> 0.2.4'
+  gem.add_dependency 'uber-s3'
   gem.add_dependency 'thor',             '~> 0.18'
 
   gem.add_development_dependency 'bundler'

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cleanroom',        '~> 1.0'
   gem.add_dependency 'mixlib-shellout',  '~> 2.0'
   gem.add_dependency 'mixlib-versioning'
-  gem.add_dependency 'ohai',             '~> 8.6'
+  gem.add_dependency 'ohai',             '~> 8.5.2'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'uber-s3',          '~> 0.2.4'
   gem.add_dependency 'thor',             '~> 0.18'

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cleanroom',        '~> 1.0'
   gem.add_dependency 'mixlib-shellout',  '~> 2.0'
   gem.add_dependency 'mixlib-versioning'
-  gem.add_dependency 'ohai',             '~> 8.0'
+  gem.add_dependency 'ohai',             '~> 8.6'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'uber-s3',          '~> 0.2.4'
   gem.add_dependency 'thor',             '~> 0.18'

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -19,7 +19,9 @@ Name: <%= name %>
 Version: <%= version %>
 Release: <%= iteration %><%= dist_tag %>
 Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
+<% if platform != 'wrlinux' -%>
 BuildArch: <%= architecture %>
+<% end -%>
 AutoReqProv: no
 BuildRoot: %buildroot
 Prefix: /


### PR DESCRIPTION
Nexus runs on top of Wind River Linux 5, which uses RPMs but is not Red Hat-based.
Ohai patches for WRL5 have been submitted and we (@edolnx and I) have unlocked
the ohai version to pick up the master branch.