### PR TITLE
OmniOS library whitelisting and IPS packaging

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -71,13 +71,24 @@ module Omnibus
     ].freeze
 
     OMNIOS_WHITELIST_LIBS = [
-      /libge/,
+      /libc\.so\.1/,
+      /libcrypt\./,
+      /libcrypt\.so\.1/,
+      /libdl\.so\.1/,
+      /libgcc_s\.so\.1/,
       /libgen\.so\.1/,
+      /libm\.so\.2/,
       /libmd\.so\.1/,
+      /libmp\.so/,
       /libmp\.so\.2/,
+      /libnsl\.so\.1/,
+      /libpthread\.so\.1/,
+      /librt\.so\.1/,
       /libsocket\.so\.1/,
-      /lib\/libssp\.s/,
-      /lib\/libssp\.so\.0/,
+      /libssp\.s/,
+      /libssp\.so./,
+      /libssp\.so\.0/,
+      /libgcc_s\.so\.1/,
     ].freeze
 
     SOLARIS_WHITELIST_LIBS = [

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -70,6 +70,16 @@ module Omnibus
       /unix$/,
     ].freeze
 
+    OMNIOS_WHITELIST_LIBS = [
+      /libge/,
+      /libgen\.so\.1/,
+      /libmd\.so\.1/,
+      /libmp\.so\.2/,
+      /libsocket\.so\.1/,
+      /lib\/libssp\.s/,
+      /lib\/libssp\.so\.0/,
+    ].freeze
+
     SOLARIS_WHITELIST_LIBS = [
       /libaio\.so/,
       /libavl\.so/,
@@ -600,6 +610,8 @@ module Omnibus
                          ARCH_WHITELIST_LIBS
                        when "mac_os_x"
                          MAC_WHITELIST_LIBS
+                       when "omnios"
+                         OMNIOS_WHITELIST_LIBS
                        when "solaris2"
                          SOLARIS_WHITELIST_LIBS
                        when "smartos"

--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -44,6 +44,7 @@ module Omnibus
       "wrlinux"  => RPM,
       "aix"      => BFF,
       "solaris"  => Solaris,
+      "omnios"   => IPS,
       "ips"      => IPS,
       "windows"  => [MSI, APPX],
       "mac_os_x" => PKG,


### PR DESCRIPTION
### Description

This pull request adds:
- Explicit whitelisting for external system libraries on OmniOS systems (using the same pattern as for other operating systems and distributions).
- Default packager mapping entry for "omnios" -> IPS.

---

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
