### PR TITLE
Promoted dist_tag method to a DSL method

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -203,6 +203,35 @@ module Omnibus
     expose :category
 
     #
+    # Set or return the dist_tag for this package
+    #
+    # The Dist Tag for this RPM package as per the Fedora packaging guidlines.
+    #
+    # @see http://fedoraproject.org/wiki/Packaging:DistTag
+    #
+    # @example
+    #   dist_tag ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
+    #
+    # @param [String] val
+    #   the dist_tag for this package
+    #
+    # @return [String]
+    #   the dist_tag for this package
+    #
+    def dist_tag(val = NULL)
+      if null?(val)
+        @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
+      else
+        unless val.is_a?(String)
+          raise InvalidValue.new(:dist_tag, 'be a String')
+        end
+
+        @dist_tag = val
+      end
+    end
+    expose :dist_tag
+
+    #
     # @!endgroup
     # --------------------------------------------------
 
@@ -210,7 +239,11 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
+      if dist_tag
+        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
+      else
+        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
+      end
     end
 
     #
@@ -433,17 +466,6 @@ module Omnibus
         .gsub("*", "[*]")
         .gsub("?", "[?]")
         .gsub("%", "[%]")
-    end
-
-    #
-    # The Dist Tag for this RPM package per the Fedora packaging guidlines.
-    #
-    # @see http://fedoraproject.org/wiki/Packaging:DistTag
-    #
-    # @return [String]
-    #
-    def dist_tag
-      ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
     end
 
     #

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -222,10 +222,6 @@ module Omnibus
       if null?(val)
         @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
       else
-        unless val.is_a?(String)
-          raise InvalidValue.new(:dist_tag, 'be a String')
-        end
-
         @dist_tag = val
       end
     end

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -17,7 +17,7 @@
 # Metadata
 Name: <%= name %>
 Version: <%= version %>
-Release: <%= iteration %><%= dist_tag %>
+Release: <%= iteration %><%= dist_tag ? dist_tag : '' %>
 Summary:  <%= description.split("\n").first.empty? ? "_" : description.split("\n").first %>
 AutoReqProv: no
 BuildRoot: %buildroot

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -113,10 +113,6 @@ module Omnibus
       it 'has a default value' do
         expect(subject.dist_tag).to eq('.el6')
       end
-
-      it 'must be a string' do
-        expect { subject.dist_tag(Object.new) }.to raise_error(InvalidValue)
-      end
     end
 
     describe '#id' do
@@ -126,12 +122,24 @@ module Omnibus
     end
 
     describe '#package_name' do
-      before do
-        allow(subject).to receive(:safe_architecture).and_return('x86_64')
+      context 'when dist_tag is enabled' do
+        before do
+          allow(subject).to receive(:safe_architecture).and_return('x86_64')
+        end
+
+        it 'includes the name, version, and build iteration' do
+          expect(subject.package_name).to eq('project-1.2.3-2.el6.x86_64.rpm')
+        end
       end
 
-      it 'includes the name, version, and build iteration' do
-        expect(subject.package_name).to eq('project-1.2.3-2.el6.x86_64.rpm')
+      context 'when dist_tag is disabled' do
+        before do
+          allow(subject).to receive(:dist_tag).and_return(false)
+        end
+
+        it 'excludes dist tag' do
+          expect(subject.package_name).to eq('project-1.2.3-2.x86_64.rpm')
+        end
       end
     end
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -276,6 +276,20 @@ module Omnibus
           expect(contents).not_to include("BuildArch")
         end
       end
+
+      context 'when dist_tag is disabled' do
+        let(:spec_file) { "#{staging_dir}/SPECS/project-1.2.3-2.x86_64.rpm.spec" }
+
+        before do
+          allow(subject).to receive(:dist_tag).and_return(false)
+        end
+
+        it 'has the correct release' do
+          subject.write_rpm_spec
+          contents = File.read(spec_file)
+          expect(contents).to include("Release: 2")
+        end
+      end
     end
 
     describe '#create_rpm_file' do

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -105,6 +105,20 @@ module Omnibus
       end
     end
 
+    describe '#dist_tag' do
+      it 'is a DSL method' do
+        expect(subject).to have_exposed_method(:dist_tag)
+      end
+
+      it 'has a default value' do
+        expect(subject.dist_tag).to eq('.el6')
+      end
+
+      it 'must be a string' do
+        expect { subject.dist_tag(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
     describe '#id' do
       it 'is :rpm' do
         expect(subject.id).to eq(:rpm)
@@ -316,12 +330,6 @@ module Omnibus
 
       it 'escapes %' do
         expect(subject.rpm_safe('%foo')).to eq('[%]foo')
-      end
-    end
-
-    describe '#dist_tag' do
-      it 'returns the Fedora packaging guidelines dist tag for the package' do
-        expect(subject.dist_tag).to eq('.el6')
       end
     end
 


### PR DESCRIPTION
This makes `dist_tag` configurable. You can disable `dist_tag` in project definition like this:

Disabling `dist_tag` is useful if you are building one rpm for all RPM based distribution and for all their releases.

```
package :rpm do
    dist_tag false
end
```