### PR TITLE
do not package appx on OS versions less than 2012

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -68,7 +68,15 @@ module Omnibus
         family = "solaris"
       end
       if klass = PLATFORM_PACKAGER_MAP[family]
-        klass.is_a?(Array) ? klass : [ klass ]
+        package_types = klass.is_a?(Array) ? klass : [ klass ]
+
+        if package_types.include?(APPX) &&
+          !Chef::Sugar::Constraints::Version.new(version).satisfies?('>= 6.2')
+          log.warn(log_key) { "APPX generation is only supported on Windows versions 2012 and above" }
+          package_types = package_types - [APPX]
+        end
+
+        package_types
       else
         log.warn(log_key) do
           "Could not determine packager for `#{family}', defaulting " \

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -10,10 +10,17 @@ module Omnibus
           end
       end
 
-      context 'on Windows' do
+      context 'on Windows 2012' do
         before { stub_ohai(platform: 'windows', version: '2012') }
           it 'prefers MSI and APPX' do
             expect(described_class.for_current_system).to eq([Packager::MSI, Packager::APPX])
+          end
+      end
+
+      context 'on Windows 2008 R2' do
+        before { stub_ohai(platform: 'windows', version: '2008R2') }
+          it 'prefers MSI only' do
+            expect(described_class.for_current_system).to eq([Packager::MSI])
           end
       end
 


### PR DESCRIPTION
Windows server versions less than 2012 do not support the running of `MakeAPPX.exe`. This removes APPX from the available packagers on those versions.