### PR TITLE
Drop support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.1.9
+  - 2.2.5
 bundler_args: "--jobs 7 --without docs local"
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
   matrix:
     - RUBY_VERSION: 22
     - RUBY_VERSION: 21
-    - RUBY_VERSION: 200
 
 clone_folder: c:\projects\omnibus
 clone_depth: 1

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.description    = gem.summary
   gem.homepage       = "https://github.com/opscode/omnibus"
 
-  gem.required_ruby_version = ">= 2"
+  gem.required_ruby_version = ">= 2.1"
 
   gem.files = `git ls-files`.split($/)
   gem.bindir = "bin"


### PR DESCRIPTION
### Description

Drop support for Ruby 2.0. ffi-yajl 2.3.0 requires Ruby 2.1 and above, and Ruby 2.0 is EOL, so this shouldn't be a huge issue in general.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

