### PR TITLE
Manifest Fixes/Improvements

### DIFF
--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -97,6 +97,8 @@ module Omnibus
       case manifest_data['manifest_format'].to_i
       when 1
         from_hash_v1(manifest_data)
+      when 2
+        from_hash_v2(manifest_data)
       else
         raise InvalidManifestFormat, "Unknown manifest format version: #{manifest_data['manifest_format']}"
       end
@@ -104,6 +106,14 @@ module Omnibus
 
     def self.from_hash_v1(manifest_data)
       m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'])
+      manifest_data['software'].each do |name, entry_data|
+        m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
+      end
+      m
+    end
+
+    def self.from_hash_v2(manifest_data)
+      m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'], manifest_data['license'])
       manifest_data['software'].each do |name, entry_data|
         m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
       end

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -35,8 +35,9 @@ module Omnibus
     end
 
     def entry_for(name)
-      if @data.key?(name)
-        @data[name]
+      name_sym = name.to_sym
+      if @data.key?(name_sym)
+        @data[name_sym]
       else
         raise MissingManifestEntry, "No manifest entry found for #{name}"
       end
@@ -47,11 +48,12 @@ module Omnibus
         raise NotAManifestEntry, "#{entry} is not an Omnibus:ManifestEntry"
       end
 
-      if @data.key?(name)
+      name_sym = name.to_sym
+      if @data.key?(name_sym)
         log.warn(log_key) { "Overritting existing manifest entry for #{name}" }
       end
 
-      @data[name] = entry
+      @data[name_sym] = entry
       self
     end
 
@@ -71,12 +73,12 @@ module Omnibus
         memo
       end
       ret = {
-        'manifest_format' => LATEST_MANIFEST_FORMAT,
-        'software' => software_hash
+        manifest_format: LATEST_MANIFEST_FORMAT,
+        software: software_hash
       }
-      ret['build_version'] = build_version if build_version
-      ret['build_git_revision'] = build_git_revision if build_git_revision
-      ret['license'] = license
+      ret[:build_version] = build_version if build_version
+      ret[:build_git_revision] = build_git_revision if build_git_revision
+      ret[:license] = license
       ret
     end
 
@@ -94,34 +96,36 @@ module Omnibus
     #
 
     def self.from_hash(manifest_data)
-      case manifest_data['manifest_format'].to_i
+      case manifest_data[:manifest_format].to_i
       when 1
         from_hash_v1(manifest_data)
       when 2
         from_hash_v2(manifest_data)
       else
-        raise InvalidManifestFormat, "Unknown manifest format version: #{manifest_data['manifest_format']}"
+        raise InvalidManifestFormat, "Unknown manifest format version: #{manifest_data[:manifest_format]}"
       end
     end
 
     def self.from_hash_v1(manifest_data)
-      m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'])
-      manifest_data['software'].each do |name, entry_data|
+      m = Omnibus::Manifest.new(manifest_data[:build_version], manifest_data[:build_git_revision])
+      manifest_data[:software].each do |name, entry_data|
         m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
       end
       m
     end
 
     def self.from_hash_v2(manifest_data)
-      m = Omnibus::Manifest.new(manifest_data['build_version'], manifest_data['build_git_revision'], manifest_data['license'])
-      manifest_data['software'].each do |name, entry_data|
+      m = Omnibus::Manifest.new(manifest_data[:build_version], manifest_data[:build_git_revision], manifest_data[:license])
+      manifest_data[:software].each do |name, entry_data|
         m.add(name, Omnibus::ManifestEntry.new(name, keys_to_syms(entry_data)))
       end
       m
     end
 
     def self.from_file(filename)
-      from_hash(JSON.parse(File.read(File.expand_path(filename))))
+      data = File.read(File.expand_path(filename))
+      hash = JSON.parse(data, symbolize_names: true)
+      from_hash(hash)
     end
 
     private

--- a/lib/omnibus/manifest_entry.rb
+++ b/lib/omnibus/manifest_entry.rb
@@ -28,11 +28,11 @@ module Omnibus
 
     def to_hash
       {
-        "locked_version" => @locked_version,
-        "locked_source" => @locked_source,
-        "source_type" => @source_type,
-        "described_version" => @described_version,
-        "license" => @license
+        locked_version: @locked_version,
+        locked_source: @locked_source,
+        source_type: @source_type,
+        described_version: @described_version,
+        license: @license
       }
     end
 

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -92,10 +92,6 @@ module Omnibus
               "described_version" => "new.newer"}}}
       }
 
-      let(:v2_manifest) {
-        {"manifest_format" => 2}
-      }
-
       it "has a build_version" do
         expect(Manifest.from_hash(manifest).build_version).to eq('12.4.0+20150629082811')
       end
@@ -112,8 +108,36 @@ module Omnibus
         expect(Manifest.from_hash(manifest).entry_for("zlib").locked_source).to eq({:url => "an_url"})
       end
 
-      it "raises an error if it doesn't recognize the manifest version" do
-        expect{Manifest.from_hash(v2_manifest)}.to raise_error Manifest::InvalidManifestFormat
+      context "v2 manifest" do
+        let(:manifest) {
+          { "manifest_format" => 2,
+            "build_version" => "12.4.0+20150629082811",
+            "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
+            "license" => "Unspecified",
+            "software" => {
+              "zlib" => {
+                "locked_source" => {
+                  "url" => "an_url"
+                },
+                "locked_version" => "new.newer",
+                "source_type" => "url",
+                "described_version" => "new.newer",
+                "license" => "Zlib"}}}
+        }
+
+        it "has a license" do
+          expect(Manifest.from_hash(manifest).license).to eq('Unspecified')
+        end
+      end
+
+      context "unsupported manifest" do
+        let(:manifest) {
+          {"manifest_format" => 99}
+        }
+
+        it "raises an error if it doesn't recognize the manifest version" do
+          expect{Manifest.from_hash(manifest)}.to raise_error Manifest::InvalidManifestFormat
+        end
       end
     end
   end

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -21,7 +21,7 @@ module Omnibus
       it "returns a ManifestEntry for the requested software" do
         me = ManifestEntry.new("foobar", {})
         subject.add("foobar", me)
-        expect(subject.entry_for("foobar")).to eq(me)
+        expect(subject.entry_for(:foobar)).to eq(me)
       end
 
       it "raises an error if no such manifest entry exists" do
@@ -45,51 +45,54 @@ module Omnibus
         second = ManifestEntry.new("wombat", {})
         subject.add("foobar", first)
         subject.add("wombat", second)
-        expect(subject.entry_names).to eq(["foobar", "wombat"])
+        expect(subject.entry_names).to eq([:foobar, :wombat])
       end
     end
 
     describe "#to_hash" do
       it "returns a Hash containg the current manifest format" do
-        expect(subject.to_hash['manifest_format']).to eq(Manifest::LATEST_MANIFEST_FORMAT)
+        expect(subject.to_hash[:manifest_format]).to eq(Manifest::LATEST_MANIFEST_FORMAT)
       end
 
       it "includes entries for software in the manifest" do
         subject.add("foobar", ManifestEntry.new("foobar", {}))
-        expect(subject.to_hash['software']).to have_key("foobar")
+        expect(subject.to_hash[:software]).to have_key(:foobar)
       end
 
       it "converts the manifest entries to hashes" do
         subject.add("foobar", ManifestEntry.new("foobar", {}))
-        expect(subject.to_hash['software']['foobar']).to be_a(Hash)
+        expect(subject.to_hash[:software][:foobar]).to be_a(Hash)
       end
 
       it "returns a build_version if one was passed in" do
-        expect(Omnibus::Manifest.new("1.2.3").to_hash["build_version"]).to eq("1.2.3")
+        expect(Omnibus::Manifest.new("1.2.3").to_hash[:build_version]).to eq("1.2.3")
       end
 
       it "returns a build_git_revision if one was passed in" do
-        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8").to_hash["build_git_revision"]).to eq("e8e8e8")
+        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8").to_hash[:build_git_revision]).to eq("e8e8e8")
       end
 
       it "returns a license if one was passed in" do
-        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8", "Apache").to_hash["license"]).to eq("Apache")
+        expect(Omnibus::Manifest.new("1.2.3", "e8e8e8", "Apache").to_hash[:license]).to eq("Apache")
       end
     end
 
     describe "#from_hash" do
       let(:manifest) {
-        { "manifest_format" => 1,
-          "build_version" => "12.4.0+20150629082811",
-          "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
-          "software" => {
-            "zlib" => {
-              "locked_source" => {
-                "url" => "an_url"
+        { manifest_format: 1,
+          build_version: "12.4.0+20150629082811",
+          build_git_revision: "2e763ac957b308ba95cef256c2491a5a55a163cc",
+          software: {
+            zlib: {
+              locked_source: {
+                url: "an_url",
               },
-              "locked_version" => "new.newer",
-              "source_type" => "url",
-              "described_version" => "new.newer"}}}
+              locked_version: "new.newer",
+              source_type: "url",
+              described_version: "new.newer",
+            }
+          }
+        }
       }
 
       it "has a build_version" do
@@ -105,24 +108,27 @@ module Omnibus
       end
 
       it "normalizes the source to use symbols" do
-        expect(Manifest.from_hash(manifest).entry_for("zlib").locked_source).to eq({:url => "an_url"})
+        expect(Manifest.from_hash(manifest).entry_for(:zlib).locked_source).to eq({url: "an_url"})
       end
 
       context "v2 manifest" do
         let(:manifest) {
-          { "manifest_format" => 2,
-            "build_version" => "12.4.0+20150629082811",
-            "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
-            "license" => "Unspecified",
-            "software" => {
-              "zlib" => {
-                "locked_source" => {
-                  "url" => "an_url"
+          { manifest_format: 2,
+            build_version: "12.4.0+20150629082811",
+            build_git_revision: "2e763ac957b308ba95cef256c2491a5a55a163cc",
+            license: "Unspecified",
+            software: {
+              zlib: {
+                locked_source: {
+                  url: "an_url"
                 },
-                "locked_version" => "new.newer",
-                "source_type" => "url",
-                "described_version" => "new.newer",
-                "license" => "Zlib"}}}
+                locked_version: "new.newer",
+                source_type: "url",
+                described_version: "new.newer",
+                license: "Zlib",
+              }
+            }
+          }
         }
 
         it "has a license" do
@@ -132,7 +138,9 @@ module Omnibus
 
       context "unsupported manifest" do
         let(:manifest) {
-          {"manifest_format" => 99}
+          {
+            manifest_format: 99,
+          }
         }
 
         it "raises an error if it doesn't recognize the manifest version" do

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -505,7 +505,7 @@ module Omnibus
       let(:manifest_entry) {Omnibus::ManifestEntry.new("software", {locked_version: "1.2.8", locked_source: a_source})}
       let(:manifest) do
         m = Omnibus::Manifest.new
-        m.add("software", manifest_entry)
+        m.add(:software, manifest_entry)
       end
 
       let(:project_with_manifest) do


### PR DESCRIPTION
### Description

* Add proper support for loading v2 manifests - This change was overlooked in #635.
* Use symbolized keys for all Manifest hashes - This ensures are internal Hash representations are consistent across objects (e.g. Metadata).

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.