### PR TITLE
Default to UTF-8 external encoding globally.

### DIFF
--- a/bin/omnibus
+++ b/bin/omnibus
@@ -8,4 +8,9 @@ $:.push File.expand_path('../../lib', __FILE__)
 $stdout.sync = true
 
 require 'omnibus/cli'
+
+# Some platforms do not have a UTF-8 locale, so we need to enforce one
+# or else the cacert chain will break among other things
+Encoding.default_external = Encoding::UTF_8
+
 Omnibus::CLI::Runner.new(ARGV.dup).execute!


### PR DESCRIPTION
Many omnibus projects will not build properly without UTF-8
encoding. This sets the default external encoding to UTF-8
via ruby, which works even when the platform's locale is C or
some other non-UTF-8 encoding. UTF-8 is backwards compatible with
C, POSIX, and ASCII so there should be no issues. The default
can be overridden the per-project omnibus.rb file still.

@chef/omnibus-maintainers 