### PR TITLE
Add a FIPS mode flag in omnibus.

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -471,6 +471,12 @@ module Omnibus
       :x86
     end
 
+    # Should FIPS mode be enabled?  This will affect how ruby is build,
+    # how openssl is built and what libraries are vendored.
+    #
+    # @return [true, false]
+    default(:fips_mode, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/sugarable.rb
+++ b/lib/omnibus/sugarable.rb
@@ -71,5 +71,10 @@ module Omnibus
     def windows_arch_i386?
       Config.windows_arch.to_sym == :x86
     end
+
+    # Returns if the global fips mode flag was enabled.
+    def fips_mode?
+      Config.fips_mode
+    end
   end
 end

--- a/spec/unit/sugarable_spec.rb
+++ b/spec/unit/sugarable_spec.rb
@@ -44,6 +44,8 @@ module Omnibus
         expect(klass).to be_method_defined(:windows?)
         expect(klass).to be_method_defined(:vagrant?)
         expect(klass).to be_method_defined(:_64_bit?)
+        expect(klass).to be_method_defined(:windows_arch_i386?)
+        expect(klass).to be_method_defined(:fips_mode?)
       end
 
       it 'makes the DSL methods available in the cleanroom' do
@@ -51,6 +53,8 @@ module Omnibus
           instance.evaluate <<-EOH.gsub(/^ {12}/, '')
             windows?
             vagrant?
+            windows_arch_i386?
+            fips_mode?
           EOH
         }.to_not raise_error
       end


### PR DESCRIPTION
This will allow software definitions to pull in the right version of binaries and vary how it builds ruby accordingly.