### PR TITLE
Debian md5sums format

### DIFF
--- a/resources/deb/md5sums.erb
+++ b/resources/deb/md5sums.erb
@@ -1,3 +1,3 @@
 <% md5sums.each do |path, checksum| -%>
-<%= checksum %> <%= path %>
+<%= checksum %>  <%= path %>
 <% end -%>

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -209,9 +209,10 @@ module Omnibus
         subject.write_md5_sums
         contents = File.read("#{staging_dir}/DEBIAN/md5sums")
 
-        expect(contents).to include("9334770d184092f998009806af702c8c .filea")
-        expect(contents).to include("826e8142e6baabe8af779f5f490cf5f5 file1")
-        expect(contents).to include("1c1c96fd2cf8330db0bfa936ce82f3b9 file2")
+        expect(contents).to include("9334770d184092f998009806af702c8c  .filea")
+        expect(contents).to include("826e8142e6baabe8af779f5f490cf5f5  file1")
+        expect(contents).to include("1c1c96fd2cf8330db0bfa936ce82f3b9  file2")
+        expect(contents).to_not include("1c1c96fd2cf8330db0bfa936ce82f3b9 file2")
       end
     end
 


### PR DESCRIPTION
Hi all, 

I've noticed that omnibus-gitlab package fails verification on debian-like systems with:

```
dpkg --verify gitlab-ce
dpkg: error: control file 'md5sums' missing value separator
```
and confirmed that the md5sums file is incorrect as it only contains one space between the hash and the file path.
This issue was originally reported by @dmlary in #462 and fixed by them in #461. 
I've attached the suggested fix and updated the specs.