### PR TITLE
Fix Windows builds

### DIFF
--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -197,13 +197,20 @@ module Omnibus
     #
     # Execute the given git command, inside the +project_dir+.
     #
+    # autcrlf is a hack to help support windows and posix clients using the
+    # same repository but canonicalizing files as they are committed to the
+    # repo but converting line endings when they are actually checked out
+    # into a working tree. We do not want to change the on-disk representation
+    # of our sources regardless of the platform we are building on unless
+    # explicitly asked for. Hence, we disable autocrlf.
+    #
     # @see Util#shellout!
     #
     # @return [Mixlib::ShellOut]
     #   the shellout object
     #
     def git(command)
-      shellout!("git #{command}", cwd: project_dir)
+      shellout!("git -c core.autocrlf=false #{command}", cwd: project_dir)
     end
 
     # Class methods

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -614,8 +614,16 @@ module Omnibus
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"
           {
             "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag}",
-            # If we're happy with these flags, enable SSE for other platforms running x86 too.
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 -mfpmath=sse -msse2 #{opt_flag}"
+            # We do not wish to enable SSE even though we target i686 because
+            # of a stack alignment issue with some libraries. We have not
+            # exactly ascertained the cause but some compiled library/binary
+            # violates gcc's assumption that the stack is going to be 16-byte
+            # aligned which is just fine as long as one is pushing 32-bit
+            # values from general purpose registers but stuff hits the fan as
+            # soon as gcc emits aligned SSE xmm register spills which generate
+            # GPEs and terminate the application very rudely with very little
+            # to debug with.
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 #{opt_flag}"
           }
         else
           {

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -267,9 +267,9 @@ module Omnibus
         context 'in 32-bit mode' do
           it 'sets the default' do
             expect(subject.with_standard_compiler_flags).to eq(
-              'CFLAGS'          => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
-              'CXXFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
-              'CPPFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
+              'CFLAGS'          => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
+              'CXXFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
+              'CPPFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
               'LDFLAGS'         => '-L/opt/project/embedded/lib -m32',
               'LD_RUN_PATH'     => '/opt/project/embedded/lib',
               'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
@@ -278,9 +278,9 @@ module Omnibus
 
           it 'sets BFD flags if requested' do
             expect(subject.with_standard_compiler_flags({}, bfd_flags: true)).to eq(
-              'CFLAGS'          => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
-              'CXXFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
-              'CPPFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -mfpmath=sse -msse2 -march=i686',
+              'CFLAGS'          => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
+              'CXXFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
+              'CPPFLAGS'        => '-I/opt/project/embedded/include -m32 -O3 -march=i686',
               'LDFLAGS'         => '-L/opt/project/embedded/lib -m32',
               'RCFLAGS'         => '--target=pe-i386',
               'ARFLAGS'         => '--target=pe-i386',
@@ -295,9 +295,9 @@ module Omnibus
 
           it 'sets the default' do
             expect(subject.with_standard_compiler_flags).to eq(
-              'CFLAGS'          => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
-              'CXXFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
-              'CPPFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
+              'CFLAGS'          => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
+              'CXXFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
+              'CPPFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
               'LDFLAGS'         => '-L/opt/project/embedded/lib -m64',
               'LD_RUN_PATH'     => '/opt/project/embedded/lib',
               'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig'
@@ -306,9 +306,9 @@ module Omnibus
 
           it 'sets BFD flags if requested' do
             expect(subject.with_standard_compiler_flags({}, bfd_flags: true)).to eq(
-              'CFLAGS'          => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
-              'CXXFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
-              'CPPFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -mfpmath=sse -msse2 -march=x86-64',
+              'CFLAGS'          => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
+              'CXXFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
+              'CPPFLAGS'        => '-I/opt/project/embedded/include -m64 -O3 -march=x86-64',
               'LDFLAGS'         => '-L/opt/project/embedded/lib -m64',
               'RCFLAGS'         => '--target=pe-x86-64',
               'ARFLAGS'         => '--target=pe-x86-64',


### PR DESCRIPTION
This is necessary to get chef-dk using compiled ruby.

Two fixes:

1. Don't change newlines when `git pull`ing.
2. Remove the `sse` flags because we can't compile on virtualbox without them.