### PR TITLE
Get DEB architecture from the packager directly

### DIFF
--- a/lib/omnibus/packagers/deb.rb
+++ b/lib/omnibus/packagers/deb.rb
@@ -397,29 +397,7 @@ module Omnibus
     # @return [String]
     #
     def safe_architecture
-      case Ohai['kernel']['machine']
-      when 'x86_64'
-        'amd64'
-      when 'i686'
-        'i386'
-      when /armv\dl/
-        if Ohai['platform'] == 'raspbian' || Ohai['platform'] == 'ubuntu'
-          'armhf'
-        else
-          Ohai['kernel']['machine']
-        end
-      when 'aarch64'
-        # Debian prefers amd64 on ARMv8/AArch64 (64bit ARM) platforms
-        # see https://wiki.debian.org/Arm64Port
-        'arm64'
-      when 'ppc64le'
-        # Debian prefers to use ppc64el for little endian architecture name
-        # where as others like gnutools/rhel use ppc64le( note the last 2 chars)
-        # see http://linux.debian.ports.powerpc.narkive.com/8eeWSBtZ/switching-ppc64el-port-name-to-ppc64le
-        'ppc64el'  #dpkg --print-architecture = ppc64el
-      else
-        Ohai['kernel']['machine']
-      end
+      @safe_architecture ||= shellout!("dpkg --print-architecture").stdout.split("\n").first || "noarch"
     end
   end
 end


### PR DESCRIPTION
We currently use `uname -m` to infer the architecture for a system, but this requires a lot of extra logic and doesn't always match 1:1 with a distro. For example: in the world of Debian gcc and kernel architecture names do not match Debian architecture names. It's further complicated in the world of ARM where the runtime architecture (armhf or armel) are designed to span processors architectures (ARMv6, ARMv7. and ARMv8).

This resolves all of that by getting the native architecture of the runtime environment from the native packaging tools in DEB environments by getting the system architecture directly from `dpkg`. This works for omnibus, but isn't a good fit for a ohai plugin becuase while `dpkg` is in all Debain runtime environments (or should be), there does not appear to be a reliable way to detect this properly in an RPM environment using the packaging tools.

Many tests are removed which were just ensuring that the platform we computed matched what was expected. The `safe_architecture` functions in the respective libraries also fall back to a known default to allow tests to succeed when the tool is not available (ex: rpm test on a deb system).

This code was tested on several architectures and distributions.