### PR TITLE
Add `maintainer` to the Software DSL

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -176,6 +176,28 @@ module Omnibus
     end
     expose :description
 
+
+    #
+    # Sets the maintainer of the software.  Currently this is for
+    # human consumption only and the tool doesn't do anything with it.
+    #
+    # @example
+    #   maintainer "Joe Bob <joeb@chef.io>"
+    #
+    # @param [String] val
+    #   the maintainer of this sofware def
+    #
+    # @return [String]
+    #
+    def maintainer(val = NULL)
+      if null?(val)
+        @maintainer
+      else
+        @description = val
+      end
+    end
+    expose :maintainer
+
     #
     # Add a software dependency to this software.
     #

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -34,6 +34,7 @@ module Omnibus
     it_behaves_like 'a cleanroom getter', :project
     it_behaves_like 'a cleanroom setter', :name, %|name 'libxml2'|
     it_behaves_like 'a cleanroom setter', :description, %|description 'The XML magician'|
+    it_behaves_like 'a cleanroom setter', :maintainer, %|maintainer 'Captain Jack <sparrow@chef.io>'|
     it_behaves_like 'a cleanroom setter', :dependency, %|dependency 'libxslt'|
     it_behaves_like 'a cleanroom setter', :source, %|source url: 'https://source.example.com'|
     it_behaves_like 'a cleanroom setter', :default_version, %|default_version '1.2.3'|
@@ -249,7 +250,7 @@ module Omnibus
 
       context 'on Windows' do
         let(:win_arch_i386) { true }
-        
+
         before do
           stub_ohai(platform: 'windows', version: '2012')
           allow(subject).to receive(:windows_arch_i386?).and_return(win_arch_i386)


### PR DESCRIPTION
The maintainer field specifies the human maintainer of the software
definition. The responsibilities of the maintainer are likely a policy
decision of the organization or project maintainer the software
definition. This field is currently unused by omnibus itself but could
be used by projects like omnibus-software to help build simple tooling
to help maintain the project.