### PR TITLE
Make LICENSE files readable for all

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -22,6 +22,7 @@ module Omnibus
   class Licensing
     include Logging
     include DownloadHelpers
+    include Sugarable
 
     OUTPUT_DIRECTORY = "LICENSES".freeze
 
@@ -150,12 +151,14 @@ module Omnibus
               input_file = File.expand_path(license_file, values[:project_dir])
               if File.exist?(input_file)
                 FileUtils.cp(input_file, output_file)
+                File.chmod 0644, output_file unless windows?
               else
                 licensing_warning("License file '#{input_file}' does not exist for software '#{name}'.")
               end
             else
               begin
                 download_file!(license_file, output_file, enable_progress_bar: false)
+                File.chmod 0644, output_file unless windows?
               rescue SocketError,
                      Errno::ECONNREFUSED,
                      Errno::ECONNRESET,

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -63,6 +63,7 @@ module Omnibus
         license_names.each do |software_license|
           license_path = File.join(license_dir, software_license)
           expect(File.exist?(license_path)).to be(true)
+          expect(File.world_readable?(license_path)).to be_truthy
           expect(File.read(license_path)).to match /#{software_license.split("-").last}/
         end
 


### PR DESCRIPTION
```
[vagrant@chef-centos-72 omnibus]$ ls -l /opt/chef/LICENSES/                                                             
total 296
-rw-r--r--. 1 root root  1118 May  4 15:21 bundler-LICENSE.md
-rw-r--r--. 1 root root 36366 May  4 15:21 cacerts-README.md
-rwxrwxr-x. 1 root root 43764 May  4 15:21 config_guess-config.guess
-rwxrwxr-x. 1 root root 36159 May  4 15:21 config_guess-config.sub
-rw-rw-r--. 1 root root  1132 May  4 15:21 libffi-LICENSE
-rw-r--r--. 1 root root 25291 May  4 15:21 libiconv-COPYING.LIB
-rw-r--r--. 1 root root  2774 May  4 15:21 liblzma-COPYING
-rw-rw-r--. 1 root root 17987 May  4 15:21 libtool-COPYING
-rw-rw-r--. 1 root root  1289 May  4 15:21 libxml2-COPYING
-rw-rw-r--. 1 root root  2968 May  4 15:21 libxslt-COPYING
-rw-r--r--. 1 root root  1058 May  4 15:21 libyaml-LICENSE
-rw-r--r--. 1 root root  2615 May  4 15:21 makedepend-COPYING
-rw-r--r--. 1 root root 10360 May  4 15:21 openssl-customization-license.html
-rw-r--r--. 1 root root 10360 May  4 15:21 openssl-fips-license.html
-rw-rw-r--. 1 root root  6279 May  4 15:21 openssl-LICENSE
-rw-rw-r--. 1 root root 18092 May  4 15:21 pkg-config-lite-COPYING
-rw-r--r--. 1 root root  1282 May  4 15:21 ruby-BSDL
-rw-r--r--. 1 root root  2504 May  4 15:21 ruby-COPYING
-rw-r--r--. 1 root root 22975 May  4 15:21 ruby-LEGAL
-rw-r--r--. 1 root root  2283 May  4 15:21 util-macros-COPYING
-rw-r--r--. 1 root root  5276 May  4 15:21 xproto-COPYING
-rw-r--r--. 1 root root  5185 May  4 15:21 zlib-README
[vagrant@chef-centos-72 omnibus]$ rpm
```

--------------------------------------------------
/cc @chef/omnibus-maintainers

```
➜  omnibus git:(praj/FLOW-355/yahoo_rpm) ✗ bundle exec rake travis:ci
(in /Users/prajaktapurohit/src/oc/omnibus)
/opt/chefdk/embedded/bin/ruby -I/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib:/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-support-3.4.1/lib /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/unit/\*\*/\*_spec.rb --color --format progress
Run options:
  include {:focus=>true}
  exclude {:windows_only=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 33731
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*......................................................................................................................................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Omnibus::S3Cache.populate pending a good samaritan to come along and write tests...
     # Not yet implemented
     # ./spec/unit/s3_cacher_spec.rb:67


Finished in 6.75 seconds (files took 1.18 seconds to load)
1020 examples, 0 failures, 1 pending

Randomized with seed 33731

/opt/chefdk/embedded/bin/ruby -I/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/lib:/opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-support-3.4.1/lib /opt/chefdk/embedded/lib/ruby/gems/2.1.0/gems/rspec-core-3.4.4/exe/rspec --pattern spec/functional/\*\*/\*_spec.rb --color --format progress
Run options:
  include {:focus=>true}
  exclude {:windows_only=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 4245
............................................................*.............                                              ................................................................                                           0% (0 KB/sec)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Omnibus::Builder#make is waiting for a good samaritan to write tests
     # No reason given
     # ./spec/functional/builder_spec.rb:114


Finished in 1 minute 14.82 seconds (files took 0.49136 seconds to load)
138 examples, 0 failures, 1 pending

Randomized with seed 4245

/opt/chefdk/embedded/bin/ruby -S bundle exec cucumber --color --format progress --strict
.......................................................................

19 scenarios (19 passed)
71 steps (71 passed)
0m0.908s

```

