### PR TITLE
There is no restriction on dashes in the base package name or identifier

### DIFF
--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -262,14 +262,14 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
-      if project.package_name =~ /\A[[:alnum:]]+\z/
+      if project.package_name =~ /\A[[:alnum:]-]+\z/
         project.package_name.dup
       else
         converted = project.package_name.downcase.gsub(/[^[:alnum:]+]/, '')
 
         log.warn(log_key) do
           "The `name' component of Mac package names can only include " \
-          "alphabetical characters (a-z, A-Z), and numbers (0-9). Converting " \
+          "alphabetical characters (a-z, A-Z), numbers (0-9), and -. Converting " \
           "`#{project.package_name}' to `#{converted}'."
         end
 

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -4,9 +4,9 @@ module Omnibus
   describe Packager::PKG do
     let(:project) do
       Project.new.tap do |project|
-        project.name('project')
+        project.name('project-full-name')
         project.homepage('https://example.com')
-        project.install_dir('/opt/project')
+        project.install_dir('/opt/project-full-name')
         project.build_version('1.2.3')
         project.build_iteration('2')
         project.maintainer('Chef Software')
@@ -15,12 +15,12 @@ module Omnibus
 
     subject { described_class.new(project) }
 
-    let(:project_root) { File.join(tmp_path, 'project/root') }
+    let(:project_root) { File.join(tmp_path, 'project-full-name/root') }
     let(:package_dir)  { File.join(tmp_path, 'package/dir') }
     let(:staging_dir)  { File.join(tmp_path, 'staging/dir') }
 
     before do
-      subject.identifier('com.getchef.project')
+      subject.identifier('com.getchef.project-full-name')
 
       Config.project_root(project_root)
       Config.package_dir(package_dir)
@@ -48,7 +48,7 @@ module Omnibus
 
     describe '#package_name' do
       it 'includes the name, version, and build iteration' do
-        expect(subject.package_name).to eq('project-1.2.3-2.pkg')
+        expect(subject.package_name).to eq('project-full-name-1.2.3-2.pkg')
       end
     end
 
@@ -69,7 +69,7 @@ module Omnibus
         let(:scripts) { %w( preinstall postinstall ) }
         before do
           scripts.each do |script_name|
-            create_file("#{project_root}/package-scripts/project/#{script_name}") do
+            create_file("#{project_root}/package-scripts/project-full-name/#{script_name}") do
               "Contents of #{script_name}"
             end
           end
@@ -90,7 +90,7 @@ module Omnibus
         let(:default_scripts) { %w( preinst postinst ) }
         before do
           default_scripts.each do |script_name|
-            create_file("#{project_root}/package-scripts/project/#{script_name}") do
+            create_file("#{project_root}/package-scripts/project-full-name/#{script_name}") do
               "Contents of #{script_name}"
             end
           end
@@ -114,12 +114,12 @@ module Omnibus
       it 'executes the pkgbuild command' do
         expect(subject).to receive(:shellout!).with <<-EOH.gsub(/^ {10}/, '')
           pkgbuild \\
-            --identifier "com.getchef.project" \\
+            --identifier "com.getchef.project-full-name" \\
             --version "1.2.3" \\
             --scripts "#{staging_dir}/Scripts" \\
-            --root "/opt/project" \\
-            --install-location "/opt/project" \\
-            "project-core.pkg"
+            --root "/opt/project-full-name" \\
+            --install-location "/opt/project-full-name" \\
+            "project-full-name-core.pkg"
         EOH
 
         subject.build_component_pkg
@@ -136,9 +136,9 @@ module Omnibus
         subject.write_distribution_file
         contents = File.read("#{staging_dir}/Distribution")
 
-        expect(contents).to include('<pkg-ref id="com.getchef.project"/>')
-        expect(contents).to include('<line choice="com.getchef.project"/>')
-        expect(contents).to include('project-core.pkg')
+        expect(contents).to include('<pkg-ref id="com.getchef.project-full-name"/>')
+        expect(contents).to include('<line choice="com.getchef.project-full-name"/>')
+        expect(contents).to include('project-full-name-core.pkg')
       end
     end
 
@@ -149,7 +149,7 @@ module Omnibus
             productbuild \\
               --distribution "#{staging_dir}/Distribution" \\
               --resources "#{staging_dir}/Resources" \\
-              "#{package_dir}/project-1.2.3-2.pkg"
+              "#{package_dir}/project-full-name-1.2.3-2.pkg"
           EOH
 
           subject.build_product_pkg
@@ -167,7 +167,7 @@ module Omnibus
               --distribution "#{staging_dir}/Distribution" \\
               --resources "#{staging_dir}/Resources" \\
               --sign "My Special Identity" \\
-              "#{package_dir}/project-1.2.3-2.pkg"
+              "#{package_dir}/project-full-name-1.2.3-2.pkg"
             EOH
           subject.build_product_pkg
         end
@@ -187,14 +187,14 @@ module Omnibus
 
     describe '#component_pkg' do
       it 'returns the project name with -core.pkg' do
-        expect(subject.component_pkg).to eq('project-core.pkg')
+        expect(subject.component_pkg).to eq('project-full-name-core.pkg')
       end
     end
 
     describe '#safe_base_package_name' do
       context 'when the project name is "safe"' do
         it 'returns the value without logging a message' do
-          expect(subject.safe_base_package_name).to eq('project')
+          expect(subject.safe_base_package_name).to eq('project-full-name')
           expect(subject).to_not receive(:log)
         end
       end
@@ -225,7 +225,7 @@ module Omnibus
         before { subject.identifier(nil) }
 
         it 'is interpreted' do
-          expect(subject.safe_identifier).to eq('test.chefsoftware.pkg.project')
+          expect(subject.safe_identifier).to eq('test.chefsoftware.pkg.project-full-name')
         end
       end
 


### PR DESCRIPTION
@chef/engineering-services @chef/omnibus-maintainers 

I ran through a full package test locally on my Mac successfully, and it looks like this is correct based on Apple's documentation: https://developer.apple.com/library/mac/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html