### PR TITLE
support epoch in RPM packages

### DIFF
--- a/docs/Building on RHEL.md
+++ b/docs/Building on RHEL.md
@@ -65,6 +65,7 @@ Some DSL methods available include:
 | `vendor`             | The name of the package producer            |
 | `license`            | The default license for the package         |
 | `priority`           | The priority for the package                |
+| `epoch`              | The epoch of the package                    |
 | `category`           | The category for this package               |
 
 If you are unfamilar with any of these terms, you should just accept the defaults. For more information on the purpose of any of these configuration options, please see the RPM spec.

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -203,6 +203,31 @@ module Omnibus
     expose :category
 
     #
+    # Set or return the epoch of the package
+    #
+    # @example
+    #   epoch 1
+    #
+    # @param [Fixnum] val
+    #   the epoch of the package
+    #
+    # @return [Fixnum]
+    #   the epoch of the package
+    #
+    def epoch(val = NULL)
+      if null?(val)
+        @epoch # nil response is okay
+      else
+        unless val.is_a?(Fixnum)
+          raise InvalidValue.new(:epoch, 'be a Fixnum')
+        end
+
+        @epoch = val
+      end
+    end
+    expose :epoch
+
+    #
     # @!endgroup
     # --------------------------------------------------
 
@@ -292,6 +317,7 @@ module Omnibus
           homepage:        project.homepage,
           description:     project.description,
           priority:        priority,
+          epoch:           epoch,
           category:        category,
           conflicts:       project.conflicts,
           replaces:        project.replaces,

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -25,6 +25,9 @@ Prefix: /
 Group: <%= category %>
 License: <%= license %>
 Vendor: <%= vendor %>
+<% if epoch -%>
+Epoch: <%= epoch %>
+<% end -%>
 URL: <%= homepage %>
 Packager: <%= maintainer %>
 <% dependencies.each do |name| -%>

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -91,6 +91,20 @@ module Omnibus
       end
     end
 
+    describe '#epoch' do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:epoch)
+      end
+
+      it 'has no default value' do
+        expect(subject.epoch).to eq(nil)
+      end
+
+      it 'must be a Fixnum' do
+        expect { subject.epoch(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
     describe '#category' do
       it 'is a DSL method' do
         expect(subject).to have_exposed_method(:category)
@@ -156,6 +170,14 @@ module Omnibus
         expect(contents).to include("URL: https://example.com")
         expect(contents).to include("Packager: Chef Software")
         expect(contents).to include("Obsoletes: old-project")
+      end
+
+      it 'supports the epoch tag' do
+        allow(subject).to receive(:epoch).and_return(42)
+        subject.write_rpm_spec
+        contents = File.read(spec_file)
+
+        expect(contents).to include("Epoch: 42")
       end
 
       context 'when scripts are given' do


### PR DESCRIPTION
Epoch number is required for some RPM packages to work correctly.

I considered adding equivalent support for Debian packages, but Omnibus already supports Debian packages by allowing a colon in the version number.