### PR TITLE
Issue#509: Reset index and working tree to original clone

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -37,7 +37,8 @@ module Omnibus
     end
 
     #
-    # Clean the project directory by removing the contents from disk.
+    # Clean the project directory by removing untracked contents from disk and
+    # resetting both index and working tree to original clone.
     #
     # @return [true, false]
     #   true if the project directory was removed, false otherwise
@@ -45,6 +46,7 @@ module Omnibus
     def clean
       if cloned?
         log.info(log_key) { 'Cleaning existing clone' }
+        git("reset --hard #{resolved_version}")
         git('clean -fdx')
         true
       else


### PR DESCRIPTION
Original the problem arrises when software uses GitFetcher and build fails **after** a patch is applied. Currently, in the next build attempt, only `git clean -fdx` is called in #{project_dir}, as result any modification to a tracked file is left un-reverted in the working tree. 

This can become an automated build blocker if there is an intermittent build failure. E.g.: timeout while running `bundle install` in Builder after a patch is applied. 

Let me know what tests to run or update.