### PR TITLE
Avoid Errno::EEXIST on rhel 5 when packaging...

### DIFF
--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -138,7 +138,7 @@ module Omnibus
     #
     def run!
       # Ensure the package directory exists
-      create_directory(Config.package_dir)
+      create_directory(Config.package_dir) unless Dir.exists?(Config.package_dir)
 
       # Run the setup and build sequences
       instance_eval(&self.class.setup) if self.class.setup


### PR DESCRIPTION
I don't even..
```
                      [HealthCheck] D | Analyzing dependencies for /opt/angrychef/bin/.gitkeep
                      [HealthCheck] D | Analyzing dependencies for /opt/angrychef/version-manifest.json
                    [Packager::RPM] D | Creating directory `/var/cache/omnibus/pkg'
/opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:250:in `mkdir': File exists @ dir_s_mkdir - /var/cache/omnibus/pkg (Errno::EEXIST)
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:250:in `fu_mkdir'
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:224:in `block (2 levels) in mkdir_p'
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:222:in `reverse_each'
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:222:in `block in mkdir_p'
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:208:in `each'
	from /opt/languages/ruby/2.1.5/lib/ruby/2.1.0/fileutils.rb:208:in `mkdir_p'
	from /home/jenkins/workspace/angrychef-build/architecture/i386/platform/el-5/project/angrychef/role/builder/vendor/bundle/ruby/2.1.0/bundler/gems/omnibus-39e6ff8fa327/lib/omnibus/util.rb:136:in `create_directory'
```

/cc @chef/engineering-services