### PR TITLE
Ensure licenses dir is not removed by git cache

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -94,6 +94,7 @@ module Omnibus
     def prepare
       FileUtils.rm_rf(output_dir)
       FileUtils.mkdir_p(output_dir)
+      FileUtils.touch(output_dir_gitkeep_file)
     end
 
     # Required callback to use instances of this class as a build wrapper for
@@ -290,6 +291,16 @@ module Omnibus
     #
     def output_dir
       File.expand_path(OUTPUT_DIRECTORY, project.install_dir)
+    end
+
+    #
+    # Path to a .gitkeep file we create in the output dir so git caching
+    # doesn't delete the directory.
+    #
+    # @return [String]
+    #
+    def output_dir_gitkeep_file
+      File.join(output_dir, ".gitkeep")
     end
 
     #

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -153,6 +153,20 @@ module Omnibus
       end
     end
 
+    describe "prepare step" do
+
+      let(:licenses_dir) { File.join(install_dir, "LICENSES") }
+
+      let(:dot_gitkeep) { File.join(licenses_dir, ".gitkeep") }
+
+      it "creates a LICENSES dir with a .gitkeep file inside the install directory" do
+        Licensing.new(project).prepare
+        expect(File).to exist(licenses_dir)
+        expect(File).to exist(dot_gitkeep)
+      end
+
+    end
+
     describe "without license definitions in the project" do
       it_behaves_like "correctly created licenses"
 


### PR DESCRIPTION
### Description

Not 100% sure if this is a bug in practice or not, but any directories we create before a git cache snapshot is taken need to have a `.gitkeep` file in them or it's possible the git cache could end up removing them if a snapshot is taken when the directory is empty and later restored.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

