### PR TITLE
add libmd.so.* to freebsd whitelist

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -140,6 +140,7 @@ module Omnibus
       /libelf\.so/,
       /libkvm\.so/,
       /libprocstat\.so/,
+      /libmd\.so/
     ].freeze
 
     class << self

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -140,7 +140,7 @@ module Omnibus
       /libelf\.so/,
       /libkvm\.so/,
       /libprocstat\.so/,
-      /libmd\.so/
+      /libmd\.so/,
     ].freeze
 
     class << self


### PR DESCRIPTION
the current version of this library seems to be the one in the freebsd
source code.  there's old versions that lack sha-2 support at

http://martin.hinner.info/libmd/
https://github.com/epowers/libmd

without something better to pull into as a software defn, it seems
best to just use the base o/s.

i also looked for ways of pointing the software at openssl instead of
libmd, but couldn't find any.