### PR TITLE
Use 7z on windows instead of tar.exe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
     - 2.0-stable
     - 3.0-stable
     - master
+before_install: gem install bundler
 script: bundle exec rake travis:ci
 notifications:
   slack:


### PR DESCRIPTION
tar.exe has issues when tar files have read-only files.
When a read only file exists on disk, tar will be unable
to overwrite the file.

cc @chef/omnibus-maintainers @chefsalim 