### PR TITLE
Add :fatal_licensing_warnings configuration option

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -446,7 +446,7 @@ module Omnibus
     #
     # For example:
     #
-    #     /PATH/files/my_map_file 
+    #     /PATH/files/my_map_file
     #
     # @return [String, nil]
     default(:solaris_linker_mapfile, "files/mapfiles/solaris")
@@ -508,6 +508,11 @@ module Omnibus
         3
       end
     end
+
+    # Fail the build or warn when build encounters a licensing warning.
+    #
+    # @return [true, false]
+    default(:fatal_licensing_warnings, false)
 
     # --------------------------------------------------
     # @!endgroup

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -335,4 +335,20 @@ EOF
       super("Failed to sign Windows Package.")
     end
   end
+
+  class LicensingError < Error
+    def initialize(errors)
+      @errors = errors
+    end
+
+    def to_s
+      <<-EOH
+Encountered error(s) with project's licensing information.
+Failing the build because :fatal_licensing_warnings is set in the configuration.
+Error(s):
+
+    #{@errors.join("\n    ")}
+EOH
+    end
+  end
 end

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -261,5 +261,15 @@ module Omnibus
         expect(output).to include("Project 'test-project' does not point to a license file.")
       end
     end
+
+    describe "with :fatal_licensing_warnings set and without license definitions in the project" do
+      before do
+        Omnibus::Config.fatal_licensing_warnings(true)
+      end
+
+      it "fails the omnibus build" do
+        expect{create_licenses}.to raise_error(Omnibus::LicensingError, /Project 'test-project' does not contain licensing information.\s{1,}Software 'private_code' does not contain licensing information./)
+      end
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -44,6 +44,7 @@ module Omnibus
     include_examples 'a configurable', :use_git_caching, true
     include_examples 'a configurable', :fetcher_read_timeout, 60
     include_examples 'a configurable', :fetcher_retries, 5
+    include_examples 'a configurable', :fatal_licensing_warnings, false
 
     describe '#workers' do
       context 'when the Ohai data is not present' do


### PR DESCRIPTION
### Description

Adding a new configuration option, as previously discussed in https://github.com/chef/omnibus/pull/662, that fails the build when we encounter a licensing warning. 

I have changed one of the warnings since practically any project who uses `omnibus-software` will hit this that warning due to this line:

https://github.com/chef/omnibus-software/blob/master/config/software/config_guess.rb#L23

Our goal is to introduce some form of configurable white-listing or black-listing in the future and convert this to warning again. 

You can see an example output both with this option set and not set below (also full logs - with redacted build stages - [here](https://gist.github.com/sersut/c161c35d6f6152a69002812e8bc498c0).)

```
$ bundle exec omnibus build harmony
...
              [Licensing] W | 2016-05-16T12:56:01-07:00 | Project 'harmony' does not contain licensing information.
 [Software: config_guess] W | 2016-05-16T12:56:01-07:00 | Version master for software config_guess was not parseable. Comparison methods such as #satisfies? will not be available for this version.
              [Licensing] W | 2016-05-16T12:56:01-07:00 | Software 'discord' does not contain licensing information.
              [Licensing] I | 2016-05-16T12:56:01-07:00 | Software 'config_guess' uses license 'GPL-3.0 (with exception)' which is not one of the standard licenses identified in https://opensource.org/licenses/alphabetical. Consider using one of the standard licenses.
              [Licensing] W | 2016-05-16T12:56:01-07:00 | Software 'popt' does not contain licensing information.
              [Licensing] W | 2016-05-16T12:56:01-07:00 | Software 'rsync' does not contain licensing information.
...

$ bundle exec omnibus build harmony --override fatal_licensing_warnings:true
...
              [Licensing] W | 2016-05-17T10:54:10-07:00 | Software 'discord' does not contain licensing information.
              [Licensing] I | 2016-05-17T10:54:10-07:00 | Software 'config_guess' uses license 'GPL-3.0 (with exception)' which is not one of the standard licenses identified in https://opensource.org/licenses/alphabetical. Consider using one of the standard licenses.
              [Licensing] W | 2016-05-17T10:54:10-07:00 | Software 'popt' does not contain licensing information.
              [Licensing] W | 2016-05-17T10:54:10-07:00 | Software 'rsync' does not contain licensing information.
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    Project 'harmony' does not contain licensing information.
    Software 'discord' does not contain licensing information.
    Software 'popt' does not contain licensing information.
    Software 'rsync' does not contain licensing information.
...
```
--------------------------------------------------
/cc @chef/omnibus-maintainers 