### PR TITLE
Warn when the specified license_file for the project does not exist

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -176,7 +176,15 @@ module Omnibus
     # @return [String]
     #
     def project_license_content
-      project.license_file.nil? ? "" : IO.read(File.join(Config.project_root,project.license_file))
+      return "" if project.license_file.nil?
+
+      full_license_file_path = File.join(Config.project_root,project.license_file)
+
+      if File.exist?(full_license_file_path)
+        IO.read(full_license_file_path)
+      else
+        licensing_warning("Specified license file '#{full_license_file_path}' does not exist for the project.")
+      end
     end
 
     #

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -163,6 +163,19 @@ module Omnibus
       end
     end
 
+    describe "without license file for the project" do
+      let(:license) { "Custom Chef" }
+      let(:license_file_path) { "CHEF.LICENSE" }
+      let(:license_file) { "CUSTOM_CHEF" }
+
+      # Note that we are not creating the license file before running create_licenses
+
+      it "warns not existing license file" do
+        output = capture_logging { create_licenses }
+        expect(output).to include("Specified license file '#{File.join(Config.project_root, license_file)}' does not exist for the project.")
+      end
+    end
+
     describe "with a local license file that does not exist" do
       let(:software_with_warnings) do
         Software.new(project, 'problematic.rb').evaluate do


### PR DESCRIPTION
### Description

This PR fixes https://github.com/chef/omnibus/issues/660. We ran into this in chef and chefdk yesterday when the license_file for the project was specified incorrectly. In general we never want to fail due to licensing information for now. 

--------------------------------------------------
/cc @chef/omnibus-maintainers, @patrick-wright 
