### PR TITLE
Set directory ownership/permissions to match the filesystem package.

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -232,13 +232,29 @@ module Omnibus
     end
 
     #
-    # Exclude directories from the spec that are owned by the filesystem package:
+    # Directories owned by the filesystem package:
     # http://fedoraproject.org/wiki/Packaging:Guidelines#File_and_Directory_Ownership
     #
     # @return [Array]
     #
     def filesystem_directories
-      @filesystem_directories ||= IO.readlines(resource_path('filesystem_list')).map! { |dirname| dirname.chomp }
+      @filesystem_directories ||= IO.readlines(resource_path('filesystem_list')).map { |f| f.chomp }
+    end
+
+    #
+    # Mark filesystem directories with ownership and permissions specified in the filesystem package
+    # https://git.fedorahosted.org/cgit/filesystem.git/plain/filesystem.spec
+    #
+    # @return [String]
+    #
+    def mark_filesystem_directories(fsdir)
+      if fsdir.eql?('/') || fsdir.eql?('/usr/lib') || fsdir.eql?('/usr/share/empty')
+        return "%dir %attr(555,root,root) #{fsdir}"
+      elsif filesystem_directories.include?(fsdir)
+        return "%dir %attr(0755,root,root) #{fsdir}"
+      else
+        return "%dir #{fsdir}"
+      end
     end
 
     #
@@ -350,12 +366,12 @@ module Omnibus
     #
     def build_filepath(path)
       filepath = rpm_safe('/' + path.gsub("#{build_dir}/", ''))
-      return if config_files.include?(filepath) || filesystem_directories.include?(filepath)
+      return if config_files.include?(filepath)
       full_path = build_dir + filepath.gsub('[%]','%')
       # FileSyncer.glob quotes pathnames that contain spaces, which is a problem on el7
       full_path.gsub!('"', '')
       # Mark directories with the %dir directive to prevent rpmbuild from counting their contents twice.
-      return "%dir #{filepath}" if !File.symlink?(full_path) && File.directory?(full_path)
+      return mark_filesystem_directories(filepath) if !File.symlink?(full_path) && File.directory?(full_path)
       filepath
     end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -249,7 +249,7 @@ module Omnibus
     #
     def mark_filesystem_directories(fsdir)
       if fsdir.eql?('/') || fsdir.eql?('/usr/lib') || fsdir.eql?('/usr/share/empty')
-        return "%dir %attr(555,root,root) #{fsdir}"
+        return "%dir %attr(0555,root,root) #{fsdir}"
       elsif filesystem_directories.include?(fsdir)
         return "%dir %attr(0755,root,root) #{fsdir}"
       else

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -234,7 +234,7 @@ module Omnibus
           contents = File.read(spec_file)
 
           expect(contents).to include("%dir %attr(0755,root,root) /opt")
-          expect(contents).to include("%dir %attr(555,root,root) /usr/lib")
+          expect(contents).to include("%dir %attr(0555,root,root) /usr/lib")
         end
       end
     end

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -224,14 +224,17 @@ module Omnibus
 
       context 'when leaf directories owned by the filesystem package are present' do
         before do
-          create_file("#{staging_dir}/BUILD/opt")
+          create_directory("#{staging_dir}/BUILD/usr/lib")
+          create_directory("#{staging_dir}/BUILD/opt")
+          create_file("#{staging_dir}/BUILD/opt/thing")
         end
 
-        it 'does not write them into the spec' do
+        it 'is written into the spec with ownership and permissions' do
           subject.write_rpm_spec
           contents = File.read(spec_file)
 
-          expect(contents).to_not include("/opt")
+          expect(contents).to include("%dir %attr(0755,root,root) /opt")
+          expect(contents).to include("%dir %attr(555,root,root) /usr/lib")
         end
       end
     end


### PR DESCRIPTION
Per the fedora package guidelines:
https://fedoraproject.org/wiki/Packaging:Guidelines#File_and_Directory_Ownership
this allows us to specify /opt in the spec file to support rpm5.

Addresses [ES-331](https://chefio.atlassian.net/browse/ES-331)

cc @chef/omnibus-maintainers 