### PR TITLE
Add update_config_guess DSL method

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -644,6 +644,35 @@ module Omnibus
     expose :sync
 
     #
+    # Helper method to update config_guess in the software's source
+    # directory.
+    # You should add a dependency on the +config_guess+ software definition if you
+    # want to use this command.
+    # @param [Hash] options
+    #   Supported options are:
+    #     target [String] subdirectory under the software source to copy
+    #       config.guess.to. Default: "."
+    #     install [Array<Symbol>] parts of config.guess to copy.
+    #       Default: [:config_guess, :config_sub]
+    def update_config_guess(target: ".", install: [:config_guess, :config_sub])
+      build_commands << BuildCommand.new("update_config_guess `target: #{target} install: #{install.inspect}'") do
+        config_guess_dir = "#{install_dir}/embedded/lib/config_guess"
+        %w{config.guess config.sub}.each do |c|
+          unless File.exist?(File.join(config_guess_dir, c))
+            raise "Can not find #{c}. Make sure you add a dependency on 'config_guess' in your software definition"
+          end
+        end
+
+        destination = File.join(software.project_dir, target)
+        FileUtils.mkdir_p(destination)
+
+        FileUtils.cp_r("#{config_guess_dir}/config.guess", destination) if install.include? :config_guess
+        FileUtils.cp_r("#{config_guess_dir}/config.sub", destination) if install.include? :config_sub
+      end
+    end
+    expose :update_config_guess
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -19,7 +19,7 @@ module Omnibus
     end
 
     subject { described_class.new(software) }
-    
+
     before do
       allow(subject).to receive(:windows?).and_return(on_windows)
       allow(subject).to receive(:windows_safe_path) do |*args|
@@ -115,6 +115,12 @@ module Omnibus
     describe '#sync' do
       it 'is a DSL method' do
         expect(subject).to have_exposed_method(:sync)
+      end
+    end
+
+    describe '#update_config_guess' do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:update_config_guess)
       end
     end
 


### PR DESCRIPTION
This PR adds a new dsl method to easily update a software's config_guess from a config_guess installed with a software dependency.

Replaces https://github.com/chef/omnibus/pull/592.
Implements the style discussed in https://github.com/chef/omnibus/pull/592#discussion_r53094053. 

This will be followed up by a PR in omnibus-software that adds a config_guess software definition.

/cc: @scotthain, @chef/omnibus-maintainers 