### PR TITLE
convert entry name symbols to strings for repo_path join

### DIFF
--- a/lib/omnibus/changelog_printer.rb
+++ b/lib/omnibus/changelog_printer.rb
@@ -49,8 +49,8 @@ module Omnibus
       diff.updated.each do |entry|
         puts sprintf("* %s (%.8s -> %.8s)",
                      entry[:name], entry[:old_version], entry[:new_version])
-        repo_path = ::File.join(source_path, entry[:name])
-        if entry[:source_type] == "git" && ::File.directory?("#{repo_path}/.git")
+        repo_path = ::File.join(source_path, entry[:name].to_s)
+        if entry[:source_type] == :git && ::File.directory?("#{repo_path}/.git")
           cl = ChangeLog.new(entry[:old_version], entry[:new_version], GitRepository.new("#{repo_path}"))
           print_changelog(cl, 2)
         end

--- a/spec/unit/changelogprinter_spec.rb
+++ b/spec/unit/changelogprinter_spec.rb
@@ -1,0 +1,130 @@
+require "spec_helper"
+require "omnibus/changelog_printer"
+require "omnibus/manifest_diff"
+
+module Omnibus
+  describe ChangeLogPrinter do
+    describe "#print" do
+      def manifest_entry_for(name, dv, lv, source_type = :local)
+        Omnibus::ManifestEntry.new(name, { :described_version => dv,
+                                           :locked_version => lv,
+                                           :locked_source => {
+                                             :git => "git://#{name}@example.com" },
+                                           :source_type => source_type,
+        })
+      end
+
+      let(:changelog) { double(ChangeLog,
+                               changelog_entries: %w{entry1 entry2},
+                               authors: %w{alice bob}) }
+      let(:git_changelog) { double(ChangeLog,
+                                   changelog_entries:
+                                   %w{sub-entry1 sub-entry2}) }
+      let(:now) { double(Time) }
+      let(:emptydiff) { EmptyManifestDiff.new }
+      let(:old_manifest) {
+        m = Manifest.new()
+        m.add("updated-comp", manifest_entry_for("updated-comp", "v9", "v9"))
+        m.add("updated-comp-2", manifest_entry_for("updated-comp-2", "someref0", "someref0", :git))
+        m.add("removed-comp", manifest_entry_for("removed-comp", "v9", "v9"))
+        m.add("removed-comp-2", manifest_entry_for("removed-comp-2", "v10", "v10"))
+        m
+      }
+      let(:new_manifest) {
+        m = Manifest.new()
+        m.add("updated-comp", manifest_entry_for("updated-comp", "v10", "v10"))
+        m.add("updated-comp-2", manifest_entry_for("updated-comp-2", "someotherref", "someotherref", :git))
+        m.add("added-comp", manifest_entry_for("added-comp", "v100", "v100"))
+        m.add("added-comp-2", manifest_entry_for("added-comp-2", "v101", "v101"))
+        m
+      }
+      let(:diff) { ManifestDiff.new(old_manifest, new_manifest) }
+
+      it "starts with a changelog version header including the time" do
+        expect(Time).to receive(:now).and_return(now)
+        expect(now).to receive(:strftime).with("%Y-%m-%d")
+          .and_return("1970-01-01")
+
+        expect { ChangeLogPrinter.new(changelog, diff).print("v1.0.1") }
+          .to output(/## v1\.0\.1 \(1970-01-01\)/).to_stdout
+      end
+
+      it "outputs the list of changelog entries" do
+        [ /entry1/, /entry2/ ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+
+      it "outputs the component sections when there are changes" do
+        expect { ChangeLogPrinter.new(changelog, diff).print("v1") }
+          .to output(/### Components/).to_stdout
+      end
+
+      it "does not output a component sections when there are no changes" do
+        expect { ChangeLogPrinter.new(changelog, emptydiff).print("v1") }
+          .not_to output(/### Components/).to_stdout
+      end
+
+      it "outputs the list of new components" do
+        [
+          /New Components/,
+          /added-comp \(v100\)/,
+          /added-comp-2 \(v101\)/,
+        ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+
+      it "outputs the list of updated components" do
+        source_path = "path/to/source/"
+        allow(File).to receive(:directory?).with("#{source_path}updated-comp-2/.git")
+          .and_return(false)
+
+        [ /Updated Components/,
+          /updated-comp \(v9 -> v10\)/,
+          /updated-comp-2 \(someref0 -> someothe\)/,
+        ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff, source_path).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+
+      it "uses git commit log for components in git repositories" do
+        git_repo = double(GitRepository)
+        source_path = "path/to/source/"
+        allow(File).to receive(:directory?).with("#{source_path}updated-comp-2/.git")
+          .and_return(true)
+        allow(GitRepository).to receive(:new).with("#{source_path}updated-comp-2")
+          .and_return(git_repo)
+        allow(ChangeLog).to receive(:new).with("someref0", "someotherref", git_repo)
+          .and_return(git_changelog)
+
+        [ /  \* sub-entry1/,
+          /  \* sub-entry2/,
+        ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff, source_path).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+
+      it "outputs the list of removed components" do
+        [ /Removed Components/,
+          /removed-comp \(v9\)/,
+          /removed-comp-2 \(v10\)/,
+        ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+
+      it "outputs the list of contributors" do
+        [ /### Contributors/, /alice/, /bob/ ].each do |re|
+          expect { ChangeLogPrinter.new(changelog, diff).print("v1") }
+            .to output(re).to_stdout
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

The introduction of symbolized keys in the metadata diffs broke change log generation:

```interactive
$ b/omnibus changelog generate --starting-manifest=../opt/opscode/version-manifest.json --ending-manifest=../version-manifest.json
                    [CLI] I | 2016-06-16T11:38:59+02:00 | Using config from 'omnibus.rb'
     [Command::ChangeLog] I | 2016-06-16T11:38:59+02:00 | Using config from 'omnibus.rb'
## 12.7.0 (2016-06-16)
### Components
New Components
* veil-gem (master)

Updated Components
* config_guess (706fbe57 -> ddd7f330)

/Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:53:in `join': no implicit conversion of Symbol into String (TypeError)
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:53:in `block in print_updated_components'
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:49:in `each'
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:49:in `print_updated_components'
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:33:in `print_components'
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/changelog_printer.rb:14:in `print'
        from /Users/stephan/Src/chef/omnibus/lib/omnibus/cli/changelog.rb:82:in `generate'
```

This fixes it. :)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

