### PR TITLE
Fix missing package name in signature

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -545,6 +545,7 @@ module Omnibus
         arr << '/sm' if machine_store?
         arr << "/s #{cert_store_name}"
         arr << "/sha1 #{thumbprint}"
+        arr << "/d #{project.package_name}"
         arr << "\"#{msi_file}\""
       end
       shellout!(cmd.join(" "))


### PR DESCRIPTION
When installing signed packages on Windows, the UAC warning currently gives a random "Program name" in the warning.  This change adds a fix so that we set the package name when signing, which then allows Windows to display the correct name.

cc @schisamo @jaym @sersut 