### PR TITLE
Pin jmespath to 1.1.x: 1.2.2 brings in json_pure and breaks us

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -31,6 +31,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ohai',             '~> 8.0'
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'aws-sdk',          '~> 2'
+  # aws-sdk brings this in, and jmespath 1.2+ brings in json_pure, which fails the build
+  gem.add_dependency 'jmespath',         '< 1.2'
   gem.add_dependency 'thor',             '~> 0.18'
 
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
### Fix issue with json_pure killing chef+chef-dk builds

aws-sdk brings in jmespath, and jmespath 1.2.2 brings in json_pure, which breaks with this error:

```
/home/jenkins/workspace/chefdk-build/architecture/x86_64/platform/ubuntu-12.04/project/chefdk/role/builder/omnibus/vendor/bundle/ruby/2.1.0/gems/json_pure-1.8.3/lib/json/pure/generator.rb:366:in `to_json': wrong argument type JSON::Pure::Generator::State (expected Data) (TypeError)`
```

--------------------------------------------------
/cc @chef/omnibus-maintainers