### PR TITLE
Also catch openssl errors when trying to fetch license files so weird openssl errors don't fail our build

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -161,7 +161,8 @@ module Omnibus
                      Errno::ECONNRESET,
                      Errno::ENETUNREACH,
                      Timeout::Error,
-                     OpenURI::HTTPError
+                     OpenURI::HTTPError,
+                     OpenSSL::SSL::SSLError
                 licensing_warning("Can not download license file '#{license_file}' for software '#{name}'.")
               end
             end


### PR DESCRIPTION
### Description

We were seeing the following errors failing our ChefDK builds:

```
/opt/languages/ruby/2.1.5/lib/ruby/2.1.0/net/http.rb:920:in `connect': SSL_connect SYSCALL returned=5 errno=0 state=SSLv2/v3 read server hello A (OpenSSL::SSL::SSLError)
```

With this change, we now see the warning:

```
[Licensing] W | 2016-05-03T10:53:04-07:00 | Can not download license file 'https://www.openssl.org/source/license.html' for software 'openssl-customization'.
```

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.