### PR TITLE
Use windows_arch to get arch in metadata

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -108,7 +108,11 @@ module Omnibus
       # @return [String]
       #
       def arch
-        Ohai['kernel']['machine']
+        if Ohai['platform'] == 'windows'
+          Config.windows_arch
+        else
+          Ohai['kernel']['machine']
+        end
       end
 
       #

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -28,6 +28,16 @@ module Omnibus
         end
         expect(described_class.arch).to eq('x86_64')
       end
+
+      context 'on windows' do
+        it 'returns the value of Config.windows_arch' do
+          stub_ohai(platform: 'windows', version: '2012R2') do |data|
+            data['kernel']['machine'] = 'x86_64'
+          end
+          allow(Config).to receive(:windows_arch).and_return('some_arch')
+          expect(described_class.arch).to eq('some_arch')
+        end
+      end
     end
 
     describe '.platform_shortname' do


### PR DESCRIPTION
Windows is special. A builder should not rely
on it's native architecture.

cc @ksubrama @chefsalim @schisamo 