### PR TITLE
Create the config script as needed when renaming files on AIX

### DIFF
--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -143,12 +143,17 @@ module Omnibus
 
           # Create a config script if needed based on resources/bff/config.erb
           config_script_path = File.join(scripts_staging_dir, 'config')
-          render_template(resource_path('config.erb'),
-            destination: config_script_path,
-          ) unless File.exists? config_script_path
+          unless File.exists? config_script_path
+            render_template(resource_path('config.erb'),
+              destination: "#{scripts_staging_dir}/config",
+              variables: {
+                name: project.name
+              }
+            )
+          end
 
           File.open(File.join(scripts_staging_dir, 'config'), 'a') do |file|
-            file.puts "mv #{alt.gsub(/^#{staging_dir}/, '')} #{path.gsub(/^#{staging_dir}/, '')}"
+            file.puts "mv '#{alt.gsub(/^#{staging_dir}/, '')}' '#{path.gsub(/^#{staging_dir}/, '')}'"
           end
 
           path = alt

--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -88,7 +88,6 @@ module Omnibus
         if File.file?(source_path)
           log.debug(log_key) { "Adding script `#{script}' to `#{scripts_staging_dir}'" }
           copy_file(source_path, scripts_staging_dir)
-          log.debug(log_key) { _installp_name + ":\n" + File.read(File.join(scripts_staging_dir, script.to_s)) }
         end
       end
     end
@@ -130,24 +129,23 @@ module Omnibus
     #   Unconfiguration Script: /path/script
     #
     def write_gen_template
-      # Create a map of scripts that exist to inject into the template
-      scripts = SCRIPT_MAP.inject({}) do |hash, (script, installp_key)|
-        staging_path =  File.join(scripts_staging_dir, script.to_s)
-
-        if File.file?(staging_path)
-          hash[installp_key] = staging_path
-        end
-
-        hash
-      end
 
       # Get a list of all files
       files = FileSyncer.glob("#{staging_dir}/**/*").map do |path|
+
+        # If paths have colons or commas, rename them and add them to a post-install,
+        # post-sysck renaming script ('config') which is created if needed
         if path.match(/:|,/)
           alt = path.gsub(/(:|,)/, '__')
           log.debug(log_key) { "Renaming #{path} to #{alt}" }
 
           File.rename(path, alt) if File.exists?(path)
+
+          # Create a config script if needed based on resources/bff/config.erb
+          config_script_path = File.join(scripts_staging_dir, 'config')
+          render_template(resource_path('config.erb'),
+            destination: config_script_path,
+          ) unless File.exists? config_script_path
 
           File.open(File.join(scripts_staging_dir, 'config'), 'a') do |file|
             file.puts "mv #{alt.gsub(/^#{staging_dir}/, '')} #{path.gsub(/^#{staging_dir}/, '')}"
@@ -157,6 +155,18 @@ module Omnibus
         end
 
         path.gsub(/^#{staging_dir}/, '')
+      end
+
+      # Create a map of scripts that exist to inject into the template
+      scripts = SCRIPT_MAP.inject({}) do |hash, (script, installp_key)|
+        staging_path =  File.join(scripts_staging_dir, script.to_s)
+
+        if File.file?(staging_path)
+          hash[installp_key] = staging_path
+          log.debug(log_key) { _installp_name + ":\n" + File.read(staging_path) }
+        end
+
+        hash
       end
 
       render_template(resource_path('gen.template.erb'),

--- a/resources/bff/config.erb
+++ b/resources/bff/config.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Perform necessary <%= config[:name] %> post install steps
+# Perform necessary <%= name %> post install steps
 # after package is installed.
 #
 
-echo "<%= config[:name] %> has been configured!"
+echo "<%= name %> has been configured!"

--- a/resources/bff/config.erb
+++ b/resources/bff/config.erb
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Perform necessary <%= config[:name] %> post install steps
+# after package is installed.
+#
+
+echo "<%= config[:name] %> has been configured!"

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -165,6 +165,30 @@ module Omnibus
         it 'renames comma directory names in the template' do
           expect(contents).to include("/comma__dir/file")
         end
+
+        context 'creates a config script' do
+          it 'when there wasn\'t one provided' do
+            FileUtils.rm_f("#{subject.scripts_staging_dir}/config")
+            subject.write_gen_template
+            expect(File).to exist("#{subject.scripts_staging_dir}/config")
+          end
+
+          it 'when one is provided in the project\'s def' do
+            create_file("#{project_root}/package-scripts/project/config")
+            subject.write_gen_template
+            contents = File.read("#{subject.scripts_staging_dir}/config")
+            expect(contents).to include("mv '/man3/App____Cpan.3' '/man3/App::Cpan.3'")
+          end
+
+          it 'with mv commands for all the renamed files' do
+            subject.write_gen_template
+            contents = File.read("#{subject.scripts_staging_dir}/config")
+            expect(contents).to include("mv '/man3/App____Cpan.3' '/man3/App::Cpan.3'")
+            expect(contents).to include("mv '/comma__file' '/comma,file'")
+            expect(contents).to include("mv '/colon____dir/file' '/colon::dir/file'")
+            expect(contents).to include("mv '/comma__dir/file' '/comma,dir/file'")
+          end
+        end
       end
 
       context 'when script files are present' do


### PR DESCRIPTION
Previously, the script would not be included in the package unless an empty 'config' script was added to said projects' `omnibus-*` repo's `package-script` directory.

/cc @chef/omnibus-maintainers @chef/engineering-services @lamont-granquist @juliandunn 