### PR TITLE
Properly render ERB templates that do not have variables

### DIFF
--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -87,7 +87,7 @@ EOH
 
     def to_s
       <<-EOH
-Attempting to evaluate the template `#{@name}', but it was not found at any of
+Attempting to evaluate the template `#{@template}', but it was not found at any of
 the following locations:
 
 #{@search_paths.map { |path| "    #{path}" }.join("\n")}

--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -53,7 +53,14 @@ module Omnibus
       end
 
       template = ERB.new(File.read(source), nil, '-')
-      struct   = Struct.new(*variables.keys).new(*variables.values)
+
+      struct =
+        if variables.empty?
+          Struct.new("Empty")
+        else
+          Struct.new(*variables.keys).new(*variables.values)
+        end
+
       result   = template.result(struct.instance_eval { binding })
 
       File.open(destination, 'w', mode) do |file|

--- a/spec/functional/templating_spec.rb
+++ b/spec/functional/templating_spec.rb
@@ -45,7 +45,6 @@ module Omnibus
       end
 
       context 'when a destination is given' do
-
         it 'renders at the destination' do
           subject.render_template(source, options)
           expect(destination).to be_a_file
@@ -65,7 +64,19 @@ module Omnibus
         let(:contents) { "<%= not_a_real_variable %>" }
 
         it 'raise an exception' do
-          expect { subject.render_template(source, options) }.to raise_error
+          expect do
+            subject.render_template(source, options)
+          end.to raise_error(NameError)
+        end
+      end
+
+      context 'when no variables are present' do
+        let(:content)   { "static content" }
+        let(:variables) { {} }
+
+        it 'renders the template' do
+          subject.render_template(source, options)
+          expect(destination).to be_a_file
         end
       end
     end


### PR DESCRIPTION
Fixes an error when rendering an ERB template that does not contain variables

```
Builder: chef-marketplace-cookbooks] I | Build chef-marketplace-cookbooks: 0.7814s
/home/vagrant/.gem/ruby/2.1.5/bundler/gems/omnibus-e28303ad28a6/lib/omnibus/templating.rb:56:in `new': wrong number of arguments (0 for 1+) (ArgumentError)
        from /home/vagrant/.gem/ruby/2.1.5/bundler/gems/omnibus-e28303ad28a6/lib/omnibus/templating.rb:56:in `render_template'
```