### PR TITLE
using chef-sugars version constraints and extending to Software#version

### DIFF
--- a/lib/omnibus/sugarable.rb
+++ b/lib/omnibus/sugarable.rb
@@ -16,11 +16,7 @@
 
 require 'chef/sugar/architecture'
 require 'chef/sugar/cloud'
-# NOTE: We cannot include the constraints library because of the conflicting
-# +version+ attribute would screw things up. You can still use the
-# +Chef::Sugar::Constraint.version('1.2.3') for comparing versions.
-#
-# require 'chef/sugar/constraints'
+require 'chef/sugar/constraints'
 require 'chef/sugar/ip'
 require 'chef/sugar/platform'
 require 'chef/sugar/platform_family'

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'chef-sugar',       '~> 3.0'
+  gem.add_dependency 'chef-sugar',       '~> 3.3'
   gem.add_dependency 'cleanroom',        '~> 1.0'
   gem.add_dependency 'mixlib-shellout',  '~> 2.0'
   gem.add_dependency 'mixlib-versioning'

--- a/spec/unit/library_spec.rb
+++ b/spec/unit/library_spec.rb
@@ -8,7 +8,7 @@ module Omnibus
     def generate_software(name, version, dependencies = [])
       software = Software.new(project, "#{name}.rb")
       software.name(name)
-      software.version(version)
+      software.default_version(version)
 
       dependencies.each do |dependency|
         software.dependency(dependency)


### PR DESCRIPTION
`#version` in software definitions has been extended using the chef-sugar constraints methods. This will allow a user to call `version.satisfies?` and perform gemspec-like comparisons rather than calling `#to_f` and `#to_i` as has been customary.

We can now `require 'chef/sugar/constraints'` safely as the `version` method has been moved to a new constraints_dsl module in chef-sugar 3.3.0, which also includes a similar extension of the `platform_version` helper method.

Additionally, the library spec has been fixed to call `default_version` to actually set the version for the created software vs. `version` (which didn't actually do anything).

**NOTE**: When this is ready to be merged, the following omnibus-software PR should be merged at the same time to avoid any build breaks: chef/omnibus-software#543

/cc @chef/omnibus-maintainers 