### PR TITLE
exclude directories owned by the filesystem package

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -391,12 +391,12 @@ module Omnibus
 
     #
     # Convert the path of a file in the staging directory to an entry for use in the spec file.
-    #
+    # Exclude directories owned by the filesystem package.
     # @return [String]
     #
     def build_filepath(path)
       filepath = rpm_safe('/' + path.gsub("#{build_dir}/", ''))
-      return if config_files.include?(filepath)
+      return if config_files.include?(filepath) || filesystem_directories.include?(filepath)
       full_path = build_dir + filepath.gsub('[%]','%')
       # FileSyncer.glob quotes pathnames that contain spaces, which is a problem on el7
       full_path.gsub!('"', '')


### PR DESCRIPTION
### Description

This addresses #663.

Directories owned by the filesystem package should be excluded from the RPM produced by Omnibus. 

From: https://fedoraproject.org/wiki/Packaging:Guidelines#File_and_Directory_Ownership

> Directory ownership is a little more complex than file ownership. Packages must own all directories they put files in, except for:
> any directories owned by the filesystem, man, or other explicitly created -filesystem packages
> any directories owned by other packages in your package's natural dependency chain 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

