### PR TITLE
Allow omnibus to build "bundled" Windows installers

### DIFF
--- a/resources/msi/bundle.wxs.erb
+++ b/resources/msi/bundle.wxs.erb
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <!-- This is how we include wxi files -->
+  <?include "parameters.wxi" ?>
+
+  <Bundle Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" >
+      <bal:WixStandardBootstrapperApplication LicenseFile="Resources\assets\LICENSE.rtf"/>
+    </BootstrapperApplicationRef>
+
+    <Chain>
+      <ExePackage SourceFile="$(var.OmnibusCacheDir)\vcredist_x64.exe" InstallCommand="/Q"
+        DownloadUrl="http://download.microsoft.com/download/d/2/4/d242c3fb-da5a-4542-ad66-f9661d0a8d19/vcredist_x64.exe" />
+      <MsiPackage SourceFile="<%= msi %>" EnableFeatureSelection="no" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/spec/unit/packagers/msi_spec.rb
+++ b/spec/unit/packagers/msi_spec.rb
@@ -93,6 +93,11 @@ module Omnibus
       it 'includes the name, version, and build iteration' do
         expect(subject.package_name).to eq('project-1.2.3-2.msi')
       end
+
+      it 'returns the bundle name when building a bundle' do
+        subject.bundle_msi(true)
+        expect(subject.package_name).to eq('project-1.2.3-2.exe')
+      end
     end
 
     describe '#resources_dir' do
@@ -169,6 +174,26 @@ module Omnibus
 
         expect(contents).to include('<?include "parameters.wxi" ?>')
         expect(contents).to include('<Property Id="WIXUI_INSTALLDIR" Value="WINDOWSVOLUME" />')
+      end
+    end
+
+    describe '#write_bundle_file' do
+      before do
+        subject.bundle_msi(true)
+        subject.upgrade_code('ABCD-1234')
+      end
+
+      it 'generates the file' do
+        subject.write_bundle_file
+        expect("#{staging_dir}/bundle.wxs").to be_a_file
+      end
+
+      it 'has the correct content' do
+        outpath = "#{tmp_path}/package/dir/project-1.2.3-2.msi"
+        outpath = outpath.gsub(File::SEPARATOR, File::ALT_SEPARATOR) if windows?
+        subject.write_bundle_file
+        contents = File.read("#{staging_dir}/bundle.wxs")
+        expect(contents).to include("<MsiPackage SourceFile=\"#{outpath}\" EnableFeatureSelection=\"no\" />")
       end
     end
 
@@ -265,6 +290,23 @@ module Omnibus
 
       it 'returns the correct value for many extensions' do
         expect(subject.wix_extension_switches(['a', 'b'])).to eq("-ext 'a' -ext 'b'")
+      end
+    end
+
+    describe "#bundle_msi" do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:bundle_msi)
+      end
+
+      it 'requires the value to be a TrueClass or a FalseClass' do
+        expect {
+          subject.bundle_msi(Object.new)
+        }.to raise_error(InvalidValue)
+      end
+
+      it 'returns the given value' do
+        subject.bundle_msi(true)
+        expect(subject.bundle_msi).to be_truthy
       end
     end
 


### PR DESCRIPTION
The delivery-cli package needs to include the MS VC Redist libraries, and so we need to create a bundled installer.
This pull-request implements the logic to do so, and I'd appreciate a review of the approach before I go through and write the necessary tests and so on.

@jaym @ksubrama @schisamo