### PR TITLE
Update generator README for correct Ruby version

### DIFF
--- a/lib/omnibus/generator_files/README.md.erb
+++ b/lib/omnibus/generator_files/README.md.erb
@@ -5,7 +5,7 @@ This project creates full-stack platform-specific packages for
 
 Installation
 ------------
-You must have a sane Ruby 1.9+ environment with Bundler installed. Ensure all
+You must have a sane Ruby 2.0.0+ environment with Bundler installed. Ensure all
 the required gems are installed:
 
 ```shell


### PR DESCRIPTION
As Omnibus now requires Ruby 2.0.0+, the generated README.md should be updated.