### PR TITLE
Fix overriding license and license files inside a version block.

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -403,7 +403,26 @@ module Omnibus
             'pass a block when given a version argument')
         else
           if val == final_version
+            #
+            # Unfortunately we need to make a specific logic here for license files.
+            # We support multiple calls `license_file` and we support overriding the
+            # license files inside a version block. We can not differentiate whether
+            # `license_file` is being called from a version block or not. So we need
+            # to check if the license files are being overridden during the call to
+            # block.
+            #
+            # If so we use the new set, otherwise we restore the old license files.
+            #
+            current_license_files = @license_files
+            @license_files = []
+
             block.call
+
+            new_license_files = @license_files
+
+            if new_license_files.empty?
+              @license_files = current_license_files
+            end
           end
         end
       end


### PR DESCRIPTION
### Description

We have an issue when we are overriding license files as in [here](https://github.com/chef/omnibus-software/blob/master/config/software/erlang.rb#L81).

We support `license_file` DSL method to be called multiple times to add multiple license files for a software. When we are overriding these license files however we end up not cleaning up the previously added license files. In the example above we look for both `LICENSE.txt` (correct) and `EPLICENCE` (the license file added by default, and wrong). 

Here we ensure that we reset the collected license files when they are being overridden inside a version block. 

We have talked about multiple options with @schisamo and this way seems the best way forward since it does not include any changes to the existing software definitions. If you have a less hacky way to do this I'm all 👂 s 😄 .

--------------------------------------------------
/cc @chef/omnibus-maintainers

