### PR TITLE
ChefDK is getting cached into a subfolder (chef-dk/chefdk) so to appbundle it we need to point to the correct directory

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -340,18 +340,26 @@ module Omnibus
     # @example
     #   appbundle 'chef'
     #
+    # @param software_name [String]
+    #  The omnibus software definition name that you want to appbundle.  We
+    #  assume that this software definition is a gem that already has `bundle
+    #  install` ran on it so it has a Gemfile.lock to appbundle.
     # @param (see #command)
     # @return (see #command)
     #
-    def appbundle(app_name, options = {})
-      build_commands << BuildCommand.new("appbundle `#{app_name}'") do
+    def appbundle(software_name, options = {})
+      build_commands << BuildCommand.new("appbundle `#{software_name}'") do
+        app_software = project.softwares.find do |p|
+          p.name == software_name
+        end
+
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin('appbundler')
 
         # Ensure the main bin dir exists
         FileUtils.mkdir_p(bin_dir)
 
-        shellout!("#{appbundler_bin} '#{Omnibus::Config.source_dir}/#{app_name}' '#{bin_dir}'", options)
+        shellout!("#{appbundler_bin} '#{app_software.project_dir}' '#{bin_dir}'", options)
       end
     end
     expose :appbundle

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -812,9 +812,6 @@ module Omnibus
         if source_type == :url && File.basename(source[:url], '?*').end_with?(*NetFetcher::ALL_EXTENSIONS)
           Fetcher.fetcher_class_for_source(self.source).new(manifest_entry, fetch_dir, build_dir)
         else
-          if File.expand_path("#{Config.source_dir}/#{relative_path}") == fetch_dir
-            fetch_dir(Config.source_dir)
-          end
           Fetcher.fetcher_class_for_source(self.source).new(manifest_entry, project_dir, build_dir)
         end
     end

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -202,6 +202,8 @@ module Omnibus
     end
 
     describe '#appbundle' do
+      let(:project) { double("Project") }
+      let(:project_softwares) { [ double("Software", name: project_name, project_dir: project_dir) ] }
       it 'executes the command as the embedded appbundler' do
         make_gemspec
         make_gemfile
@@ -213,6 +215,10 @@ module Omnibus
         subject.gem("build #{project_name}.gemspec", shellout_opts(subject))
         subject.gem("install #{project_name}-1.0.0.gem", shellout_opts(subject))
         subject.appbundle(project_name, shellout_opts(subject))
+
+        expect(subject).to receive(:project).and_return(project)
+        expect(project).to receive(:softwares).and_return(project_softwares)
+
         output = capture_logging { subject.build }
 
         appbundler_path = File.join(embedded_bin_dir, 'appbundler')

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -492,12 +492,12 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
-          
+
           it 'sets the fetcher project_dir to fetch_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -505,12 +505,12 @@ module Omnibus
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to fetch_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
           end
@@ -527,25 +527,25 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'for back-compat, changes fetch_dir' do
             subject.send(:fetcher)
-            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
+            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
-            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
+            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
         end
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
@@ -561,25 +561,25 @@ module Omnibus
 
         context 'when relative_path is the same as name' do
           let(:rel_path) { 'software' }
-          
+
           it 'for back-compat, changes fetch_dir' do
             subject.send(:fetcher)
-            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
+            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
-            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software"))
+            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
           end
         end
 
         context 'when relative_path is different from name' do
           let(:rel_path) { 'foo' }
-          
+
           it 'ignores back-compat and leaves fetch_dir alone' do
             subject.send(:fetcher)
             expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end
-          
+
           it 'sets the fetcher project_dir to project_dir' do
             expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
           end


### PR DESCRIPTION
This is to fix ChefDK builds on Manhattan

\cc @jaym @danielsdeleo @schisamo 