### PR TITLE
Make generated package scripts old-school Unix friendly

### DIFF
--- a/lib/omnibus/generator_files/package_scripts/postinst.erb
+++ b/lib/omnibus/generator_files/package_scripts/postinst.erb
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Perform necessary <%= config[:name] %> setup steps
 # after package is installed.
 #
 
-PROGNAME=$(basename $0)
+PROGNAME=`basename $0`
 
-function error_exit
+error_exit()
 {
   echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
   exit 1

--- a/lib/omnibus/generator_files/package_scripts/postrm.erb
+++ b/lib/omnibus/generator_files/package_scripts/postrm.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Perform necessary <%= config[:name] %> removal steps
 # after package is uninstalled.

--- a/lib/omnibus/generator_files/package_scripts/preinst.erb
+++ b/lib/omnibus/generator_files/package_scripts/preinst.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Perform necessary <%= config[:name] %> setup steps
 # before package is installed.

--- a/lib/omnibus/generator_files/package_scripts/prerm.erb
+++ b/lib/omnibus/generator_files/package_scripts/prerm.erb
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Perform necessary <%= config[:name] %> setup steps
 # prior to installing package.
 #
 
-PROGNAME=$(basename $0)
+PROGNAME=`basename $0`
 
-function error_exit
+error_exit()
 {
   echo "${PROGNAME}: ${1:-"Unknown Error"}" 1>&2
   exit 1


### PR DESCRIPTION
This matches the scripts we use in the Chef project. This change has been tested across the full Chef matrix in the context of the Harmony integration project also:
https://github.com/chef/omnibus-harmony/pull/13
http://manhattan.ci.chef.co/job/harmony-trigger-ad_hoc/5/downstreambuildview/

/cc @chef/omnibus-maintainers @chef/engineering-services 