### PR TITLE
More msys2 upgrade fallout.

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -281,6 +281,14 @@ module Omnibus
     expose :windows_safe_path
 
     #
+    # (see Util#to_msys2_path)
+    #
+    def to_msys2_path(*pieces)
+      super
+    end
+    expose :to_msys2_path
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -674,7 +674,7 @@ module Omnibus
           arch_flag = windows_arch_i386? ? "-m32" : "-m64"
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"
           {
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -fno-lto",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -Wl,-rpath,#{install_dir}/embedded/lib",
             # We do not wish to enable SSE even though we target i686 because
             # of a stack alignment issue with some libraries. We have not
             # exactly ascertained the cause but some compiled library/binary
@@ -688,9 +688,7 @@ module Omnibus
             # TODO: This was true of our old TDM gcc 4.7 compilers. Is it still
             # true with mingw-w64?
             #
-            # XXX: Temporarily turning -O3 into -O2 -fno-lto to work around some
-            # weird linker issues.
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O2 -fno-lto #{opt_flag}",
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 #{opt_flag}",
           }
         else
           {
@@ -729,12 +727,23 @@ module Omnibus
         extra_linker_flags["LD_OPTIONS"] = ld_options
       end
 
+      # Always want to favor pkg-config from embedded location to not hose
+      # configure scripts which try to be too clever and ignore our explicit
+      # CFLAGS and LDFLAGS in favor of pkg-config info.
+      pkg_config_flags = {
+        "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+      }
+
+      # On windows, make this an msys style path because autotools don't grok
+      # windows paths and use : as a path separator. See the mingw cookbook for
+      # how the flag gets passed into the msys2 shell.
+      if windows?
+        pkg_config_flags["PREMSYS2_PKG_CONFIG_PATH"] = to_msys2_path(pkg_config_flags["PKG_CONFIG_PATH"])
+      end
+
       env.merge(compiler_flags).
         merge(extra_linker_flags).
-        # always want to favor pkg-config from embedded location to not hose
-        # configure scripts which try to be too clever and ignore our explicit
-        # CFLAGS and LDFLAGS in favor of pkg-config info
-        merge({ "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig" }).
+        merge(pkg_config_flags).
         # Set default values for CXXFLAGS and CPPFLAGS.
         merge("CXXFLAGS" => compiler_flags["CFLAGS"]).
         merge("CPPFLAGS" => compiler_flags["CFLAGS"])
@@ -753,7 +762,14 @@ module Omnibus
     def with_embedded_path(env = {})
       paths = ["#{install_dir}/bin", "#{install_dir}/embedded/bin"]
       path_value = prepend_path(paths)
-      env.merge(path_key => path_value)
+      new_env = env.merge(path_key => path_value)
+
+      # Extra path elements for msys2.
+      if windows?
+        msys2_paths = paths.map { |x| to_msys2_path(x) }
+        new_env["PREMSYS2_PATH"] = msys2_paths.join(":")
+      end
+      new_env
     end
     expose :with_embedded_path
 
@@ -1115,6 +1131,10 @@ module Omnibus
 
     private
 
+    def to_msys2_path(path)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
     #
     # The git caching implementation for this software.
     #
@@ -1122,28 +1142,6 @@ module Omnibus
     #
     def git_cache
       @git_cache ||= GitCache.new(self)
-    end
-
-    #
-    # The proper platform-specific "$PATH" key.
-    #
-    # @return [String]
-    #
-    def path_key
-      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
-      # $WINDOWSRAGE, and if you don't set that your native gem compiles
-      # will fail because the magic fixup it does to add the mingw compiler
-      # stuff won't work.
-      #
-      # Turns out there is other build environments that only set ENV['PATH'] and if we
-      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
-      # one that we find.
-      #
-      if Ohai["platform"] == "windows"
-        ENV.keys.grep(/\Apath\Z/i).first
-      else
-        "PATH"
-      end
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1131,10 +1131,6 @@ module Omnibus
 
     private
 
-    def to_msys2_path(path)
-      path.sub(/^([A-Za-z]):\//, "/\\1/")
-    end
-
     #
     # The git caching implementation for this software.
     #

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -114,7 +114,7 @@ module Omnibus
         path_dirs = path_dirs.map { |p| windows_safe_path(p) }
         safe_install_dir = windows_safe_path(install_dir)
         path_dirs = path_dirs.reject do |p|
-          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| safe_p.start_with?(f) }
+          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| p.start_with?(f) }
         end
         options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
       end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -32,7 +32,6 @@ module Omnibus
     SHELLOUT_OPTIONS = {
       log_level: :internal,
       timeout: 7200, # 2 hours
-      environment: {},
     }.freeze
 
     #
@@ -78,6 +77,7 @@ module Omnibus
     def shellout(*args)
       options = args.last.kind_of?(Hash) ? args.pop : {}
       options = SHELLOUT_OPTIONS.merge(options)
+      options[:environment] = {} unless options.has_key? :environment
 
       command_string = args.join(" ")
       in_msys = options.delete(:in_msys_bash) && windows?

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -21,6 +21,7 @@ module Omnibus
     def self.included(base)
       # This module requires logging is also available
       base.send(:include, Logging)
+      base.send(:include, Sugarable)
     end
 
     #
@@ -33,6 +34,31 @@ module Omnibus
       timeout: 7200, # 2 hours
       environment: {},
     }.freeze
+
+    #
+    # The proper platform-specific "$PATH" key.
+    #
+    # @return [String]
+    #
+    def path_key
+      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
+      # $WINDOWSRAGE, and if you don't set that your native gem compiles
+      # will fail because the magic fixup it does to add the mingw compiler
+      # stuff won't work.
+      #
+      # Turns out there is other build environments that only set ENV['PATH'] and if we
+      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
+      # one that we find.
+      #
+      if windows?
+        result = ENV.keys.grep(/\Apath\Z/i)
+        raise "The current omnibus environment has no PATH" if result.length == 0
+        raise "The current omnibus environment has duplicate PATHs" if result.length > 1
+        result.first
+      else
+        "PATH"
+      end
+    end
 
     #
     # Shells out and runs +command+.
@@ -53,6 +79,14 @@ module Omnibus
       options = args.last.kind_of?(Hash) ? args.pop : {}
       options = SHELLOUT_OPTIONS.merge(options)
 
+      command_string = args.join(" ")
+      in_msys = options.delete(:in_msys_bash) && windows?
+      # Mixlib will handle escaping characters for cmd but our command might
+      # contain '. For now, assume that won't happen because I don't know
+      # whether this command is going to be played via cmd or through
+      # ProcessCreate.
+      command_string = "bash -c \'#{command_string}\'" if in_msys
+
       # Grab the log_level
       log_level = options.delete(:log_level)
 
@@ -65,18 +99,54 @@ module Omnibus
         options[:environment] = options.fetch(:environment, {}).merge(options[:env])
       end
 
+      # Double check that we don't have conflicting PATH definitions.
+      path_keys = options[:environment].keys.grep(/\Apath\Z/i)
+      if path_keys.length > 1
+        raise InvalidValue.new("shellout", "receive environment without duplicate PATH values")
+      elsif path_keys.length == 1 && path_keys.first != path_key
+        options[:environment][path_key] = options[:environment].delete(path_keys.first)
+      end
+
+      # Try our best to get rid of the "outer" omnibus ruby and any current
+      # chef-client/chef-dk installations from the path.
+      if options.delete(:clean_ruby_path)
+        path_dirs = options[:environment].fetch(path_key, "").split(File::PATH_SEPARATOR || ":")
+        path_dirs = path_dirs.reject do |p|
+          filter_paths.any? { |f| windows_safe_path(p).start_with?(f) }
+        end
+        options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
+      end
+
       # Log any environment options given
       unless options[:environment].empty?
         log.public_send(log_level, log_key) { "Environment:" }
-        options[:environment].sort.each do |key, value|
-          log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+        if in_msys
+          # Run a command to log the actual environment variables inside the
+          # msys shell. Live stream at the same level we would have otherwise
+          # logged the environment at.
+          env_options = options.dup
+          env_options[:live_stream] = log.live_stream(log_level || :info)
+          env_cmds = options[:environment].keys.sort.map do |key|
+            # Special case "PATH" because it's capitalized and handled differently.
+            key = "PATH" if key == path_key
+            "echo #{key}=$#{key}"
+          end
+          env_cmds << "echo PWD=$PWD"
+
+          cmd = Mixlib::ShellOut.new("bash -c \'#{env_cmds.join(';')}\'", env_options)
+          cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
+          cmd.run_command
+        else
+          options[:environment].sort.each do |key, value|
+            log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+          end
         end
       end
 
       # Log the actual command
-      log.public_send(log_level, log_key) { "$ #{args.join(' ')}" }
+      log.public_send(log_level, log_key) { "$ #{command_string}" }
 
-      cmd = Mixlib::ShellOut.new(*args, options)
+      cmd = Mixlib::ShellOut.new(command_string, options)
       cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
       cmd.run_command
       cmd
@@ -219,6 +289,25 @@ module Omnibus
     def create_link(a, b)
       log.debug(log_key) { "Linking `#{a}' to `#{b}'" }
       FileUtils.ln_s(a, b)
+    end
+
+    private
+
+    def filter_paths
+      @filter_paths ||=
+        begin
+          # Any alternate binaries or gems from the users environment.
+          filters = Gem.paths.path.dup
+          # Any possible embedded ruby in chef products.
+          if windows?
+            filters << "C:/opscode"
+          else
+            filters << "/opt/chef" << "/opt/chefdk" << "/opt/delivery-cli"
+          end
+          # Current ruby - this is the ruby that omnibus itself uses.
+          filters << File.expand_path(File.join(RbConfig.ruby, "../.."))
+          filters.map { |p| windows_safe_path(p) }
+        end
     end
   end
 end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -192,6 +192,18 @@ module Omnibus
     end
 
     #
+    # Takes a ruby style path (e.g. C:/foo/bar) and coverts it to an msys path (/C/foo/bar).
+    #
+    # @param [String, Array<String>] pieces
+    #   the pieces of the path to join and fix
+    # @return [String]
+    #
+    def to_msys2_path(*pieces)
+      path = File.join(*pieces)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
+    #
     # Create a directory at the given +path+.
     #
     # @param [String, Array<String>] paths

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -303,28 +303,28 @@ module Omnibus
       it "invokes patch with patch level 1 unless specified" do
         expect { subject.patch(source: "good_patch") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch with patch level provided" do
         expect { subject.patch(source: "good_patch", plevel: 0) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch differently if target is provided" do
         expect { subject.patch(source: "good_patch", target: "target/path") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true)
+          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "persists other options" do
         expect { subject.patch(source: "good_patch", timeout: 3600) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
     end


### PR DESCRIPTION
- Be very conservative when putting items on the path when invoking
  commands that involve embedded ruby.
- Be accurate when logging environment variables that are to be used
  within msys2 shells.
- Handle new flags in the mingw cookbook that let you pass env variable
  prefixes into msys2 shells.

---

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
