### PR TITLE
kill ourselves and all our children

### DIFF
--- a/bin/omnibus
+++ b/bin/omnibus
@@ -2,7 +2,7 @@
 
 # Trap interrupts to quit cleanly. See
 # https://twitter.com/mitchellh/status/283014103189053442
-Signal.trap('INT') { exit 1 }
+Signal.trap('INT') { Process.kill(:KILL, -Process.getpgid(Process.pid()) }
 
 $:.push File.expand_path('../../lib', __FILE__)
 $stdout.sync = true

--- a/bin/omnibus
+++ b/bin/omnibus
@@ -1,8 +1,20 @@
 #!/usr/bin/env ruby
 
-# Trap interrupts to quit cleanly. See
-# https://twitter.com/mitchellh/status/283014103189053442
-Signal.trap('INT') { Process.kill(:KILL, -Process.getpgid(Process.pid()); exit 1 }
+# become our own process leader so we can kill our process tree
+unless Gem.win_platform?
+  Process.setpgid(0,0)
+end
+
+Signal.trap('INT') do
+  unless Gem.win_platform?
+    Process.kill(:INT, -Process.getpgid(Process.pid()))
+    sleep 1
+    Process.kill(:KILL, -Process.getpgid(Process.pid()))
+  end
+  # Trap interrupts to quit cleanly. See
+  # https://twitter.com/mitchellh/status/283014103189053442
+  exit 1
+end
 
 $:.push File.expand_path('../../lib', __FILE__)
 $stdout.sync = true

--- a/bin/omnibus
+++ b/bin/omnibus
@@ -2,7 +2,7 @@
 
 # Trap interrupts to quit cleanly. See
 # https://twitter.com/mitchellh/status/283014103189053442
-Signal.trap('INT') { Process.kill(:KILL, -Process.getpgid(Process.pid()) }
+Signal.trap('INT') { Process.kill(:KILL, -Process.getpgid(Process.pid()); exit 1 }
 
 $:.push File.expand_path('../../lib', __FILE__)
 $stdout.sync = true


### PR DESCRIPTION
Extend the SIGINT handler so that we nuke our own process group from orbit.

This may fix some issues with cancelling jobs in jenkins and not having the process tree cleaned up and subsequent jobs failing.

Does not address windows.  Similar code from mixlib-shellout could probably be stolen to fix windows...
