### PR TITLE
Skip registry harvesting, suppress warning

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -53,7 +53,7 @@ module Omnibus
       Dir.chdir(staging_dir) do
         shellout! <<-EOH.split.join(' ').squeeze(' ').strip
           heat.exe dir "#{windows_safe_path(project.install_dir)}"
-            -nologo -srd -gg -cg ProjectDir
+            -nologo -srd -sreg -gg -cg ProjectDir
             -dr PROJECTLOCATION
             -var "var.ProjectSourceDir"
             -out "project-files.wxs"


### PR DESCRIPTION
Heat currently spits out tons of warnings like this:
| heat.exe : warning HEAT5150 : Could not harvest data from a file that was expected to be a SelfReg DLL: C:\opscode\chef\embedded\bin\libeay32.dll. If this file does not support SelfReg you can ignore this warning. Otherwise, this error detail may be helpful to diagnose the failure: Unable to load file: C:\opscode\chef\embedded\bin\libeay32.dll, error: 193

These are false positives.  Since we don't actually do any registry harvesting, we can turn these off by passing the "-sreg" flag to heat.

@chef/omnibus-maintainers @ksubrama 
