### PR TITLE
Check dlls on windows for base address clashes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 gemspec
 
+# Fork to allow for a recent version of multipart-post.
+gem 'pedump', git: 'https://github.com/ksubrama/pedump', branch: 'patch-1'
+
 group :docs do
   gem 'yard',          '~> 0.8'
   gem 'redcarpet',     '~> 2.2.2'

--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -62,14 +62,16 @@ module Omnibus
     #   the path of the directory to digest
     # @param [Symbol] type
     #   the type of digest to use
+    # @param [Hash] options
+    #   options to pass through to the FileSyncer when scanning for files
     #
     # @return [String]
     #   the hexdigest of the directory
     #
-    def digest_directory(path, type = :md5)
+    def digest_directory(path, type = :md5, options = {})
       digest = digest_from_type(type)
       log.info(log_key) { "Digesting #{path} with #{type}" }
-      FileSyncer.glob("#{path}/**/*").each do |filename|
+      FileSyncer.all_files_under(path, options).each do |filename|
         # Calculate the filename relative to the given path. Since directories
         # are SHAed according to their filepath, two difference directories on
         # disk would have different SHAs even if they had the same content.

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -118,7 +118,7 @@ module Omnibus
     # @return [String]
     #
     def target_shasum
-      @target_shasum ||= digest_directory(project_dir, :sha256)
+      @target_shasum ||= digest_directory(project_dir, :sha256, source_options)
     end
 
     #
@@ -127,7 +127,7 @@ module Omnibus
     # @return [String]
     #
     def destination_shasum
-      @destination_shasum ||= digest_directory(source_path, :sha256)
+      @destination_shasum ||= digest_directory(source_path, :sha256, source_options)
     end
   end
 end

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'aws-sdk',          '~> 2'
   gem.add_dependency 'thor',             '~> 0.18'
+  gem.add_dependency 'pedump'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 2.0'

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'aws-sdk',          '~> 2'
   gem.add_dependency 'thor',             '~> 0.18'
-  gem.add_dependency 'pedump'
+  gem.add_dependency 'pedump',           '~> 0.5'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 2.0'

--- a/spec/unit/fetchers/path_fetcher_spec.rb
+++ b/spec/unit/fetchers/path_fetcher_spec.rb
@@ -69,7 +69,7 @@ module Omnibus
 
       before do
         allow(subject).to receive(:digest_directory)
-          .with(source_path, :sha256)
+          .with(source_path, :sha256, {})
           .and_return(shasum)
       end
 

--- a/spec/unit/health_check_spec.rb
+++ b/spec/unit/health_check_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pedump'
 
 module Omnibus
   describe HealthCheck do
@@ -12,7 +13,84 @@ module Omnibus
       )
     end
 
+    def mkdump(base, size, x64 = false)
+      dump = double(PEdump)
+      pe = double(PEdump::PE,
+        x64?: x64,
+        ioh: double(x64 ? PEdump::IMAGE_OPTIONAL_HEADER64 : PEdump::IMAGE_OPTIONAL_HEADER32,
+          ImageBase: base,
+          SizeOfImage: size,
+        ),
+      )
+      expect(dump).to receive(:pe).and_return(pe)
+      dump
+    end
+
     subject { described_class.new(project) }
+
+    context 'on windows' do
+      let(:pmdumps) do
+        {
+          'a' => mkdump(0x10000000, 0x00001000),
+          'b/b' => mkdump(0x20000000, 0x00002000),
+          'c/c/c' => mkdump(0x30000000, 0x00004000),
+        }
+      end
+
+      let(:search_dir) { "#{project.install_dir}/embedded/bin" }
+
+      before do
+        stub_ohai(platform: 'windows', version: '2012')
+
+        r = allow(Dir).to receive(:glob).with("#{search_dir}/*.dll")
+        pmdumps.each do |file, dump|
+          path = File.join(search_dir, file)
+          r.and_yield(path)
+          expect(File).to receive(:open).with(path, 'rb').and_yield(double(File))
+          expect(PEdump).to receive(:new).with(path).and_return(dump)
+        end
+      end
+
+      context 'when given non-overlapping dlls' do
+        it 'should always return true' do
+          expect(subject.run!).to eq(true)
+        end
+
+        it 'should not identify conflicts' do
+          expect(subject.relocation_check).to eq({})
+        end
+      end
+
+      context 'when presented with overlapping dlls' do
+        let(:pmdumps) do
+          {
+            'a' => mkdump(0x10000000, 0x00001000),
+            'b/b' => mkdump(0x10000500, 0x00002000),
+            'c/c/c' => mkdump(0x30000000, 0x00004000),
+          }
+        end
+
+        it 'should always return true' do
+          expect(subject.run!).to eq(true)
+        end
+
+        it 'should identify two conflicts' do
+          expect(subject.relocation_check).to eq({
+            'a' => {
+              base: 0x10000000,
+              size: 0x00001000,
+              conflicts: [ 'b' ],
+            },
+            'b' => {
+              base: 0x10000500,
+              size: 0x00002000,
+              conflicts: [ 'a' ],
+            },
+          })
+        end
+      end
+      
+    end
 
     context 'on linux' do
       before { stub_ohai(platform: 'ubuntu', version: '12.04') }


### PR DESCRIPTION
This is primarily of concern to FIPS which reaaaally cares to only be loaded at its preferred base address and will fail if rebased.  For other builds, it's a performance boost to not have windows rebase your dlls.

Example output:
```
                      [HealthCheck] I | Running health on chef-fips
                      [HealthCheck] W | Skipping dependency health checks on Windows.
                      [HealthCheck] W | Multiple dlls with overlapping images detected
                      [HealthCheck] W |     libeay32.dll :
    IMAGE BASE: 0x63000000
    IMAGE SIZE: 0x00217000 (2191360 bytes)
    NEXT VALID BASE: 0x63217000
    CONFLICTS:
    - zlib1.dll 0x63080000+00023000

                      [HealthCheck] W |     libexslt-0.dll :
    IMAGE BASE: 0x6d600000
    IMAGE SIZE: 0x00032000 (204800 bytes)
    NEXT VALID BASE: 0x6d632000
    CONFLICTS:
    - msvcrt-ruby210.dll 0x6d400000+002b8000

                      [HealthCheck] W |     msvcrt-ruby210.dll :
    IMAGE BASE: 0x6d400000
    IMAGE SIZE: 0x002b8000 (2850816 bytes)
    NEXT VALID BASE: 0x6d6b8000
    CONFLICTS:
    - libexslt-0.dll 0x6d600000+00032000

                      [HealthCheck] W |     zlib1.dll :
    IMAGE BASE: 0x63080000
    IMAGE SIZE: 0x00023000 (143360 bytes)
    NEXT VALID BASE: 0x630a3000
    CONFLICTS:
    - libeay32.dll 0x63000000+00217000
```