### PR TITLE
Pin uber-s3 to ~> 0.2.4

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mixlib-versioning'
   gem.add_dependency 'ohai',             '~> 8.0'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
-  gem.add_dependency 'uber-s3'
+  gem.add_dependency 'uber-s3',          '~> 0.2.4'
   gem.add_dependency 'thor',             '~> 0.18'
 
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
uber-s3 0.1.1 does not work with the cache commands