### PR TITLE
Replacing the use of JSON gem with FFI_yajl

### DIFF
--- a/features/commands/manifest.feature
+++ b/features/commands/manifest.feature
@@ -18,6 +18,7 @@ Feature: omnibus manifest
     And  the output should contain:
          """
            "software": {
+
            },
          """
 

--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -18,7 +18,6 @@ require 'omnibus/core_extensions'
 
 require 'cleanroom'
 require 'pathname'
-require 'json'
 
 require 'omnibus/exceptions'
 require 'omnibus/version'

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -16,6 +16,7 @@
 
 require 'thor'
 require 'omnibus'
+require "ffi_yajl"
 
 module Omnibus
   class CLI < Command::Base
@@ -85,7 +86,7 @@ module Omnibus
       if @options[:output_manifest]
         FileUtils.mkdir_p('pkg')
         File.open(::File.join('pkg', 'version-manifest.json'), 'w') do |f|
-          f.write(project.built_manifest.to_json)
+          f.write(FFI_Yajl::Encoder.encode(project.built_manifest.to_hash))
         end
       end
     end
@@ -121,7 +122,7 @@ module Omnibus
       Ohai['platform'] = @options[:platform] if @options[:platform]
       Ohai['platform_version'] = @options[:platform_version] if @options[:platform_version]
       Ohai['kernel']['machine'] = @options[:architecture] if @options[:architecture]
-      puts JSON.pretty_generate(Project.load(name).built_manifest.to_hash)
+      puts FFI_Yajl::Encoder.encode(Project.load(name).built_manifest.to_hash, pretty: true)
     end
 
     #

--- a/lib/omnibus/cli/changelog.rb
+++ b/lib/omnibus/cli/changelog.rb
@@ -18,6 +18,7 @@ require 'omnibus/changelog'
 require 'omnibus/changelog_printer'
 require 'omnibus/manifest_diff'
 require 'omnibus/semantic_version'
+require 'ffi_yajl'
 
 module Omnibus
   class Command::ChangeLog < Command::Base
@@ -104,7 +105,7 @@ module Omnibus
     end
 
     def manifest_for_revision(rev)
-      Omnibus::Manifest.from_hash(JSON.parse(local_git_repo.file_at_revision("version-manifest.json", rev)))
+      Omnibus::Manifest.from_hash(FFI_Yajl::Parser.parse(local_git_repo.file_at_revision("version-manifest.json", rev)))
     end
 
 

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -94,7 +94,7 @@ module Omnibus
     #
     def publish(klass, pattern, options)
       if options[:platform_mappings]
-        options[:platform_mappings] = JSON.parse(File.read(File.expand_path(options[:platform_mappings])))
+        options[:platform_mappings] = FFI_Yajl::Parser.parse(File.read(File.expand_path(options[:platform_mappings])))
       end
 
       klass.publish(pattern, options) do |package|

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require 'json'
+require 'ffi_yajl'
 
 module Omnibus
   class Manifest
@@ -88,7 +88,7 @@ module Omnibus
     # @return [String]
     #
     def to_json
-      JSON.pretty_generate(to_hash)
+      FFI_Yajl::Encoder.encode(to_hash, pretty: true)
     end
 
     #
@@ -124,7 +124,7 @@ module Omnibus
 
     def self.from_file(filename)
       data = File.read(File.expand_path(filename))
-      hash = JSON.parse(data, symbolize_names: true)
+      hash = FFI_Yajl::Parser.parse(data, symbolize_names: true)
       from_hash(hash)
     end
 

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require 'json'
+require 'ffi_yajl'
 
 module Omnibus
   class Metadata
@@ -80,7 +80,7 @@ module Omnibus
       #
       def for_package(package)
         data = File.read(path_for(package))
-        hash = JSON.parse(data, symbolize_names: true)
+        hash = FFI_Yajl::Parser.parse(data, symbolize_names: true)
 
          # Ensure Platform version has been truncated
          if hash[:platform_version] && hash[:platform]
@@ -267,7 +267,7 @@ module Omnibus
     #
     def save
       File.open(path, 'w+')  do |f|
-        f.write(to_json)
+        f.write(FFI_Yajl::Encoder.encode(to_hash, pretty: true))
       end
 
       true
@@ -288,7 +288,7 @@ module Omnibus
     # @return [String]
     #
     def to_json
-      JSON.pretty_generate(@data)
+      FFI_Yajl::Encoder.encode(@data, pretty: true)
     end
   end
 end

--- a/lib/omnibus/package.rb
+++ b/lib/omnibus/package.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require 'json'
+require 'ffi_yajl'
 
 module Omnibus
   class Package
@@ -95,7 +95,7 @@ module Omnibus
     # The parsed contents of the metadata.
     #
     # @raise [NoPackageMetadataFile] if the {#metadata} does not exist
-    # @raise [JSON::ParserError] if the JSON is not valid
+    # @raise [FFI_Yajl::ParseError] if the JSON is not valid
     #
     # @return [Hash<Symbol, String>]
     #

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -16,7 +16,7 @@
 #
 
 require 'time'
-require 'json'
+require 'ffi_yajl'
 require 'omnibus/manifest'
 require 'omnibus/manifest_entry'
 require 'omnibus/reports'
@@ -1087,7 +1087,7 @@ module Omnibus
 
     def write_json_manifest
       File.open(json_manifest_path, 'w') do |f|
-        f.write(JSON.pretty_generate(built_manifest.to_hash))
+        f.write(FFI_Yajl::Encoder.encode(built_manifest.to_hash, pretty: true))
       end
     end
 
@@ -1206,7 +1206,7 @@ module Omnibus
 
         update_with_string(digest, name)
         update_with_string(digest, install_dir)
-        update_with_string(digest, JSON.fast_generate(overrides))
+        update_with_string(digest, FFI_Yajl::Encoder.encode(overrides))
 
         if filepath && File.exist?(filepath)
           update_with_file_contents(digest, filepath)

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -16,6 +16,7 @@
 
 require 'uri'
 require 'benchmark'
+require 'ffi_yajl'
 
 module Omnibus
   class ArtifactoryPublisher < Publisher
@@ -127,7 +128,7 @@ module Omnibus
         properties: default_properties.merge(
           'omnibus.project' => name,
           'omnibus.version' => manifest.build_version,
-          'omnibus.version_manifest' => manifest.to_json,
+          'omnibus.version_manifest' => FFI_Yajl::Encoder.encode(manifest.to_hash, pretty: true),
         ),
         modules: [
           {

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -30,7 +30,7 @@ module Omnibus
 
         # Upload the metadata first
         log.debug(log_key) { "Uploading '#{package.metadata.name}'" }
-        store_object(key_for(package, package.metadata.name), package.metadata.to_json,
+        store_object(key_for(package, package.metadata.name), FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
                      nil, access_policy)
 
         # Upload the actual package

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1059,7 +1059,7 @@ module Omnibus
         update_with_string(digest, builder.shasum)
         update_with_string(digest, name)
         update_with_string(digest, version_for_cache)
-        update_with_string(digest, JSON.fast_generate(overrides))
+        update_with_string(digest, FFI_Yajl::Encoder.encode(overrides))
 
         if filepath && File.exist?(filepath)
           update_with_file_contents(digest, filepath)

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'ruby-progressbar', '~> 1.7'
   gem.add_dependency 'aws-sdk',          '~> 2'
   gem.add_dependency 'thor',             '~> 0.18'
+  gem.add_dependency "ffi-yajl",         '~> 2.2'
 
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'artifactory', '~> 2.0'

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -250,7 +250,7 @@ module Omnibus
 
     describe '#to_json' do
       it 'generates pretty JSON' do
-        expect(subject.to_json).to eq <<-EOH.gsub(/^ {10}/, '').strip
+        expect(subject.to_json.strip).to eq <<-EOH.gsub(/^ {10}/, '').strip
           {
             "foo": "bar"
           }

--- a/spec/unit/publishers/s3_publisher_spec.rb
+++ b/spec/unit/publishers/s3_publisher_spec.rb
@@ -51,7 +51,7 @@ module Omnibus
       it 'uploads the metadata' do
         expect(subject).to receive(:store_object).with(
           'ubuntu/14.04/x86_64/chef.deb/chef.deb.metadata.json',
-          package.metadata.to_json,
+          FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
           nil,
           'private',
         ).once
@@ -76,7 +76,7 @@ module Omnibus
         it 'sets the access control to public_read' do
           expect(subject).to receive(:store_object).with(
             'ubuntu/14.04/x86_64/chef.deb/chef.deb.metadata.json',
-            package.metadata.to_json,
+            FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
             nil,
             'public-read',
           ).once
@@ -91,7 +91,7 @@ module Omnibus
         it 'sets the access control to private' do
           expect(subject).to receive(:store_object).with(
             'ubuntu/14.04/x86_64/chef.deb/chef.deb.metadata.json',
-            package.metadata.to_json,
+            FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
             nil,
             'private',
           ).once


### PR DESCRIPTION
### Description

In the ChefDK one of our dependencies recently started pulling in the `json_pure` gem which has a bug trying to print out the omnibus manifest.  To avoid this (and any more JSON gem shenanigans) I wanted to just start using FFI_Yajl.

I also removed the use of `to_json` everywhere (even on the classes that defined it) to avoid accidentally using the extensions that the JSON gem applies.

--------------------------------------------------

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

