### PR TITLE
Proposal: Add an an option to include all licenses in one file

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -204,7 +204,8 @@ module Omnibus
     # For details, see:
     # /opt/opscode/LICENSES/python-LICENSE
     # ...
-    #
+    # If #{project.license_compiled_output} is set
+    # it will append the license contents
     # @return [String]
     #
     def components_license_summary
@@ -218,15 +219,38 @@ module Omnibus
         out << "This product bundles #{name} #{version},\n"
         out << "which is available under a \"#{license}\" License.\n"
         if !license_files.empty?
-          out << "For details, see:\n"
+          out << "Details:\n\n"
           license_files.each do |license_file|
-            out << "#{license_package_location(name, license_file)}\n"
+            path = license_package_location(name, license_file)
+            if project.license_compiled_output
+              out << "#{license_content(path)}"
+            else
+              out << "#{path}\n"
+            end
           end
         end
         out << "\n"
       end
 
       out
+    end
+
+    #
+    # Reads the content of the license file
+    # It is in the form of:
+    # ...
+    # MIT License
+    # Permission is hereby granted, free of charge, to any person obtaining
+    # ...
+    #
+    # @return [String]
+    #
+    def license_content(path)
+      if File.exist?(path)
+        File.read(path)
+      else
+        path
+      end
     end
 
     #

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -761,6 +761,14 @@ module Omnibus
     end
     expose :license_file_path
 
+    def license_compiled_output(val = NULL)
+      if null?(val)
+        @license_compiled_output
+      else
+        @license_compiled_output = val
+      end
+    end
+    expose :license_compiled_output
     #
     # Location of json-formated version manifest, written at at the
     # end of the build. If no path is specified

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -6,6 +6,7 @@ module Omnibus
     let(:license_file_path) { nil }
     let(:license_file) { nil }
     let(:zlib_version_override) { nil }
+    let(:license_compiled_output) { nil }
 
     let(:install_dir) { File.join(tmp_path, "install_dir") }
     let(:software_project_dir) { File.join(tmp_path, "software_project_dir") }
@@ -95,6 +96,8 @@ module Omnibus
         if zlib_version_override
           project.override :zlib, version: zlib_version_override
         end
+        project.license_compiled_output(license_compiled_output) unless license_compiled_output.nil?
+        project.build_version('1.2.3')
       end
     end
 
@@ -269,6 +272,18 @@ module Omnibus
 
       it "fails the omnibus build" do
         expect { create_licenses }.to raise_error(Omnibus::LicensingError, /Project 'test-project' does not contain licensing information.\s{1,}Software 'private_code' does not contain licensing information./)
+      end
+    end
+
+    describe "with license_compiled_output set" do
+      let(:license_compiled_output) { true }
+
+      it "creates the main license file for the project correctly" do
+        create_licenses
+        project_license = File.join(install_dir, expected_project_license_path)
+        expect(File.exist?(project_license)).to be(true)
+        project_license = File.read(project_license)
+        expect(project_license).to match /THIS PACKAGE IS PROVIDED \"AS IS\" AND WITHOUT ANY EXPRESS OR\nIMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED\nWARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE./
       end
     end
   end


### PR DESCRIPTION
### Description

We had multiple users requesting one file which contains all the generated licenses for their internal approving processes.

This PR is more of a proposal to see if this use case would be acceptable for more users, the code is written to demonstrate how this might look.

If `license_compiled_output  true`, the main `LICENSE` file would contain the actual text from each individual license, otherwise the behaviour remains the same.

My questions would be: Would something like this be useful to more omnibus users and the maintainers? If yes, how could this be improved to be accepted? If no, thanks for reading :)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

