### PR TITLE
Issue #540 - Fix building RPMs on ARM platforms.

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -288,7 +288,6 @@ module Omnibus
           vendor:         vendor,
           license:        license,
           dist_tag:       dist_tag,
-          architecture:   safe_architecture,
           maintainer:     project.maintainer,
           homepage:       project.homepage,
           description:    project.description,
@@ -316,6 +315,7 @@ module Omnibus
     #
     def create_rpm_file
       command =  %|fakeroot rpmbuild|
+      command << %| --target #{safe_architecture}|
       command << %| -bb|
       command << %| --buildroot #{staging_dir}/BUILD|
       command << %| --define '_topdir #{staging_dir}'|

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -19,7 +19,6 @@ Name: <%= name %>
 Version: <%= version %>
 Release: <%= iteration %><%= dist_tag %>
 Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
-BuildArch: <%= architecture %>
 AutoReqProv: no
 BuildRoot: %buildroot
 Prefix: /

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -19,6 +19,7 @@ module Omnibus
     let(:project_root) { File.join(tmp_path, 'project/root') }
     let(:package_dir)  { File.join(tmp_path, 'package/dir') }
     let(:staging_dir)  { File.join(tmp_path, 'staging/dir') }
+    let(:architecture) { 'x86_64' }
 
     before do
       Config.project_root(project_root)
@@ -32,7 +33,9 @@ module Omnibus
       create_directory("#{staging_dir}/SOURCES")
       create_directory("#{staging_dir}/SPECS")
 
-      stub_ohai(platform: 'redhat', version: '6.5')
+      stub_ohai(platform: 'redhat', version: '6.5') do |data|
+        data['kernel']['machine'] = architecture
+      end
     end
 
     describe '#signing_passphrase' do
@@ -251,7 +254,7 @@ module Omnibus
 
       it 'uses the correct command' do
         expect(subject).to receive(:shellout!)
-          .with(/rpmbuild --target x86_64 -bb --buildroot/)
+          .with(/rpmbuild --target #{architecture} -bb --buildroot/)
         subject.create_rpm_file
       end
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -144,7 +144,6 @@ module Omnibus
         expect(contents).to include("Version: 1.2.3")
         expect(contents).to include("Release: 2.el6")
         expect(contents).to include("Summary:  The full stack of project")
-        expect(contents).to include("BuildArch: x86_64")
         expect(contents).to include("AutoReqProv: no")
         expect(contents).to include("BuildRoot: %buildroot")
         expect(contents).to include("Prefix: /")
@@ -252,7 +251,7 @@ module Omnibus
 
       it 'uses the correct command' do
         expect(subject).to receive(:shellout!)
-          .with(/rpmbuild -bb --buildroot/)
+          .with(/rpmbuild --target x86_64 -bb --buildroot/)
         subject.create_rpm_file
       end
 


### PR DESCRIPTION
The BuildArch line technically is not needed as we are not building anything during the RPM generation stage. On some systems this line causes a failure, which can be handled by specifying the target arch
when creating the rpm instead.

Closes #540.