### PR TITLE
Properly decompress `.tar.lzma` files

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -271,10 +271,11 @@ module Omnibus
       elsif Ohai['platform'] != 'windows' && downloaded_file.end_with?('.zip')
         "unzip #{windows_safe_path(downloaded_file)} -d #{Config.source_dir}"
       elsif downloaded_file.end_with?(*TAR_EXTENSIONS)
-        compression_switch = 'z' if downloaded_file.end_with?('gz')
-        compression_switch = 'j' if downloaded_file.end_with?('bz2')
-        compression_switch = 'J' if downloaded_file.end_with?('xz')
-        compression_switch = ''  if downloaded_file.end_with?('tar')
+        compression_switch = 'z'        if downloaded_file.end_with?('gz')
+        compression_switch = '--lzma -' if downloaded_file.end_with?('lzma')
+        compression_switch = 'j'        if downloaded_file.end_with?('bz2')
+        compression_switch = 'J'        if downloaded_file.end_with?('xz')
+        compression_switch = ''         if downloaded_file.end_with?('tar')
 
         "#{tar} #{compression_switch}xf #{windows_safe_path(downloaded_file)} -C#{Config.source_dir}"
       end

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -334,7 +334,7 @@ module Omnibus
         it_behaves_like 'an extractor', 'tar.bz2', 'tar jxf C:\\file.tar.bz2 -C/tmp/out'
         it_behaves_like 'an extractor', 'txz',     'tar Jxf C:\\file.txz -C/tmp/out'
         it_behaves_like 'an extractor', 'tar.xz',  'tar Jxf C:\\file.tar.xz -C/tmp/out'
-        it_behaves_like 'an extractor', 'tar.lzma', 'tar xf C:\\file.tar.lzma -C/tmp/out'
+        it_behaves_like 'an extractor', 'tar.lzma', 'tar --lzma -xf C:\\file.tar.lzma -C/tmp/out'
       end
 
       context 'on Linux' do
@@ -352,7 +352,7 @@ module Omnibus
         it_behaves_like 'an extractor', 'tar.bz2', 'tar jxf /file.tar.bz2 -C/tmp/out'
         it_behaves_like 'an extractor', 'txz',     'tar Jxf /file.txz -C/tmp/out'
         it_behaves_like 'an extractor', 'tar.xz',  'tar Jxf /file.tar.xz -C/tmp/out'
-        it_behaves_like 'an extractor', 'tar.lzma', 'tar xf /file.tar.lzma -C/tmp/out'
+        it_behaves_like 'an extractor', 'tar.lzma', 'tar --lzma -xf /file.tar.lzma -C/tmp/out'
       end
 
       context 'when gtar is present' do
@@ -375,7 +375,7 @@ module Omnibus
         it_behaves_like 'an extractor', 'tar.bz2', 'gtar jxf /file.tar.bz2 -C/tmp/out'
         it_behaves_like 'an extractor', 'txz',     'gtar Jxf /file.txz -C/tmp/out'
         it_behaves_like 'an extractor', 'tar.xz',  'gtar Jxf /file.tar.xz -C/tmp/out'
-        it_behaves_like 'an extractor', 'tar.lzma', 'gtar xf /file.tar.lzma -C/tmp/out'
+        it_behaves_like 'an extractor', 'tar.lzma', 'gtar --lzma -xf /file.tar.lzma -C/tmp/out'
       end
     end
   end

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -137,7 +137,7 @@ module Omnibus
         end
       end
 
-      context 'when paths with colons/commas are present' do
+      context 'when paths with colons/commas are present', if: !windows? do
         let(:contents) do
           subject.write_gen_template
           File.read(gen_file)


### PR DESCRIPTION
This builds on the `.tar.lzma` support added in chef/omnibus#572. We should properly decompress the file before extracting. This follows the pattern followed by other compressed files like `.tar.gz` and `.tar.bz2`.

/cc @chef/omnibus-maintainers @ksubrama 