### PR TITLE
Use gcc 4.9 on Freebsd 9 if it exists

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -606,6 +606,13 @@ module Omnibus
             "LDFLAGS" => "-L#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
+          # Enable gcc version 4.9 if it is available
+          if (Ohai['os_version'].to_i <= 903000) && which('gcc49')
+            freebsd_flags.merge!(
+              "CC" => "gcc49",
+              "CXX" => "g++49",
+            )
+          end
           # Clang became the default compiler in FreeBSD 10+
           if Ohai['os_version'].to_i >= 1000024
             freebsd_flags.merge!(

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -235,6 +235,24 @@ module Omnibus
             'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig',
           )
         end
+
+        context 'with gcc 4.9 installed' do
+          before do
+            allow(subject).to receive(:which).and_return('/usr/local/bin/gcc49')
+          end
+
+          it 'sets the compiler args' do
+            expect(subject.with_standard_compiler_flags).to eq(
+              'CC'              => 'gcc49',
+              'CXX'             => 'g++49',
+              'CFLAGS'  => '-I/opt/project/embedded/include -O2',
+              'CXXFLAGS'  => '-I/opt/project/embedded/include -O2',
+              'CPPFLAGS'  => '-I/opt/project/embedded/include -O2',
+              'LDFLAGS' => '-L/opt/project/embedded/lib',
+              'LD_RUN_PATH' => '/opt/project/embedded/lib',
+              'PKG_CONFIG_PATH' => '/opt/project/embedded/lib/pkgconfig',            )
+          end
+        end
       end
 
       context 'on freebsd 10' do


### PR DESCRIPTION
@chef/engineering-services @chef/omnibus-maintainers 

replaces https://github.com/chef-cookbooks/omnibus/pull/157