### PR TITLE
Collect licenses incrementally so they cache correctly

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -353,6 +353,10 @@ module Omnibus
               File.chmod 0644, output_file unless windows?
             else
               licensing_warning("License file '#{input_file}' does not exist for software '#{software_name}'.")
+              # If we got here, we need to fail now so we don't take a git
+              # cache snapshot, or else the software build could be restored
+              # from cache without fixing the license issue.
+              raise_if_warnings_fatal!
             end
           else
             begin
@@ -366,6 +370,10 @@ module Omnibus
                    OpenURI::HTTPError,
                    OpenSSL::SSL::SSLError
               licensing_warning("Can not download license file '#{license_file}' for software '#{software_name}'.")
+              # If we got here, we need to fail now so we don't take a git
+              # cache snapshot, or else the software build could be restored
+              # from cache without fixing the license issue.
+              raise_if_warnings_fatal!
             end
           end
         end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1072,13 +1072,14 @@ module Omnibus
       FileUtils.rm_rf(install_dir)
       FileUtils.mkdir_p(install_dir)
 
-      softwares.each do |software|
-        software.build_me
+      Licensing.create_incrementally(self) do |license_collector|
+        softwares.each do |software|
+          software.build_me([license_collector])
+        end
       end
 
       write_json_manifest
       write_text_manifest
-      Licensing.create!(self)
       HealthCheck.run!(self)
       package_me
       compress_me

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -146,7 +146,11 @@ module Omnibus
       project.library.component_added(private_code)
       project.library.component_added(software_with_warnings) if software_with_warnings
 
-      Licensing.create!(project)
+      Licensing.create_incrementally(project) do |licensing|
+        project.softwares.each do |software|
+          licensing.execute_post_build(software)
+        end
+      end
     end
 
     describe "without license definitions in the project" do


### PR DESCRIPTION
### Description

There are two motivations here:
1. Fix https://github.com/chef/omnibus/issues/696 by copying the license
   files from the cached source to the build directory during the
   software build (so that the license file is cached)
2. Lay the groundwork for transitive dependency license collection that
   works incrementally so that it doesn't have a similar flaw

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

