### PR TITLE
net_fetcher: missing checksum raises exception

### DIFF
--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -214,6 +214,18 @@ EOH
     end
   end
 
+  class ChecksumMissing < Error
+    def initialize(software)
+      super <<-EOH
+Verification for #{software.name} failed due to a missing checksum.
+
+This added security check is used to prevent MITM attacks when downloading the
+remote file. You must specify a checksum for each version of software downloaded
+from a remote location.
+EOH
+    end
+  end
+
   class ChecksumMismatch < Error
     def initialize(software, expected, actual)
       super <<-EOH

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -229,12 +229,16 @@ module Omnibus
     #
     # The digest type defined in the software definition
     #
+    # @raise [ChecksumMissing]
+    #   if the checksum does not exist
+    #
     # @return [Symbol]
     #
     def digest_type
       DIGESTS.each do |digest|
         return digest if source.key? digest
       end
+      raise ChecksumMissing.new(self)
     end
 
     #

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -96,7 +96,7 @@ module Omnibus
       when 1
         from_hash_v1(manifest_data)
       else
-        raise InvalidManifestFormat, "Unknown manifest fromat version: #{manifest_data['manifest_format']}"
+        raise InvalidManifestFormat, "Unknown manifest format version: #{manifest_data['manifest_format']}"
       end
     end
 

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -137,6 +137,16 @@ module Omnibus
         end
       end
 
+      context 'source with no checksum' do
+        let(:source) do
+          { url: source_url }
+        end
+
+        it 'raises an exception' do
+          expect { fetch! }.to raise_error(ChecksumMissing)
+        end
+      end
+
       context 'source with sha1' do
         let(:source) do
           { url: source_url, sha1: source_sha1 }


### PR DESCRIPTION

Changes a stack trace that looks like this...

```
/usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-c1ba5c098195/lib/omnibus/digestable.rb:104:in `const_get': wrong constant name [:SHA512, :SHA256, :SHA1, :MD5] (NameError)
	from /usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-c1ba5c098195/lib/omnibus/digestable.rb:104:in `digest_from_type'
	from /usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-c1ba5c098195/lib/omnibus/digestable.rb:40:in `digest'
	from /usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-c1ba5c098195/lib/omnibus/fetchers/net_fetcher.rb:250:in `verify_checksum!'
```

To an error message that looks like this...

```
Verification for _SOURCENAME_ failed due to a missing checksum.

This added security check is used to prevent MITM attacks when downloading the
remote file. You must specify a checksum for each version of software downloaded
from a remote location.

/usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-7253666105ad/lib/omnibus/fetchers/net_fetcher.rb:241:in `digest_type'
  /usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-7253666105ad/lib/omnibus/fetchers/net_fetcher.rb:125:in `checksum'
  /usr/lib64/ruby/gems/2.0.0/bundler/gems/omnibus-7253666105ad/lib/omnibus/fetchers/net_fetcher.rb:253:in `verify_checksum!'
...
```

Also sneaks in a fix for a typo.
