### PR TITLE
[JEX-162] Prefer server marketing names on Windows

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -203,16 +203,16 @@ module Omnibus
           when '6.0.6001', '2008'   then '2008'
           when '6.1.7600', '7'      then '7'
           when '6.1.7601', '2008r2' then '2008r2'
-          when '6.2.9200', '8'      then '8'
-          # The following `when` will never match since Windows 2012's platform
-          # version is the same as Windows 8. It's only here for completeness and
-          # documentation.
           when '6.2.9200', '2012'   then '2012'
-          when /6\.3\.\d+/, '8.1' then '8.1'
-          # The following `when` will never match since Windows 2012R2's platform
-          # version is the same as Windows 8.1. It's only here for completeness
-          # and documentation.
+          # The following `when` will never match since Windows 8's platform
+          # version is the same as Windows 2012. It's only here for completeness and
+          # documentation.
+          when '6.2.9200', '8'      then '8'
           when /6\.3\.\d+/, '2012r2' then '2012r2'
+          # The following `when` will never match since Windows 8.1's platform
+          # version is the same as Windows 2012R2. It's only here for completeness
+          # and documentation.
+          when /6\.3\.\d+/, '8.1' then '8.1'
           when /^10\.0/ then '10'
           else
             raise UnknownPlatformVersion.new(platform, platform_version)

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -240,9 +240,9 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       it_behaves_like 'a version manipulator', 'windows', '6.0.6001', '2008'
       it_behaves_like 'a version manipulator', 'windows', '6.1.7600', '7'
       it_behaves_like 'a version manipulator', 'windows', '6.1.7601', '2008r2'
-      it_behaves_like 'a version manipulator', 'windows', '6.2.9200', '8'
-      it_behaves_like 'a version manipulator', 'windows', '6.3.9200', '8.1'
-      it_behaves_like 'a version manipulator', 'windows', '6.3.9600', '8.1'
+      it_behaves_like 'a version manipulator', 'windows', '6.2.9200', '2012'
+      it_behaves_like 'a version manipulator', 'windows', '6.3.9200', '2012r2'
+      it_behaves_like 'a version manipulator', 'windows', '6.3.9600', '2012r2'
       it_behaves_like 'a version manipulator', 'windows', '10.0.10240', '10'
 
       context 'given an unknown platform' do


### PR DESCRIPTION
In order to support the creation of `*.appx` packages we will begin executing our Windows Omnibus builds on Windows 2012R2 (currently we use 2008R2). Right now builds executed on Windows 2012R2 generate a `*.metadata.json` file with a platform_version of `8.1`. This is because Windows 8.1 and Windows Server 2012R2 share the same underlying platform version (`6.3.9600`). In order to definitively identify the correct marketing name you need to make additional Win32 API function calls. We would prefer to not incur the overhead required to query the Win32 API directly. We also don't need to be that accurate in this situation and preferring the Windows server marketing names is "good 'nuff"!

Take a look at Chef's `Chef::ReservedNames::Win32::Version` class for some of the fun backflips you have to perform in order to correctly identify Windows 8 vs Windows 2012 and Windows 8.1 vs Windows 2012R2:
https://github.com/chef/chef/blob/master/lib/chef/win32/version.rb

/cc @chef/omnibus-maintainers @chef/engineering-services @mwrock @btm