### PR TITLE
Publish a package’s `*.metadata.json` to Artifactory

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -63,6 +63,7 @@ module Omnibus
           iteration:        project.build_iteration,
           license:          project.license,
           version_manifest: project.built_manifest.to_hash,
+          license_content:  File.exist?(project.license_file_path) ? File.read(project.license_file_path) : ''
         }
 
         instance = new(package, data)

--- a/lib/omnibus/publisher.rb
+++ b/lib/omnibus/publisher.rb
@@ -16,6 +16,8 @@
 
 module Omnibus
   class Publisher
+    include Digestable
+
     class << self
       #
       # Shortcut class method for creating a new instance of this class and

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'aruba',       '~> 0.5'
   gem.add_development_dependency 'fauxhai',     '~> 3.2'
   gem.add_development_dependency 'rspec',       '~> 3.0'
+  gem.add_development_dependency 'rspec-json_expectations'
   gem.add_development_dependency 'rspec-its'
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'rake'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'rspec/its'
+require "rspec/json_expectations"
 require 'webmock/rspec'
 
 require 'cleanroom/rspec'

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -74,18 +74,64 @@ module Omnibus
             sha1: 'SHA1',
             md5: 'ABCDEF123456',
             version_manifest: {
-              'manifest_format' => 1,
-              'build_version' => '11.0.6',
-              'build_git_revision' => '2e763ac957b308ba95cef256c2491a5a55a163cc',
-              'software' => {
-                'zlib' => {
-                  'locked_source' => {
-                    'url' => 'an_url'
+              manifest_format: 1,
+              build_version: '11.0.6',
+              build_git_revision: '2e763ac957b308ba95cef256c2491a5a55a163cc',
+              software: {
+                zlib: {
+                  locked_source: {
+                    md5: '44d667c142d7cda120332623eab69f40',
+                    url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
                   },
-                  'locked_version' => 'new.newer',
-                  'source_type' => 'url',
-                  'described_version' => 'new.newer'
-                }
+                  locked_version: '1.2.8',
+                  source_type: 'url',
+                  described_version: '1.2.8',
+                  license: 'Zlib',
+                },
+                openssl: {
+                  locked_source: {
+                    md5: '562986f6937aabc7c11a6d376d8a0d26',
+                    extract: 'lax_tar',
+                    url: 'http://iweb.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz',
+                  },
+                  locked_version: '1.0.1s',
+                  source_type: 'url',
+                  described_version: '1.0.1s',
+                  license: 'OpenSSL',
+                },
+                ruby: {
+                  locked_source: {
+                    md5: '091b62f0a9796a3c55de2a228a0e6ef3',
+                    url: 'https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.8.tar.gz',
+                  },
+                  locked_version: '2.1.8',
+                  source_type: 'url',
+                  described_version: '2.1.8',
+                  license: 'BSD-2-Clause',
+                },
+                ohai: {
+                  locked_source: {
+                    git: 'https://github.com/opscode/ohai.git'
+                  },
+                  locked_version: 'fec0959aa5da5ce7ba0e07740dbc08546a8f53f0',
+                  source_type: 'git',
+                  described_version: 'master',
+                  license: 'Apache-2.0',
+                },
+                chef: {
+                  locked_source: {
+                    path: '/home/jenkins/workspace/chef-build/architecture/x86_64/platform/ubuntu-10.04/project/chef/role/builder/omnibus/files/../..',
+                    options: {
+                      exclude: [
+                        'omnibus/vendor',
+                      ],
+                    },
+                  },
+                  locked_version: 'local_source',
+                  source_type: 'path',
+                  described_version: 'local_source',
+                  license: 'Apache-2.0',
+                },
               }
             }
           )


### PR DESCRIPTION
Publishing a package with a large `omnibus.version_manifest` property fails with the following cryptic error:

```
/opt/languages/ruby/2.1.5/lib/ruby/2.1.0/net/http/generic_request.rb:202:in
`copy_stream': Broken pipe - sendfile (Errno::EPIPE)
```

The error is caused by large property values and is related to the way in which properties are set in Artifactory's REST API. The properties are attached to the upload URI as matrix parameters:
https://www.jfrog.com/confluence/display/RTF3X/Artifactory+REST+API#ArtifactoryRESTAPI-SetItemProperties
https://www.w3.org/DesignIssues/MatrixURIs.html

We’ll workaround this issue by by publishing all `*.metadata.json` files alongside their respective packages. This will allow us to index additional information about a package or build while avoiding any technical limitations that Artifactory properties might have.

I've also added the actual content of a project's actual `LICENSE` file to the Metadata which should make retrieval/display easy on distribution services like downloads.chef.io.

/cc @chef/omnibus-maintainers @chef/engineering-services @sersut @jamesc @cwebberOps 
