### PR TITLE
Don't publish full version manifest to Artifactory

### DIFF
--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -205,7 +205,7 @@ module Omnibus
         'omnibus.sha1'             => package.metadata[:sha1],
         'omnibus.sha256'           => package.metadata[:sha256],
         'omnibus.sha512'           => package.metadata[:sha512],
-        'omnibus.version_manifest' => package.metadata[:version_manifest] || '',
+        'omnibus.dependencies'     => dependency_data_for(package),
       }.tap do |h|
         if build_record?
           h['build.name'] = package.metadata[:name]
@@ -256,6 +256,28 @@ module Omnibus
         package.metadata[:platform_version],
         package.metadata[:basename],
       )
+    end
+
+    #
+    # Dependency data for all of a package
+    #
+    # @param [Package] package
+    #   the package to generate the dependency data for
+    #
+    # @return [Hash<String, String>]
+    #
+    def dependency_data_for(package)
+      dependency_data = {}
+      dep_list = package.metadata.to_hash.fetch(:version_manifest, {}).fetch(:software, {})
+      dep_list.each do |name, data|
+        dependency_data[name.to_s] = {
+          'source_type'       => data[:source_type],
+          'described_version' => data[:described_version],
+          'locked_version'    => data[:locked_version],
+          'license'           => data[:license],
+        }
+      end
+      dependency_data
     end
   end
 end

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -74,18 +74,64 @@ module Omnibus
             sha1: 'SHA1',
             md5: 'ABCDEF123456',
             version_manifest: {
-              'manifest_format' => 1,
-              'build_version' => '11.0.6',
-              'build_git_revision' => '2e763ac957b308ba95cef256c2491a5a55a163cc',
-              'software' => {
-                'zlib' => {
-                  'locked_source' => {
-                    'url' => 'an_url'
+              manifest_format: 1,
+              build_version: '11.0.6',
+              build_git_revision: '2e763ac957b308ba95cef256c2491a5a55a163cc',
+              software: {
+                zlib: {
+                  locked_source: {
+                    md5: '44d667c142d7cda120332623eab69f40',
+                    url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
                   },
-                  'locked_version' => 'new.newer',
-                  'source_type' => 'url',
-                  'described_version' => 'new.newer'
-                }
+                  locked_version: '1.2.8',
+                  source_type: 'url',
+                  described_version: '1.2.8',
+                  license: 'Zlib',
+                },
+                openssl: {
+                  locked_source: {
+                    md5: '562986f6937aabc7c11a6d376d8a0d26',
+                    extract: 'lax_tar',
+                    url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
+                  },
+                  locked_version: '1.0.1s',
+                  source_type: 'url',
+                  described_version: '1.0.1s',
+                  license: 'OpenSSL',
+                },
+                ruby: {
+                  locked_source: {
+                    md5: '091b62f0a9796a3c55de2a228a0e6ef3',
+                    url: 'https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz',
+                  },
+                  locked_version: '2.1.8',
+                  source_type: 'url',
+                  described_version: '2.1.8',
+                  license: 'BSD-2-Clause',
+                },
+                ohai: {
+                  locked_source: {
+                    git: 'https://github.com/opscode/ohai.git'
+                  },
+                  locked_version: 'fec0959aa5da5ce7ba0e07740dbc08546a8f53f0',
+                  source_type: 'git',
+                  described_version: 'master',
+                  license: 'Apache-2.0',
+                },
+                chef: {
+                  locked_source: {
+                    path: '/home/jenkins/workspace/chef-build/architecture/x86_64/platform/ubuntu-10.04/project/chef/role/builder/omnibus/files/../..',
+                    options: {
+                      exclude: [
+                        'omnibus/vendor',
+                      ],
+                    },
+                  },
+                  locked_version: 'local_source',
+                  source_type: 'path',
+                  described_version: 'local_source',
+                  license: 'Apache-2.0',
+                },
               }
             }
           )

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -31,18 +31,64 @@ module Omnibus
         sha512: 'SHA512',
         md5: 'ABCDEF123456',
         version_manifest: {
-          'manifest_format' => 1,
-          'build_version' => '11.0.6',
-          'build_git_revision' => '2e763ac957b308ba95cef256c2491a5a55a163cc',
-          'software' => {
-            'zlib' => {
-              'locked_source' => {
-                'url' => 'an_url'
+          manifest_format: 1,
+          build_version: '11.0.6',
+          build_git_revision: '2e763ac957b308ba95cef256c2491a5a55a163cc',
+          software: {
+            zlib: {
+              locked_source: {
+                md5: '44d667c142d7cda120332623eab69f40',
+                url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
               },
-              'locked_version' => 'new.newer',
-              'source_type' => 'url',
-              'described_version' => 'new.newer',
-            }
+              locked_version: '1.2.8',
+              source_type: 'url',
+              described_version: '1.2.8',
+              license: 'Zlib',
+            },
+            openssl: {
+              locked_source: {
+                md5: '562986f6937aabc7c11a6d376d8a0d26',
+                extract: 'lax_tar',
+                url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
+              },
+              locked_version: '1.0.1s',
+              source_type: 'url',
+              described_version: '1.0.1s',
+              license: 'OpenSSL',
+            },
+            ruby: {
+              locked_source: {
+                md5: '091b62f0a9796a3c55de2a228a0e6ef3',
+                url: 'https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz',
+              },
+              locked_version: '2.1.8',
+              source_type: 'url',
+              described_version: '2.1.8',
+              license: 'BSD-2-Clause',
+            },
+            ohai: {
+              locked_source: {
+                git: 'https://github.com/opscode/ohai.git'
+              },
+              locked_version: 'fec0959aa5da5ce7ba0e07740dbc08546a8f53f0',
+              source_type: 'git',
+              described_version: 'master',
+              license: 'Apache-2.0',
+            },
+            chef: {
+              locked_source: {
+                path: '/home/jenkins/workspace/chef-build/architecture/x86_64/platform/ubuntu-10.04/project/chef/role/builder/omnibus/files/../..',
+                options: {
+                  exclude: [
+                    'omnibus/vendor',
+                  ],
+                },
+              },
+              locked_version: 'local_source',
+              source_type: 'path',
+              described_version: 'local_source',
+              license: 'Apache-2.0',
+            },
           }
         }
       )
@@ -66,18 +112,37 @@ module Omnibus
         "omnibus.sha512" => "SHA512",
         "omnibus.version" => "11.0.6",
         "omnibus.license" => "Apache-2.0",
-        "omnibus.version_manifest" => {
-          "manifest_format" => 1,
-          "build_version" => "11.0.6",
-          "build_git_revision" => "2e763ac957b308ba95cef256c2491a5a55a163cc",
-          "software" => {
-            "zlib" => {
-              "locked_source" => {
-                "url" => "an_url"
-              },
-              "locked_version" => "new.newer",
-              "source_type" => "url",
-              "described_version" => "new.newer"}}
+        "omnibus.dependencies" => {
+          'zlib' => {
+            'source_type'       => 'url',
+            'described_version' => '1.2.8',
+            'locked_version'    => '1.2.8',
+            'license'           => 'Zlib',
+          },
+          'openssl' => {
+            'source_type'       => 'url',
+            'described_version' => '1.0.1s',
+            'locked_version'    => '1.0.1s',
+            'license'           => 'OpenSSL',
+          },
+          'ruby' => {
+            'source_type'       => 'url',
+            'described_version' => '2.1.8',
+            'locked_version'    => '2.1.8',
+            'license'           => 'BSD-2-Clause',
+          },
+          'ohai' => {
+            'source_type'       => 'git',
+            'described_version' => 'master',
+            'locked_version'    => 'fec0959aa5da5ce7ba0e07740dbc08546a8f53f0',
+            'license'           => 'Apache-2.0',
+          },
+          'chef' => {
+            'source_type'       => 'path',
+            'described_version' => 'local_source',
+            'locked_version'    => 'local_source',
+            'license'           => 'Apache-2.0',
+          }
         }
       }
     end


### PR DESCRIPTION
Publishing a package with a large version manifest fails with the following cryptic error:

```
/opt/languages/ruby/2.1.5/lib/ruby/2.1.0/net/http/generic_request.rb:202:in
`copy_stream': Broken pipe - sendfile (Errno::EPIPE)
```

The error is related to the way in which properties are set via Artifactory's REST API. The properties are attached to the upload URI as matrix parameters:
https://www.jfrog.com/confluence/display/RTF3X/Artifactory+REST+API#ArtifactoryRESTAPI-SetItemProperties
https://www.w3.org/DesignIssues/MatrixURIs.html

We'll avoid this issue by publishing a subset of the version manifest data as the `omnibus.dependencies` property. This lighterweight hash will only contain a list of dependencies and their associated version and license data.

/cc @chef/omnibus-maintainers 

:construction: I will perform some end-to-end integration testing with this updated publisher before merging.