### PR TITLE
Add info message for publish cli corner case

### DIFF
--- a/lib/omnibus/publisher.rb
+++ b/lib/omnibus/publisher.rb
@@ -112,6 +112,10 @@ module Omnibus
           publish_packages.concat(build_packages)
         end
 
+        if publish_packages.empty?
+          log.info(log_key) { 'No packages found, skipping publish' }
+        end
+
         publish_packages
       end
     end

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -23,6 +23,10 @@ module Omnibus
       log.info(log_key) { 'Starting artifactory publisher' }
       safe_require('artifactory')
 
+      if packages.empty?
+        log.info(log_key) { 'No packages found, skipping publish' }
+      end
+
       packages.each do |package|
         # Make sure the package is good to go!
         log.debug(log_key) { "Validating '#{package.name}'" }

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -23,10 +23,6 @@ module Omnibus
       log.info(log_key) { 'Starting artifactory publisher' }
       safe_require('artifactory')
 
-      if packages.empty?
-        log.info(log_key) { 'No packages found, skipping publish' }
-      end
-
       packages.each do |package|
         # Make sure the package is good to go!
         log.debug(log_key) { "Validating '#{package.name}'" }

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -107,6 +107,20 @@ module Omnibus
           end
         end
       end
+
+      context 'there are no packages to publish' do
+        before do
+          allow(FileSyncer).to receive(:glob)
+            .with(pattern)
+            .and_return([])
+        end
+
+        it 'prints a warning' do
+          output = capture_logging { subject.packages }
+          expect(output).to include('No packages found, skipping publish')
+        end
+      end
+
     end
 
     describe '#publish' do


### PR DESCRIPTION
Simple corner case on the off chance you are using publish from command line, if no packages are found, it silently 'fails'

@chef/omnibus-maintainers 