### PR TITLE
Actually flush files before performing inode operations

### DIFF
--- a/lib/omnibus/compressors/tgz.rb
+++ b/lib/omnibus/compressors/tgz.rb
@@ -89,6 +89,7 @@ module Omnibus
         while chunk = contents.read(1024)
           tgz.write(chunk)
         end
+        tgz.fsync if tgz.respond_to?(:fsync)
       end
 
       # Copy the .tar.gz into the package directory

--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -77,9 +77,14 @@ module Omnibus
         end
 
         file = open(from_url, options)
-        # This is a temporary file. Close and flush it before attempting to copy
-        # it over.
+        # This is a temporary file. You must fsync a file before you can copy it
+        # directly. Just closing/flushing is insufficient as the file-system can
+        # decide to buffer your write and (depending on the ordering-guarantee
+        # flags you have chosen) choose to execute the copy operation before
+        # the contents are written out.
+        file.fsync if file.respond_to?(:fsync)
         file.close
+
         FileUtils.cp(file.path, to_path)
         file.unlink
       rescue SocketError,

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -214,6 +214,7 @@ module Omnibus
 
           fetched_file
         end
+        expect(fetched_file).to receive(:fsync)
         expect(fetched_file).to receive(:close)
         expect(FileUtils).to receive(:cp).with(tempfile_path, destination_path)
         expect(fetched_file).to receive(:unlink)


### PR DESCRIPTION
### Description

A ruby IO.close doesn't flush filesystem buffers.  A file copy and a file write can be considered out-of-order by the underlying file-system.  See also: everyone hating on ext4 when it first came out...

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

