### PR TITLE
Initial WIP for automatically updating config.guess via DSL call

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -635,6 +635,37 @@ module Omnibus
     end
     expose :sync
 
+
+    def update_config_guess(target = '', version = 'master', options = {})
+      destination = File.join(software.project_dir, target)
+
+      c_g_data = {
+        :locked_version => version,
+        :locked_source => {
+          :git=>"http://git.savannah.gnu.org/r/config.git"
+        },
+        :source_type => 'git',
+        :described_version => version
+      }
+
+      config_guess_manifest = ManifestEntry.new('config_guess', c_g_data)
+
+      config_guess_dir = File.join(Config.source_dir, "config_guess-#{version}")
+      config_guess_fetcher = GitFetcher.new(config_guess_manifest, config_guess_dir, destination)
+
+      config_guess_fetcher.fetch
+
+      if options[:config_guess_only] == true
+        copy("#{config_guess_dir}/config.guess", destination)
+      elsif options[:config_sub_only] == true
+        copy("#{config_guess_dir}/config.sub", destination)
+      else
+        copy("#{config_guess_dir}/config.guess", destination)
+        copy("#{config_guess_dir}/config.sub", destination)
+      end
+    end
+    expose :update_config_guess
+
     #
     # @!endgroup
     # --------------------------------------------------


### PR DESCRIPTION
:construction: 

@lamont-granquist @edolnx @curiositycasualty  @chef/omnibus-maintainers 

Based on Lamont's idea here: https://github.com/chef/omnibus-software/pull/511

More to get some kind of idea if I'm going in the right direction, and see if anyone wants to work with me on it.

What works:
- `update_config_guess` - puts stuff into the root directory of the current software def's src folder
- `update_config_guess('build-aux')` - will put it into `src-folder/build-aux` in this example

What doesn't work:
- adding a revision/timestamp for 2nd parameter. I didn't have time to dig into the GitFetcher to pass the right info

I didn't test the `config_guess_only` etc logic.

Some concerns I have about this in general that I'm not sure how to fix:
- The timing of when this happens is weird. Ideally it would fit into a `BuildCommand` step and go after the previous `BuildCommand`, but I couldn't figure out how to slot it in there and still utilize the GitFetcher sort of 'on the fly'. I'm sure someone smarter than I can figure this out.
- My Ruby code style is not super great so any refactors for clarity and "don't abuse the Ruby like this"
- Tests! TESTS! I started writing some then my head started to hurt due to the "when things run" issue. (I probably was doing it wrong.)
