### PR TITLE
strip trailing whitespace from certificate subject

### DIFF
--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -166,7 +166,7 @@ module Omnibus
         arr << "-Command (Get-Item Cert:/#{store}/#{cert_store_name}/#{thumbprint}).Subject"
       end.join(" ")
 
-      shellout!(cmd).stdout
+      shellout!(cmd).stdout.strip
     end
 
     #

--- a/spec/unit/packagers/appx_spec.rb
+++ b/spec/unit/packagers/appx_spec.rb
@@ -48,7 +48,8 @@ module Omnibus
 
     describe '#write_manifest_file' do
       before do
-        allow(subject).to receive(:certificate_subject).and_return('CN=Chef')
+        allow(subject).to receive(:shellout!).and_return(double('output', stdout: 'CN=Chef '))
+        allow(subject).to receive(:signing_identity).and_return({})
       end
 
       it 'generates the file' do


### PR DESCRIPTION
Ugh. Just noticed that #675 has an issue with grabbing the certificate subject that did not manifest in my testing before. It appears the powershell returns the string with trailing whitespace which then kills `makeappx.exe`. This strips the whitesspace and adds a test for that.