### PR TITLE
Include license and version manifest data in `*.metadata.json`

### DIFF
--- a/features/commands/publish.feature
+++ b/features/commands/publish.feature
@@ -6,3 +6,10 @@ Feature: omnibus publish
       """
       Publishing will be performed using provided platform mappings.
       """
+
+  Scenario: When a user provides the deprecated `--version-manifest` flag
+    * I run `omnibus publish artifactory fake * --version-manifest /fake/path/version-manifest.json`
+    * the output should contain:
+      """
+      The `--version-manifest' option has been deprecated. Version manifest data is now part of the `*.metadata.json' file
+      """

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -76,6 +76,11 @@ module Omnibus
       default: {}
     desc 'artifactory REPOSITORY PATTERN', 'Publish to an Artifactory instance'
     def artifactory(repository, pattern)
+
+      Omnibus.logger.deprecated('ArtifactoryPublisher') do
+        "The `--version-manifest' option has been deprecated. Version manifest data is now part of the `*.metadata.json' file"
+      end if options[:version_manifest]
+
       options[:repository] = repository
       publish(ArtifactoryPublisher, pattern, options)
     end

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -61,6 +61,8 @@ module Omnibus
           homepage:         project.homepage,
           version:          project.build_version,
           iteration:        project.build_iteration,
+          license:          project.license,
+          version_manifest: project.built_manifest.to_hash,
         }
 
         instance = new(package, data)

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -67,11 +67,27 @@ module Omnibus
             version: '11.0.6',
             iteration: 1,
             basename: 'chef.deb',
+            license: 'Apache-2.0',
             platform: 'ubuntu',
             platform_version: '12.04',
             arch: 'x86_64',
             sha1: 'SHA1',
             md5: 'ABCDEF123456',
+            version_manifest: {
+              'manifest_format' => 1,
+              'build_version' => '11.0.6',
+              'build_git_revision' => '2e763ac957b308ba95cef256c2491a5a55a163cc',
+              'software' => {
+                'zlib' => {
+                  'locked_source' => {
+                    'url' => 'an_url'
+                  },
+                  'locked_version' => 'new.newer',
+                  'source_type' => 'url',
+                  'described_version' => 'new.newer'
+                }
+              }
+            }
           )
         end
 

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -21,6 +21,7 @@ module Omnibus
         homepage: 'https://www.getchef.com',
         version: '11.0.6',
         iteration: 1,
+        license:  'Apache-2.0',
         basename: 'chef.deb',
         platform: 'ubuntu',
         platform_version: '14.04',
@@ -29,6 +30,21 @@ module Omnibus
         sha256: 'SHA256',
         sha512: 'SHA512',
         md5: 'ABCDEF123456',
+        version_manifest: {
+          'manifest_format' => 1,
+          'build_version' => '11.0.6',
+          'build_git_revision' => '2e763ac957b308ba95cef256c2491a5a55a163cc',
+          'software' => {
+            'zlib' => {
+              'locked_source' => {
+                'url' => 'an_url'
+              },
+              'locked_version' => 'new.newer',
+              'source_type' => 'url',
+              'described_version' => 'new.newer',
+            }
+          }
+        }
       )
     end
 
@@ -49,6 +65,20 @@ module Omnibus
         "omnibus.sha256" => "SHA256",
         "omnibus.sha512" => "SHA512",
         "omnibus.version" => "11.0.6",
+        "omnibus.license" => "Apache-2.0",
+        "omnibus.version_manifest" => {
+          "manifest_format" => 1,
+          "build_version" => "11.0.6",
+          "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
+          "software" => {
+            "zlib" => {
+              "locked_source" => {
+                "url" => "an_url"
+              },
+              "locked_version" => "new.newer",
+              "source_type" => "url",
+              "described_version" => "new.newer"}}
+        }
       }
     end
     let(:build_values) do


### PR DESCRIPTION
### Description

* Include license and version manifest in generated `*.metadata.json`
* Publish license and manifest data to Artifactory - We’ll attach the data to the following new Artifactory properties attached to the published package:
  * `omnibus.license`
  * `omnibus.version_manifest`

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.