### PR TITLE
Default windows_arch to x86 until Omnibus 5

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -452,11 +452,15 @@ module Omnibus
     #
     # @return [:x86, :x64]
     default(:windows_arch) do
-        if Ohai['kernel']['machine'] == 'x86_64'
-            :x64
-        else
-            :x86
+      if Ohai['kernel']['machine'] == 'x86_64'
+        Omnibus.logger.deprecated('Config') do
+          "windows_arch is defaulting to :x86. In Omnibus 5, it will " \
+          "default to :x64 if the machine architecture is x86_64. " \
+          "If you would like to continue building 32 bit packages, please "\
+          "manually set windows_arch in your omnibus.rb file to :x86."
         end
+      end
+      :x86
     end
 
     # --------------------------------------------------


### PR DESCRIPTION
We're going to do an omnibus release, and we'd like to not have to bump the major version