### PR TITLE
Add Debian arm64 support

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -408,6 +408,10 @@ module Omnibus
         else
           Ohai['kernel']['machine']
         end
+      when 'aarch64'
+        # Debian prefers amd64 on ARMv8/AArch64 (64bit ARM) platforms
+        # see https://wiki.debian.org/Arm64Port
+        'arm64'
       when 'ppc64le'
         # Debian prefers to use ppc64el for little endian architecture name 
         # where as others like gnutools/rhel use ppc64le( note the last 2 chars)

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -209,9 +209,9 @@ module Omnibus
         subject.write_md5_sums
         contents = File.read("#{staging_dir}/DEBIAN/md5sums")
 
-         expect(contents).to include("9334770d184092f998009806af702c8c .filea")
-         expect(contents).to include("826e8142e6baabe8af779f5f490cf5f5 file1")
-         expect(contents).to include("1c1c96fd2cf8330db0bfa936ce82f3b9 file2")
+        expect(contents).to include("9334770d184092f998009806af702c8c .filea")
+        expect(contents).to include("826e8142e6baabe8af779f5f490cf5f5 file1")
+        expect(contents).to include("1c1c96fd2cf8330db0bfa936ce82f3b9 file2")
       end
     end
 
@@ -243,8 +243,8 @@ module Omnibus
       before do
         project.install_dir(staging_dir)
 
-        create_file("#{staging_dir}/file1") { "1"*10_000 }
-        create_file("#{staging_dir}/file2") { "2"*20_000 }
+        create_file("#{staging_dir}/file1") { "1" * 10_000 }
+        create_file("#{staging_dir}/file2") { "2" * 20_000 }
       end
 
       it 'stats all the files in the install_dir' do
@@ -388,6 +388,18 @@ module Omnibus
           it 'returns armhf' do
             expect(subject.safe_architecture).to eq('armhf')
           end
+        end
+      end
+
+      context '64bit ARM platform' do
+        before do
+          stub_ohai(platform: 'ubuntu', version: '14.04') do |data|
+            data['kernel']['machine'] = 'aarch64'
+          end
+        end
+
+        it 'returns arm64' do
+          expect(subject.safe_architecture).to eq('arm64')
         end
       end
     end


### PR DESCRIPTION
Debian has decided that ARMv8 is "arm64" platform instead of the
GCC stated "aarch64" platform. This adds support for that in the
omnibus deb packager.

Greetings @chef/omnibus-maintainers This just makes building packages on 64bit ARM platforms work correctly in Debian. Similar to Raspberry Pi issues. This is the replacement for #562 