### PR TITLE
Don't insist on .exe extension - use .bat if present

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -240,7 +240,7 @@ module Omnibus
           returns = [0]
           returns << 1 if source[:extract] == :lax_tar
 
-          shellout!("tar.exe #{compression_switch}xf #{safe_downloaded_file} -C#{safe_project_dir}", returns: returns)
+          shellout!("tar #{compression_switch}xf #{safe_downloaded_file} -C#{safe_project_dir}", returns: returns)
         elsif downloaded_file.end_with?(*COMPRESSED_TAR_EXTENSIONS)
           Dir.mktmpdir do |temp_dir|
             log.debug(log_key) { "Temporarily extracting `#{safe_downloaded_file}' to `#{temp_dir}'" }

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -339,19 +339,19 @@ module Omnibus
           it_behaves_like "an extractor", "zip", {},
             ['7z.exe x C:\\file.zip -oC:\\tmp\\project -r -y']
           it_behaves_like "an extractor", "tar", {},
-            [['tar.exe xf C:\\file.tar -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar xf C:\\file.tar -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "tgz", {},
-            [['tar.exe zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "tar.gz", {},
-            [['tar.exe zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "tar.bz2", {},
-            [['tar.exe jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "txz", {},
-            [['tar.exe Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "tar.xz", {},
-            [['tar.exe Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0] }]]
           it_behaves_like "an extractor", "tar.lzma", {},
-            [['tar.exe --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0] }]]
+            [['tar --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0] }]]
         end
 
         context "when seven_zip extract strategy is chosen" do
@@ -387,19 +387,19 @@ module Omnibus
           it_behaves_like "an extractor", "zip", { extract: :lax_tar },
             ['7z.exe x C:\\file.zip -oC:\\tmp\\project -r -y']
           it_behaves_like "an extractor", "tar", { extract: :lax_tar },
-            [['tar.exe xf C:\\file.tar -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar xf C:\\file.tar -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tgz", { extract: :lax_tar },
-            [['tar.exe zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.gz", { extract: :lax_tar },
-            [['tar.exe zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.bz2", { extract: :lax_tar },
-            [['tar.exe jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "txz", { extract: :lax_tar },
-            [['tar.exe Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.xz", { extract: :lax_tar },
-            [['tar.exe Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.lzma", { extract: :lax_tar },
-            [['tar.exe --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [['tar --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0, 1] }]]
         end
       end
 


### PR DESCRIPTION
### Description

Allow omnibus to use bash.bat or tar.bat as exported by https://github.com/chef-cookbooks/build-essential/pull/111.  Also fix platform triple on windows.

This can be merged after https://github.com/chef-cookbooks/omnibus/pull/170 has gone in.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.