### PR TITLE
Use -O2 when building with standard compiler flags

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -492,7 +492,7 @@ module Omnibus
         when "mac_os_x"
           {
             "LDFLAGS" => "-L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "solaris2"
           {
@@ -505,7 +505,7 @@ module Omnibus
         when "freebsd"
           freebsd_flags = {
             "LDFLAGS" => "-L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
           # Clang became the default compiler in FreeBSD 10+
           if Ohai['os_version'].to_i >= 1000024
@@ -532,7 +532,7 @@ module Omnibus
         else
           {
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         end
 

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -62,9 +62,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -72,9 +72,9 @@ module Omnibus
         it 'overrides LDFLAGS' do
           expect(subject.with_standard_compiler_flags('LDFLAGS'        => 'foo')).to eq(
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -82,9 +82,9 @@ module Omnibus
         it 'overrides CFLAGS' do
           expect(subject.with_standard_compiler_flags('CFLAGS'=>'foo')).to eq(
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -92,9 +92,9 @@ module Omnibus
         it 'overrides CXXFLAGS' do
           expect(subject.with_standard_compiler_flags('CXXFLAGS'=>'foo')).to eq(
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -102,9 +102,9 @@ module Omnibus
         it 'overrides CPPFLAGS' do
           expect(subject.with_standard_compiler_flags('CPPFLAGS'=>'foo')).to eq(
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -113,9 +113,9 @@ module Omnibus
           expect(subject.with_standard_compiler_flags('numberwang'=>4)).to eq(
             'numberwang'      => 4,
             'LDFLAGS'         => '-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            'CXXFLAGS'        => '-I/opt/project/embedded/include',
-            'CPPFLAGS'        => '-I/opt/project/embedded/include',
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -177,9 +177,9 @@ module Omnibus
         it 'sets the defaults' do
           expect(subject.with_standard_compiler_flags).to eq(
             'LDFLAGS'         => '-L/opt/project/embedded/lib',
-            'CFLAGS'          => '-I/opt/project/embedded/include',
-            "CXXFLAGS"        => "-I/opt/project/embedded/include",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include",
+            'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             'LD_RUN_PATH'     => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
           )
@@ -218,9 +218,9 @@ module Omnibus
 
         it 'sets the defaults' do
           expect(subject.with_standard_compiler_flags).to eq(
-            'CFLAGS'  => '-I/opt/project/embedded/include',
-            'CXXFLAGS'  => '-I/opt/project/embedded/include',
-            'CPPFLAGS'  => '-I/opt/project/embedded/include',
+            'CFLAGS'  => '-I/opt/project/embedded/include -O2',
+            'CXXFLAGS'  => '-I/opt/project/embedded/include -O2',
+            'CPPFLAGS'  => '-I/opt/project/embedded/include -O2',
             'LDFLAGS' => '-L/opt/project/embedded/lib',
             'LD_RUN_PATH' => '/opt/project/embedded/lib',
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig',
@@ -236,9 +236,9 @@ module Omnibus
             expect(subject.with_standard_compiler_flags).to eq(
               'CC'              => 'clang',
               'CXX'             => 'clang++',
-              'CFLAGS'          => '-I/opt/project/embedded/include',
-              'CXXFLAGS'        => '-I/opt/project/embedded/include',
-              'CPPFLAGS'        => '-I/opt/project/embedded/include',
+              'CFLAGS'          => '-I/opt/project/embedded/include -O2',
+              'CXXFLAGS'        => '-I/opt/project/embedded/include -O2',
+              'CPPFLAGS'        => '-I/opt/project/embedded/include -O2',
               'LDFLAGS'         => '-L/opt/project/embedded/lib',
               'LD_RUN_PATH'     => '/opt/project/embedded/lib',
               'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig',
@@ -474,12 +474,12 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
-          
+
           it 'sets the fetcher project_dir to fetch_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -487,12 +487,12 @@ module Omnibus
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to fetch_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -509,12 +509,12 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'for back-compat, changes fetch_dir' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -522,12 +522,12 @@ module Omnibus
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
@@ -543,12 +543,12 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'for back-compat, changes fetch_dir' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -556,12 +556,12 @@ module Omnibus
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end


### PR DESCRIPTION
Since we are setting CFLAGS explicitly, we override any Makefile
defaults, which will often be -O2.