### PR TITLE
Licensing warnings

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -55,6 +55,7 @@ module Omnibus
     #
     def create!
       prepare
+      validate_license_info
       create_software_license_files
       create_project_license_file
     end
@@ -67,6 +68,49 @@ module Omnibus
     def prepare
       FileUtils.rm_rf(output_dir)
       FileUtils.mkdir_p(output_dir)
+    end
+
+    #
+    # Inspects the licensing information for the project and the included
+    # software components. Logs the found issues to the log as warning.
+    #
+    # @return [void]
+    #
+    def validate_license_info
+      # First check the project licensing information
+
+      # Check existence of licensing information
+      if project.license == "Unspecified"
+        licensing_warning("Project '#{project.name}' does not contain licensing information.")
+      end
+
+      # Check license file exists
+      if project.license != "Unspecified" && project.license_file.nil?
+        licensing_warning("Project '#{project.name}' does not point to a license file.")
+      end
+
+      # Check used license is a standard license
+      if project.license != "Unspecified" && !STANDARD_LICENSES.include?(project.license)
+        licensing_warning("Project '#{project.name}' is using '#{project.license}' which is not one of the standard licenses identified in https://opensource.org/licenses/alphabetical. Consider using one of the standard licenses.")
+      end
+
+      # Now let's check the licensing info for software components
+      license_map.each do |software_name, license_info|
+        # First check if the software specified a license
+        if license_info[:license] == "Unspecified"
+          licensing_warning("Software '#{software_name}' does not contain licensing information.")
+        end
+
+        # Check if the software specifies any license files
+        if license_info[:license] != "Unspecified" && license_info[:license_files].empty?
+          licensing_warning("Software '#{software_name}' does not point to any license files.")
+        end
+
+        # Check if the software license is one of the standard licenses
+        if license_info[:license] != "Unspecified" && !STANDARD_LICENSES.include?(license_info[:license])
+          licensing_warning("Software '#{software_name}' uses license '#{license_info[:license]}' which is not one of the standard licenses identified in https://opensource.org/licenses/alphabetical. Consider using one of the standard licenses.")
+        end
+      end
     end
 
     #
@@ -253,5 +297,98 @@ module Omnibus
     def licensing_warning(message)
       log.warn(log_key) { message }
     end
+
+    STANDARD_LICENSES = [
+      #
+      # Below licenses are compiled based on https://opensource.org/licenses/alphabetical
+      #
+      "AFL-3.0",       # Academic Free License 3.0
+      "AGPL-3.0",      # Affero General Public License
+      "APL-1.0",       # Adaptive Public License
+      "Apache-2.0",    # Apache License 2.0
+      "APSL-2.0",      # Apple Public Source License
+      "Artistic-2.0",  # Artistic license 2.0
+      "AAL",           # Attribution Assurance Licenses
+      "BSD-3-Clause",  # BSD 3-Clause "New" or "Revised" License
+      "BSD-2-Clause",  # BSD 2-Clause "Simplified" or "FreeBSD" License
+      "BSL-1.0",       # Boost Software License
+      "CECILL-2.1",    # CeCILL License 2.1
+      "CATOSL-1.1",    # Computer Associates Trusted Open Source License 1.1
+      "CDDL-1.0",      # Common Development and Distribution License 1.0
+      "CPAL-1.0",      # Common Public Attribution License 1.0
+      "CUA-OPL-1.0",   # CUA Office Public License Version 1.0
+      "EUDatagrid",    # EU DataGrid Software License
+      "EPL-1.0",       # Eclipse Public License 1.0
+      "eCos-2.0",      # eCos License version 2.0
+      "ECL-2.0",       # Educational Community License, Version 2.0
+      "EFL-2.0",       # Eiffel Forum License V2.0
+      "Entessa",       # Entessa Public License
+      "EUPL-1.1",      # European Union Public License, Version 1.1
+      "Fair",          # Fair License
+      "Frameworx-1.0", # Frameworx License
+      "FPL-1.0.0",     # Free Public License 1.0.0
+      "AGPL-3.0",      # GNU Affero General Public License v3
+      "GPL-2.0",       # GNU General Public License version 2.0
+      "GPL-3.0",       # GNU General Public License version 3.0
+      "LGPL-2.1",      # GNU Library or "Lesser" General Public License version 2.1
+      "LGPL-3.0",      # GNU Library or "Lesser" General Public License version 3.0
+      "HPND",          # Historical Permission Notice and Disclaimer
+      "IPL-1.0",       # IBM Public License 1.0
+      "IPA",           # IPA Font License
+      "ISC",           # ISC License
+      "LPPL-1.3c",     # LaTeX Project Public License 1.3c
+      "LiLiQ-P",       # Licence Libre du Quebec Permissive
+      "LiLiQ-R",       # Licence Libre du Quebec Reciprocite
+      "LiLiQ-R+",      # Licence Libre du Quebec Reciprocite forte
+      "LPL-1.02",      # Lucent Public License Version 1.02
+      "MirOS",         # MirOS Licence
+      "MS-PL",         # Microsoft Public License
+      "MS-RL",         # Microsoft Reciprocal License
+      "MIT",           # MIT license
+      "Motosoto",      # Motosoto License
+      "MPL-2.0",       # Mozilla Public License 2.0
+      "Multics",       # Multics License
+      "NASA-1.3",      # NASA Open Source Agreement 1.3
+      "NTP",           # NTP License
+      "Naumen",        # Naumen Public License
+      "NGPL",          # Nethack General Public License
+      "Nokia",         # Nokia Open Source License
+      "NPOSL-3.0",     # Non-Profit Open Software License 3.0
+      "OCLC-2.0",      # OCLC Research Public License 2.0
+      "OGTSL",         # Open Group Test Suite License
+      "OSL-3.0",       # Open Software License 3.0
+      "OPL-2.1",       # OSET Public License version 2.1
+      "PHP-3.0",       # PHP License 3.0
+      "PostgreSQL",    # The PostgreSQL License
+      "Python-2.0",    # Python License
+      "CNRI-Python",   # CNRI Python license
+      "QPL-1.0",       # Q Public License
+      "RPSL-1.0",      # RealNetworks Public Source License V1.0
+      "RPL-1.5",       # Reciprocal Public License 1.5
+      "RSCPL",         # Ricoh Source Code Public License
+      "OFL-1.1",       # SIL Open Font License 1.1
+      "SimPL-2.0",     # Simple Public License 2.0
+      "Sleepycat",     # Sleepycat License
+      "SPL-1.0",       # Sun Public License 1.0
+      "Watcom-1.0",    # Sybase Open Watcom Public License 1.0
+      "NCSA",          # University of Illinois/NCSA Open Source License
+      "UPL",           # Universal Permissive License
+      "VSL-1.0",       # Vovida Software License v. 1.0
+      "W3C",           # W3C License
+      "WXwindows",     # wxWindows Library License
+      "Xnet",          # X.Net License
+      "0BSD",          # Zero Clause BSD License
+      "ZPL-2.0",       # Zope Public License 2.0
+      "Zlib",          # zlib/libpng license
+      #
+      # In addition to these we would like to add some of the licenses that
+      # are frequently used in our depedencies.
+      #
+      "Public-Domain", # https://opensource.org/faq#public-domain
+      "Ruby",          # http://www.ruby-lang.org/en/LICENSE.txt
+      "Erlang-Public", # http://www.erlang.org/EPLICENSE
+      "Oracle-Binary", # http://www.oracle.com/technetwork/java/javase/terms/license/index.html
+      "OpenSSL",       # https://www.openssl.org/source/license.html
+    ].freeze
   end
 end


### PR DESCRIPTION
This PR adds some warnings to the build log so that we can see when licensing information is having issues. We will be introducing the option to convert these warnings to failures in a later PR. 

Added checks are:
* Warn when project / software licensing information does not exist.
* Warn when project / software doesn't point to any license files.
* Warn when project / software license files are missing.
* Warn when license set is not a standard license.

- [x] Incoming tests.

/cc: @chef/omnibus-maintainers, @jamesc