### PR TITLE
Remove fakeroot from RPM

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -337,14 +337,14 @@ module Omnibus
     end
 
     #
-    # Generate the RPM file using +rpmbuild+.  The use of the +fakeroot+ command
-    # is required so that the package is owned by +root:root+, but the build
-    # user does not need to have sudo permissions.
+    # Generate the RPM file using +rpmbuild+. Unlike debian,the +fakeroot+
+    # command is not required for the package to be owned by +root:root+. The
+    # rpmuser specified in the spec file dictates this.
     #
     # @return [void]
     #
     def create_rpm_file
-      command =  %{fakeroot rpmbuild}
+      command =  %{rpmbuild}
       command << %{ --target #{safe_architecture}}
       command << %{ -bb}
       command << %{ --buildroot #{staging_dir}/BUILD}


### PR DESCRIPTION
### Description

Fakeroot was added to both deb and rpm style a while ago and is still needed for the dpkg-deb packaging. With rpmbuild, the same effect can be done by setting the `rpm_user` in the rpm spec file. Removing fakeroot from rpm based platforms simplifies this and fixes some issues we have seen with package availability on certain platforms.


--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

@chef/engineering-services 