### PR TITLE
Reverting https://github.com/chef/omnibus/pull/583 to try and fix ChefDK build errors

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -525,9 +525,7 @@ module Omnibus
           end
           {
             "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag}",
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag}",
-            "RCFLAGS" => "--target=#{bfd_target}",
-            "ARFLAGS" => "--target=#{bfd_target}",
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag}"
           }
         else
           {


### PR DESCRIPTION
\cc @jaym @danielsdeleo @schisamo @ksubrama 

This fixes the builds because (we think) the makefile for libgecode isn't appropriate leveraging the `ARFLAGS` environment variable.  This causes the ar command to lose its operation (add, replace, etc.).