### PR TITLE
License reporting in omnibus

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -62,6 +62,7 @@ module Omnibus
   autoload :Templating,       'omnibus/templating'
   autoload :ThreadPool,       'omnibus/thread_pool'
   autoload :Util,             'omnibus/util'
+  autoload :Licensing,        'omnibus/licensing'
 
   autoload :GitFetcher,  'omnibus/fetchers/git_fetcher'
   autoload :NetFetcher,  'omnibus/fetchers/net_fetcher'

--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -1,0 +1,227 @@
+#
+# Copyright 2015 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'uri'
+require 'fileutils'
+
+module Omnibus
+  class Licensing
+    include Logging
+
+    OUTPUT_DIRECTORY = "LICENSES".freeze
+
+    class << self
+      # @see (Licensing#create!)
+      def create!(project)
+        new(project).create!
+      end
+    end
+
+    #
+    # The project to create licenses for.
+    #
+    # @return [Project]
+    #
+    attr_reader :project
+
+    #
+    # @param [Project] project
+    #   the project to create licenses for.
+    #
+    def initialize(project)
+      @project = project
+    end
+
+    #
+    # Creates the license files for given project.
+    # It is assumed that the project has already been built.
+    #
+    # @return [void]
+    #
+    def create!
+      prepare
+      create_software_license_files
+      create_project_license_file
+    end
+
+    #
+    # Creates the required directories for licenses.
+    #
+    # @return [void]
+    #
+    def prepare
+      FileUtils.rm_rf(output_dir)
+      FileUtils.mkdir_p(output_dir)
+    end
+
+    #
+    # Creates the top level license file for the project.
+    # Top level file is created at #{project.license_file_path}
+    # and contains the name of the project, version of the project,
+    # text of the license of the project and a summary of the licenses
+    # of the included software components.
+    #
+    # @return [void]
+    #
+    def create_project_license_file
+      File.open(project.license_file_path, 'w') do |f|
+        f.puts "#{project.name} #{project.build_version} license: \"#{project.license}\""
+        f.puts ""
+        f.puts project_license_content
+        f.puts ""
+        f.puts components_license_summary
+      end
+    end
+
+    #
+    # Copies the license files specified by the software components into the
+    # output directory.
+    #
+    # @return [void]
+    #
+    def create_software_license_files
+      license_map.each do |name, values|
+        license_files = values[:license_files]
+
+        license_files.each do |license_file|
+          if license_file && local?(license_file)
+            input_file = File.expand_path(license_file, values[:project_dir])
+            output_file = license_package_location(name, license_file)
+            FileUtils.cp(input_file, output_file) if File.exist?(input_file)
+          end
+        end
+      end
+    end
+
+    #
+    # Contents of the project's license
+    #
+    # @return [String]
+    #
+    def project_license_content
+      project.license_file.nil? ? "" : IO.read(File.join(Config.project_root,project.license_file))
+    end
+
+    #
+    # Summary of the licenses included by the softwares of the project.
+    # It is in the form of:
+    # ...
+    # This product bundles python 2.7.9,
+    # which is available under a "Python" License.
+    # For details, see:
+    # /opt/opscode/LICENSES/python-LICENSE
+    # ...
+    #
+    # @return [String]
+    #
+    def components_license_summary
+      out = "\n\n"
+
+      license_map.keys.sort.each do |name|
+        license = license_map[name][:license]
+        license_files = license_map[name][:license_files]
+        version = license_map[name][:version]
+
+        out << "This product bundles #{name} #{version},\n"
+        out << "which is available under a \"#{license}\" License.\n"
+        if !license_files.empty?
+          out << "For details, see:\n"
+          license_files.each do |license_file|
+            out << "#{license_package_location(name, license_file)}\n"
+          end
+        end
+        out << "\n"
+      end
+
+      out
+    end
+
+    #
+    # Map that collects information about the licenses of the softwares
+    # included in the project.
+    #
+    # @example
+    # {
+    #   ...
+    #   "python" => {
+    #     "license" => "Python",
+    #     "license_files" => "LICENSE",
+    #     "version" => "2.7.9",
+    #     "project_dir" => "/var/cache/omnibus/src/python/Python-2.7.9/"
+    #   },
+    #   ...
+    # }
+    #
+    # @return [Hash]
+    #
+    def license_map
+      @license_map ||= begin
+        map = {}
+
+        project.library.each do |component|
+          # Some of the components do not bundle any software but contain
+          # some logic that we use during the build. These components are
+          # covered under the project's license and they do not need specific
+          # license files.
+          next if component.license == :project_license
+
+          map[component.name] = {
+            license: component.license,
+            license_files: component.license_files,
+            version: component.version,
+            project_dir: component.project_dir,
+          }
+        end
+
+        map
+      end
+    end
+
+    #
+    # Returns the location where the license file should reside in the package.
+    # License file is named as <project_name>-<license_file_name> and created
+    # under the output licenses directory.
+    #
+    # @return [String]
+    #
+    def license_package_location(component_name, where)
+      if local?(where)
+        File.join(output_dir, "#{component_name}-#{File.split(where).last}")
+      else
+        where
+      end
+    end
+
+    #
+    # Output directory to create the licenses in.
+    #
+    # @return [String]
+    #
+    def output_dir
+      File.expand_path(OUTPUT_DIRECTORY, project.install_dir)
+    end
+
+    #
+    # Returns if the given path to a license is local or a remote url.
+    #
+    # @return [Boolean]
+    #
+    def local?(license)
+      u = URI(license)
+      return u.scheme.nil?
+    end
+  end
+end

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -24,13 +24,14 @@ module Omnibus
 
     include Logging
 
-    LATEST_MANIFEST_FORMAT = 1
+    LATEST_MANIFEST_FORMAT = 2
 
-    attr_reader :build_version, :build_git_revision
-    def initialize(version=nil, git_rev=nil)
+    attr_reader :build_version, :build_git_revision, :license
+    def initialize(version=nil, git_rev=nil, license="Unspecified")
       @data = {}
       @build_version = version
       @build_git_revision = git_rev
+      @license = license
     end
 
     def entry_for(name)
@@ -75,6 +76,7 @@ module Omnibus
       }
       ret['build_version'] = build_version if build_version
       ret['build_git_revision'] = build_git_revision if build_git_revision
+      ret['license'] = license
       ret
     end
 

--- a/lib/omnibus/manifest_entry.rb
+++ b/lib/omnibus/manifest_entry.rb
@@ -16,13 +16,14 @@
 
 module Omnibus
   class ManifestEntry
-    attr_reader :locked_version, :locked_source, :source_type, :described_version, :name
+    attr_reader :locked_version, :locked_source, :source_type, :described_version, :name, :license
     def initialize(name, manifest_data)
       @name = name
       @locked_version = manifest_data[:locked_version]
       @locked_source = manifest_data[:locked_source]
       @source_type = manifest_data[:source_type]
       @described_version = manifest_data[:described_version]
+      @license = manifest_data[:license]
     end
 
     def to_hash
@@ -30,7 +31,8 @@ module Omnibus
         "locked_version" => @locked_version,
         "locked_source" => @locked_source,
         "source_type" => @source_type,
-        "described_version" => @described_version
+        "described_version" => @described_version,
+        "license" => @license
       }
     end
 

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -692,6 +692,70 @@ module Omnibus
     expose :ohai
 
     #
+    # Set or retrieve the {#license} of the project.
+    #
+    # @example
+    #   license 'Apache 2.0'
+    #
+    # @param [String] val
+    #   the license to set for the project.
+    #
+    # @return [String]
+    #
+    def license(val = NULL)
+      if null?(val)
+        @license || 'Unspecified'
+      else
+        @license = val
+      end
+    end
+    expose :license
+
+    #
+    # Set or retrieve the location of the {#license_file}
+    # of the project.  It can either be a relative path inside
+    # the project source directory or a URL.
+    #
+    #
+    # @example
+    #   license_file 'LICENSES/artistic.txt'
+    #
+    # @param [String] val
+    #   the location of the license file for the project.
+    #
+    # @return [String]
+    #
+    def license_file(val = NULL)
+      if null?(val)
+        @license_file
+      else
+        @license_file = val
+      end
+    end
+    expose :license_file
+
+    #
+    # Location of license file that omnibus will create and that will contain
+    # the information about the license of the project plus the details about
+    # the licenses of the software components included in the project.
+    #
+    # If no path is specified  install_dir/LICENSE is used.
+    #
+    # @example
+    #   license_file_path
+    #
+    # @return [String]
+    #
+    def license_file_path(path = NULL)
+      if null?(path)
+        @license_file_path || File.join(install_dir, "LICENSE")
+      else
+        @license_file_path = File.join(install_dir, path)
+      end
+    end
+    expose :license_file_path
+
+    #
     # Location of json-formated version manifest, written at at the
     # end of the build. If no path is specified
     # +install_dir+/version-manifest.json is used.
@@ -983,7 +1047,7 @@ module Omnibus
     #
     def built_manifest
       log.info(log_key) { "Building version manifest" }
-      m = Omnibus::Manifest.new(build_version, build_git_revision)
+      m = Omnibus::Manifest.new(build_version, build_git_revision, license)
       softwares.each do |software|
         m.add(software.name, software.manifest_entry)
       end
@@ -1008,6 +1072,7 @@ module Omnibus
 
       write_json_manifest
       write_text_manifest
+      Licensing.create!(self)
       HealthCheck.run!(self)
       package_me
       compress_me

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -328,6 +328,46 @@ module Omnibus
     expose :default_version
 
     #
+    # Set or retrieve the {#license} of the software to build.
+    #
+    # @example
+    #   license 'Apache 2.0'
+    #
+    # @param [String] val
+    #   the license to set for the software.
+    #
+    # @return [String]
+    #
+    def license(val = NULL)
+      if null?(val)
+        @license || 'Unspecified'
+      else
+        @license = val
+      end
+    end
+    expose :license
+
+    #
+    # Set or retrieve the location of a {#license_file}
+    # of the software.  It can either be a relative path inside
+    # the source package or a URL.
+    #
+    #
+    # @example
+    #   license_file 'LICENSES/artistic.txt'
+    #
+    # @param [String] val
+    #   the location of the license file for the software.
+    #
+    # @return [String]
+    #
+    def license_file(file)
+      license_files << file
+      license_files.dup
+    end
+    expose :license_file
+
+    #
     # Evaluate a block only if the version matches.
     #
     # @example
@@ -727,7 +767,9 @@ module Omnibus
                                    source_type: source_type,
                                    described_version: version,
                                    locked_version: Fetcher.resolve_version(version, source),
-                                   locked_source: source})
+                                   locked_source: source,
+                                   license: license
+      })
     end
 
     #
@@ -768,6 +810,17 @@ module Omnibus
     #
     def whitelist_files
       @whitelist_files ||= []
+    end
+
+    #
+    # The list of license files for this software
+    #
+    # @see #license_file
+    #
+    # @return [Array<String>]
+    #
+    def license_files
+      @license_files ||= []
     end
 
     #

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -608,7 +608,7 @@ module Omnibus
       end
     end
 
-    describe '#update_config_guess', :not_supported_on_windows, :focus => true do
+    describe '#update_config_guess', :not_supported_on_windows do
       let(:config_guess_dir) { "#{install_dir}/embedded/lib/config_guess" }
 
       before do

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -1,0 +1,141 @@
+require "spec_helper"
+
+module Omnibus
+  describe Licensing do
+    let(:license) { nil }
+    let(:license_file_path) { nil }
+    let(:license_file) { nil }
+
+    let(:install_dir) { File.join(tmp_path, "install_dir")}
+    let(:software_project_dir) { File.join(tmp_path, "software_project_dir")}
+
+    before do
+      FileUtils.mkdir_p(install_dir)
+      FileUtils.mkdir_p(software_project_dir)
+      allow_any_instance_of(Software).to receive(:project_dir).and_return(software_project_dir)
+      %w{README LICENSE NOTICE}.each do |file|
+        File.open(File.join(software_project_dir, file), "w+") do |f|
+          f.puts "This file is #{file}."
+        end
+      end
+    end
+
+    shared_examples "correctly created licenses" do
+      it "creates the main license file for the project correctly" do
+        project_license = File.join(install_dir, expected_project_license_path)
+        expect(File.exist?(project_license)).to be(true)
+        project_license = File.read(project_license)
+        expect(project_license).to match /test-project 1.2.3 license: "#{expected_project_license}"/
+        expect(project_license).to match /#{expected_project_license_content}/
+        expect(project_license).to match /This product bundles private_code 1.7.2,\nwhich is available under a "Unspecified"/
+        expect(project_license).to match /This product bundles snoopy 1.0.0,\nwhich is available under a "GPL v2"/
+        expect(project_license).to match /This product bundles zlib 1.7.2,\nwhich is available under a "Zlib"/
+        expect(project_license).not_to match /preparation/
+        expect(project_license).to match /LICENSES\/snoopy-README/
+        expect(project_license).to match /LICENSES\/snoopy-NOTICE/
+        expect(project_license).to match /LICENSES\/zlib-LICENSE/
+      end
+
+      it "creates the license files of software components correctly" do
+        license_dir = File.join(install_dir, "LICENSES")
+        expect(Dir.glob("#{license_dir}/**/*").length).to be(3)
+
+        %w{snoopy-NOTICE snoopy-README zlib-LICENSE}.each do |software_license|
+          license_path = File.join(license_dir, software_license)
+          expect(File.exist?(license_path)).to be(true)
+          expect(File.read(license_path)).to match /#{software_license.split("-").last}/
+        end
+      end
+    end
+
+    let(:project) do
+      Project.new.tap do |project|
+        project.name('test-project')
+        project.install_dir(install_dir)
+        project.license(license) unless license.nil?
+        project.license_file_path(license_file_path) unless license_file_path.nil?
+        project.license_file(license_file) unless license_file.nil?
+        project.build_version('1.2.3')
+      end
+    end
+
+    let(:private_code) do
+      Software.new(project, 'private_code.rb').evaluate do
+        name 'private_code'
+        default_version '1.7.2'
+      end
+    end
+
+    let(:zlib) do
+      Software.new(project, 'zlib.rb').evaluate do
+        name 'zlib'
+        default_version '1.7.2'
+        license "Zlib"
+        license_file "LICENSE"
+      end
+    end
+
+    let(:snoopy) do
+      Software.new(project, 'snoopy.rb').evaluate do
+        name 'snoopy'
+        default_version '1.0.0'
+        license "GPL v2"
+        license_file "README"
+        license_file "NOTICE"
+      end
+    end
+
+    let(:preparation) do
+      Software.new(project, 'preparation.rb').evaluate do
+        name 'preparation'
+        default_version '1.0.0'
+        license :project_license
+      end
+    end
+
+    def create_licenses
+      project.library.component_added(preparation)
+      project.library.component_added(snoopy)
+      project.library.component_added(zlib)
+      project.library.component_added(private_code)
+
+      Licensing.create!(project)
+    end
+
+    describe "without license definitions in the project" do
+      let(:expected_project_license_path) { "LICENSE" }
+      let(:expected_project_license) { "Unspecified" }
+      let(:expected_project_license_content) { "" }
+
+      before do
+        create_licenses
+      end
+
+      it_behaves_like "correctly created licenses"
+    end
+
+    describe "with license definitions in the project" do
+      let(:license) { "Custom Chef" }
+      let(:license_file_path) { "CHEF.LICENSE" }
+      let(:license_file) { "CUSTOM_CHEF" }
+
+      let(:expected_project_license_path) { license_file_path }
+      let(:expected_project_license) { license }
+      let(:expected_project_license_content) { "Chef Custom License" }
+
+      before do
+        File.open(File.join(Config.project_root, license_file), "w+") do |f|
+          f.puts "Chef Custom License is awesome."
+        end
+
+        create_licenses
+      end
+
+      after do
+        FileUtils.rm_rf(license_file)
+      end
+
+      it_behaves_like "correctly created licenses"
+    end
+  end
+end

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -71,6 +71,10 @@ module Omnibus
       it "returns a build_git_revision if one was passed in" do
         expect(Omnibus::Manifest.new("1.2.3", "e8e8e8").to_hash["build_git_revision"]).to eq("e8e8e8")
       end
+
+      it "returns a license if one was passed in" do
+        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8", "Apache").to_hash["license"]).to eq("Apache")
+      end
     end
 
     describe "#from_hash" do

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -45,6 +45,9 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :json_manifest_path, %|json_manifest_path '/path/to/manifest.txt'|
     it_behaves_like 'a cleanroom setter', :build_git_revision, %|build_git_revision 'wombats'|
     it_behaves_like 'a cleanroom getter', :files_path
+    it_behaves_like 'a cleanroom setter', :license, %|license 'Apache 2.0'|
+    it_behaves_like 'a cleanroom setter', :license_file, %|license_file 'LICENSES/artistic.txt'|
+    it_behaves_like 'a cleanroom setter', :license_file_path, %|license_file_path 'CHEF_LICENSE'|
 
     describe 'basics' do
       it 'returns a name' do
@@ -139,6 +142,18 @@ module Omnibus
         Dir.chdir(git_repo_subdir_path) do
           expect(subject.build_git_revision).to eq("632501dde2c41f3bdd988b818b4c008e2ff398dc")
         end
+      end
+    end
+
+    describe '#license' do
+      it "sets the default to Unspecified" do
+        expect(subject.license).to eq ('Unspecified')
+      end
+    end
+
+    describe '#license_file_path' do
+      it "sets the default to LICENSE" do
+        expect(subject.license_file_path).to eq ('/sample/LICENSE')
       end
     end
 

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -39,6 +39,8 @@ module Omnibus
     it_behaves_like 'a cleanroom setter', :source, %|source url: 'https://source.example.com'|
     it_behaves_like 'a cleanroom setter', :default_version, %|default_version '1.2.3'|
     it_behaves_like 'a cleanroom setter', :version, %|version '1.2.3'|
+    it_behaves_like 'a cleanroom setter', :license, %|license 'Apache 2.0'|
+    it_behaves_like 'a cleanroom setter', :license_file, %|license_file 'LICENSES/artistic.txt'|
     it_behaves_like 'a cleanroom setter', :whitelist_file, %|whitelist_file '/opt/whatever'|
     it_behaves_like 'a cleanroom setter', :relative_path, %|relative_path '/path/to/extracted'|
     it_behaves_like 'a cleanroom setter', :build, %|build {}|
@@ -54,6 +56,12 @@ module Omnibus
       before { allow(subject).to receive(:source_uri).and_return(uri) }
 
       it_behaves_like 'a cleanroom getter', :project_file
+    end
+
+    context 'when no license is present' do
+      it "sets the defaults" do
+        expect(subject.license).to eq ('Unspecified')
+      end
     end
 
     describe "with_standard_compiler_flags helper" do


### PR DESCRIPTION
This PR adds omnibus the ability to collect and report license information for projects and software components that are being included. I will try my best to describe this feature below but if you have more detailed questions, hit me directly and we can chat. 

This features targets two main scenarios:

* As an enterprise user; I would like to see 1) "the list of software components", 2) "the licenses these components are using" and 3) "the actual files that are referred by these licenses" for the package that I am installing, so that I can check these against our companies open source licensing policy and make sure we are compliant.
* As a developer, I would like to be informed about the licenses of the software components that are going into the package that I am building, so that I can ensure we are not including a software component with a license that is incompatible with our license.

This PR contains the MVP of this feature. You can see [this gist](https://gist.github.com/sersut/e1012c38e55a3890232b) with an example output created with https://github.com/chef/omnibus-software/pull/620 and https://github.com/chef/chef-server/pull/775.

Here is a high level summary of this feature:

- Adds 2 new DSL methods to software:
  - `license`: The name of the license software is using.
  - `license_file`: File that are part of the license for the software. Can be a partial path relative to the software's source directory or a URL. Can be used multiple times if license has more than 1 file.
- Adds 3 new DSL methods to project:
  - `license`: The name of the license project is using.
  - `license_file`: File that contains the text of the license project is using.
  - `license_file_path`: Path of the file that will be created under `install_dir` which will contain license information for the project.
- Adds a new post-build stage to the build command. During this stage omnibus does two things:
  - It copies the license files specified by software definitions to `#{install_dir}/LICENSES`
  - It creates a file at `license_file_path` specified by the project that contains:
    - project's name, version and license name. 
    - license name and list of file paths that belong to the license for each software
  - If you use the special license type `:project_license` in software definitions, we skip adding that software's license information to the main license file. We use this for things like, `preparation`, `private-chef-cookbooks`, `private-chef-ctl`, etc..
- Updates the version manifest files with the license name of each software.
There are many features that are missing to fulfill the above mentioned scenarios. Some that we have thought of are:
* Add warnings to omnibus build output for important cases like software config that is missing license, license files that do not exist anymore, etc. **(next item)**
* Add logic to catch licenses of hidden dependencies like gems that are being installed from rubygems during `bundle install` command runs.

Comments, questions, suggestions, error cases I have missed are much appreciated :smile: 

/cc: @chef/omnibus-maintainers, @jamesc 