### PR TITLE
[JEX-52] support custom properties in Artifactory publishing

### DIFF
--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -70,6 +70,10 @@ module Omnibus
       type: :boolean,
       desc: 'Optionally create an Artifactory build record for the published artifacts',
       default: true
+    method_option :properties,
+      type: :hash,
+      desc: 'Properites to attach to published artifacts',
+      default: {}
     desc 'artifactory REPOSITORY PATTERN', 'Publish to an Artifactory instance'
     def artifactory(repository, pattern)
       options[:repository] = repository

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -38,7 +38,7 @@ module Omnibus
             artifact_for(package).upload(
               repository,
               remote_path_for(package),
-              metadata_properties_for(package),
+              default_properties.merge(metadata_properties_for(package)),
             )
           end
         rescue Artifactory::Error::HTTPError => e
@@ -117,11 +117,11 @@ module Omnibus
           name: 'omnibus',
           version: Omnibus::VERSION,
         },
-        properties: {
+        properties: default_properties.merge(
           'omnibus.project' => name,
           'omnibus.version' => manifest.build_version,
           'omnibus.version_manifest' => manifest.to_json,
-        },
+        ),
         modules: [
           {
             # com.getchef:chef-server:12.0.0
@@ -204,6 +204,14 @@ module Omnibus
       ) if build_record?
       metadata
     end
+
+    #
+    # Properties to attach to published artifacts (and build record).
+    #
+    # @return [Hash<String, String>]
+    #
+    def default_properties
+      @properties ||= @options[:properties] || {}
     end
 
     #

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -38,10 +38,7 @@ module Omnibus
             artifact_for(package).upload(
               repository,
               remote_path_for(package),
-              metadata_for(package).merge(
-                'build.name'   => package.metadata[:name],
-                'build.number' => package.metadata[:version],
-              ),
+              metadata_properties_for(package),
             )
           end
         rescue Artifactory::Error::HTTPError => e
@@ -188,8 +185,8 @@ module Omnibus
     #
     # @return [Hash<String, String>]
     #
-    def metadata_for(package)
-      {
+    def metadata_properties_for(package)
+      metadata = {
         'omnibus.project'          => package.metadata[:name],
         'omnibus.platform'         => package.metadata[:platform],
         'omnibus.platform_version' => package.metadata[:platform_version],
@@ -201,6 +198,12 @@ module Omnibus
         'omnibus.sha256'           => package.metadata[:sha256],
         'omnibus.sha512'           => package.metadata[:sha512],
       }
+      metadata.merge!(
+        'build.name'   => package.metadata[:name],
+        'build.number' => package.metadata[:version],
+      ) if build_record?
+      metadata
+    end
     end
 
     #


### PR DESCRIPTION
This will allow an end user to attach custom artifact properties when publishing to Artifactory. Chef Software, Inc. will leverage this feature to attach various Delivery metadata (`delivery.change_id`, `delivery.sha` etc) to each published artifact.

@chef/engineering-services @chef/omnibus-maintainers @xenolinguist @oferrigni @seth 