### PR TITLE
Artifactory publisher improvements

### DIFF
--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -62,6 +62,10 @@ module Omnibus
     #
     #   $ omnibus publish artifactory libs-omnibus-local pkg/chef*
     #
+    method_option :build_record,
+      type: :boolean,
+      desc: 'Optionally create an Artifactory build record for the published artifacts',
+      default: true
     desc 'artifactory REPOSITORY PATTERN', 'Publish to an Artifactory instance'
     def artifactory(repository, pattern)
       options[:repository] = repository

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -45,24 +45,6 @@ EOH
     end
   end
 
-  class InvalidBuildPlatform < Error
-    def initialize(build_platform, pattern)
-      @build_platform, @pattern = build_platform, pattern
-    end
-
-    def to_s
-      <<-EOH
-Could not locate a package for build platform:
-
-    #{@build_platform}
-
-using pattern of:
-
-    #{@pattern}
-EOH
-    end
-  end
-
   class MissingRequiredAttribute < Error
     def initialize(instance, name, sample = '<VALUE>')
       @instance, @name, @sample = instance, name, sample

--- a/lib/omnibus/publisher.rb
+++ b/lib/omnibus/publisher.rb
@@ -82,7 +82,12 @@ module Omnibus
                 p.metadata[:platform_version] == build_platform_version
             end
 
-            raise InvalidBuildPlatform.new("#{build_platform}-#{build_platform_version}", @pattern) if packages.empty?
+            if packages.empty?
+              log.warn(log_key) do
+                "Could not locate a package for build platform #{build_platform}-#{build_platform_version}. " \
+                "Publishing will be skipped for: #{publish_platforms.join(', ')}"
+              end
+            end
 
             publish_platforms.each do |publish_platform|
               publish_platform, publish_platform_version = publish_platform.rpartition('-') - %w( - )

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -60,10 +60,12 @@ module Omnibus
         block.call(package) if block
       end
 
-      if packages.empty?
-         log.warn(log_key) { "No packages were uploaded, build object will not be created." }
-      else
-        build_for(packages).save
+      if build_record?
+        if packages.empty?
+          log.warn(log_key) { "No packages were uploaded, build record will not be created." }
+        else
+          build_for(packages).save
+        end
       end
     end
 
@@ -142,6 +144,21 @@ module Omnibus
           }
         ]
       )
+    end
+
+    #
+    # Indicates if an Artifactory build record should be created for the
+    # published set of packages.
+    #
+    # @return [Boolean]
+    #
+    def build_record?
+      # We want to create a build record by default
+      if @options[:build_record].nil?
+        true
+      else
+        @options[:build_record]
+      end
     end
 
     #

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -101,8 +101,9 @@ module Omnibus
             }
           end
 
-          it 'raises an error' do
-            expect { subject.packages }.to raise_error(InvalidBuildPlatform)
+          it 'prints a warning' do
+            output = capture_logging { subject.packages }
+            expect(output).to include('Could not locate a package for build platform ubuntu-10.04. Publishing will be skipped for: ubuntu-12.04, ubuntu-14.04')
           end
         end
       end

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -68,7 +68,7 @@ module Omnibus
         subject.publish
       end
 
-      it 'it creates a build object for all packages' do
+      it 'it creates a build record for all packages' do
         expect(build).to receive(:save).once
         subject.publish
       end
@@ -107,6 +107,15 @@ module Omnibus
           block = ->(package) { package.do_something! }
           expect(package).to receive(:do_something!).once
           subject.publish(&block)
+        end
+      end
+
+      context 'when the :build_record option is false' do
+        subject { described_class.new(path, repository: repository, build_record: false) }
+
+        it 'does not create a build record at the end of publishing' do
+          expect(build).to_not receive(:save)
+          subject.publish
         end
       end
     end


### PR DESCRIPTION
Two small tweaks from Artifactory publishing changes introduced in https://github.com/chef/omnibus/pull/508:

* only `WARN` on missing build platforms during publishing - There are valid cases where publishing will need to be done with a subset of the platform mappings matrix, for example publishing being done directly from a build slave.
* support opting out of build record creation - If we are only publishing for a subset of the platform mappings matrix we will not want an Artifactory build record created as it won’t fully represent all packages in the build.

/cc @chef/omnibus-maintainers @christophermaier 