### PR TITLE
Prep v5.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Omnibus CHANGELOG
 =================
 
+v5.4.0 (April 18, 2016)
+-----------------------
+### New Features
+- Include license and version manifest in generated `*.metadata.json` (#656)
+- Deprecate the `--version-manifest` on `omnibus publish` (#656)
+- Create Solaris IPS package (#654)
+- Use symbolized keys for all Manifest hashes (#657)
+- Publish a package’s `*.metadata.json` to Artifactory (#664)
+- Add the build’s `LICENSE` content to `*.metadata.json` (#664)
+
+### Bug Fixes
+- Add proper support for loading v2 manifests (#657)
+- Replacing the use of JSON gem with FFI_yajl (#661)
+
 v5.3.0 (March 25, 2016)
 -----------------------
 ### New Features

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,9 @@ platform:
 
 environment:
   matrix:
-    - ruby_version: "200"
+    - RUBY_VERSION: 22
+    - RUBY_VERSION: 21
+    - RUBY_VERSION: 200
 
 clone_folder: c:\projects\omnibus
 clone_depth: 1
@@ -16,13 +18,13 @@ branches:
     - master
 
 install:
-  - SET PATH=C:\Ruby%ruby_version%\bin;C:\Ruby21%ruby_version:~3%\Devkit\mingw\bin;%PATH%
+  - SET PATH=C:\Ruby%RUBY_VERSION%\bin;C:\Ruby23-x64\DevKit\mingw\bin;%PATH%
   - echo %PATH%
   - ruby --version
   - gem --version
   - gem install bundler -v 1.10.6 --quiet --no-ri --no-rdoc
   - bundler --version
-  - cp C:\Ruby21%ruby_version:~3%\Devkit\mingw\bin\bsdtar.exe C:\Ruby21%ruby_version:~3%\Devkit\mingw\bin\tar.exe
+  - cp C:\Ruby23-x64\DevKit\mingw\bin\bsdtar.exe C:\Ruby23-x64\DevKit\mingw\bin\tar.exe
   - appveyor DownloadFile http://curl.haxx.se/ca/cacert.pem -FileName C:\cacert.pem
   - set SSL_CERT_FILE=C:\cacert.pem
   - git config --global user.email "clouseau@chef.io"

--- a/lib/omnibus/version.rb
+++ b/lib/omnibus/version.rb
@@ -15,5 +15,5 @@
 #
 
 module Omnibus
-  VERSION = '5.3.0'
+  VERSION = '5.4.0'
 end


### PR DESCRIPTION
This will allow us to update the default version of Omnibus installed by the `artifactory-pro` cookbook (used by the `artifactory_omnibus_publisher` resource).

/cc @chef/omnibus-maintainers @chef/engineering-services