### PR TITLE
`Metadata#arch` should return a valid Ohai architecture

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -108,8 +108,8 @@ module Omnibus
       # @return [String]
       #
       def arch
-        if Ohai['platform'] == 'windows'
-          Config.windows_arch
+        if (Ohai['platform'] == 'windows') && (Config.windows_arch == :x86)
+          'i386'
         else
           Ohai['kernel']['machine']
         end

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -108,7 +108,7 @@ module Omnibus
       # @return [String]
       #
       def arch
-        if (Ohai['platform'] == 'windows') && (Config.windows_arch == :x86)
+        if (Ohai['platform'] == 'windows') && (Config.windows_arch.to_sym == :x86)
           'i386'
         else
           Ohai['kernel']['machine']

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -502,7 +502,7 @@ module Omnibus
     #
     def wix_candle_flags
       # we support x86 or x64.  No Itanium support (ia64).
-      @wix_candle_flags ||= "-arch " + (Config.windows_arch == :x86 ? "x86" : "x64")
+      @wix_candle_flags ||= "-arch " + (Config.windows_arch.to_sym == :x86 ? "x86" : "x64")
     end
 
     #

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -260,7 +260,7 @@ module Omnibus
     # @option params [String] :store (My)
     #   The name of the certificate store which contains the certificate
     # @option params [Array<String>, String] :timestamp_servers
-    #   A trusted timestamp server or a list of truested timestamp servers to 
+    #   A trusted timestamp server or a list of truested timestamp servers to
     #   be tried. They are tried in the order provided.
     # @option params [TrueClass, FalseClass] :machine_store (false)
     #   If set to true, the local machine store will be searched for a valid
@@ -293,7 +293,7 @@ module Omnibus
           end
 
           if !params[:machine_store].nil? && !(
-             params[:machine_store].is_a?(TrueClass) || 
+             params[:machine_store].is_a?(TrueClass) ||
              params[:machine_store].is_a?(FalseClass))
             raise InvalidValue.new(:params, 'contain key :machine_store of type TrueClass or FalseClass')
           end

--- a/lib/omnibus/sugarable.rb
+++ b/lib/omnibus/sugarable.rb
@@ -64,7 +64,7 @@ module Omnibus
     # Returns whether the Windows build target is 32-bit (x86).
     # If this returns false, the target is x64. Itanium is not supported.
     def windows_arch_i386?
-      Config.windows_arch == :x86
+      Config.windows_arch.to_sym == :x86
     end
   end
 end

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -30,12 +30,12 @@ module Omnibus
       end
 
       context 'on windows' do
-        it 'returns the value of Config.windows_arch' do
+        it 'returns a 32-bit value based on Config.windows_arch being set to x86' do
           stub_ohai(platform: 'windows', version: '2012R2') do |data|
             data['kernel']['machine'] = 'x86_64'
           end
-          allow(Config).to receive(:windows_arch).and_return('some_arch')
-          expect(described_class.arch).to eq('some_arch')
+          expect(Config).to receive(:windows_arch).and_return(:x86)
+          expect(described_class.arch).to eq('i386')
         end
       end
     end


### PR DESCRIPTION
The change introduced in #535 began returning architecture values of `:x86` and `:x64` on Windows. We would prefer the `*.metadata.json` files contain valid Ohai-based values of `i386` or `x86_64` as we use this data when publishing to backend systems like Artifactory. This saves unnecessary translation when fetching packages at install time.

/cc @chef/engineering-services @chef/omnibus-maintainers @chef/client-windows 
