### PR TITLE
Skip adding DEBIAN directory to md5sums file.

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -263,7 +263,7 @@ module Omnibus
     def write_md5_sums
       path = "#{staging_dir}/**/*"
       hash = FileSyncer.glob(path).inject({}) do |hash, path|
-        if File.file?(path) && !File.symlink?(path)
+        if File.file?(path) && !File.symlink?(path) && !(File.dirname(path) == debian_dir)
           relative_path = path.gsub("#{staging_dir}/", '')
           hash[relative_path] = digest(path, :md5)
         end
@@ -413,7 +413,7 @@ module Omnibus
         # see https://wiki.debian.org/Arm64Port
         'arm64'
       when 'ppc64le'
-        # Debian prefers to use ppc64el for little endian architecture name 
+        # Debian prefers to use ppc64el for little endian architecture name
         # where as others like gnutools/rhel use ppc64le( note the last 2 chars)
         # see http://linux.debian.ports.powerpc.narkive.com/8eeWSBtZ/switching-ppc64el-port-name-to-ppc64le
         'ppc64el'  #dpkg --print-architecture = ppc64el

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -198,6 +198,8 @@ module Omnibus
         create_file("#{staging_dir}/.filea") { ".filea" }
         create_file("#{staging_dir}/file1") { "file1" }
         create_file("#{staging_dir}/file2") { "file2" }
+        create_file("#{staging_dir}/DEBIAN/preinst") { "preinst" }
+        create_file("#{staging_dir}/DEBIAN/postrm") { "postrm" }
       end
 
       it 'generates the file' do
@@ -212,6 +214,8 @@ module Omnibus
         expect(contents).to include("9334770d184092f998009806af702c8c .filea")
         expect(contents).to include("826e8142e6baabe8af779f5f490cf5f5 file1")
         expect(contents).to include("1c1c96fd2cf8330db0bfa936ce82f3b9 file2")
+        expect(contents).to_not include("0c5bc033075b0c1062e861f18219f8fd DEBIAN/preinst")
+        expect(contents).to_not include("4e8ed96bd90c2c964c0e9d36865e53e5 DEBIAN/postrm")
       end
     end
 


### PR DESCRIPTION
Hi all, 

I've noticed that debian packager adds the DEBIAN directory to the md5sums file. However, this directory does not end up in the package directory so if you test the package with `debsums -c` you can end up with the warnings like following:

```
debsums: missing file /DEBIAN/control (from gitlab-ce package)
debsums: missing file /DEBIAN/postinst (from gitlab-ce package)
debsums: missing file /DEBIAN/postrm (from gitlab-ce package)
debsums: missing file /DEBIAN/preinst (from gitlab-ce package)
```

I am not sure if this can be done more elegantly and I am open for suggestions.