### PR TITLE
License collection for transitive dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 # Fork to allow for a recent version of multipart-post.
 gem "pedump", git: "https://github.com/ksubrama/pedump", branch: "patch-1"
 
+gem "license_scout", github: "chef/license_scout", branch: "sersut/ruby_bin"
+
 group :docs do
   gem "yard",          "~> 0.8"
   gem "redcarpet",     "~> 2.2.2"

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -771,10 +771,6 @@ module Omnibus
 
     private
 
-    def embedded_bin(bin)
-      windows_safe_path("#{install_dir}/embedded/bin/#{bin}")
-    end
-
     #
     # The **in-order** list of {BuildCommand} for this builder.
     #

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -281,6 +281,14 @@ module Omnibus
     expose :windows_safe_path
 
     #
+    # (see Util#to_msys2_path)
+    #
+    def to_msys2_path(*pieces)
+      super
+    end
+    expose :to_msys2_path
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -81,6 +81,10 @@ module Omnibus
       warn_for_shell_commands(command)
 
       build_commands << BuildCommand.new("Execute: `#{command}'") do
+        # If we expect the command to run cleanly in windows within a limited
+        # msys shell, we also expect it to run cleanly on other platforms
+        # without the assistance of our chef or ruby binaries.
+        options[:clean_ruby_path] = true if options[:in_msys_bash]
         shellout!(command, options)
       end
     end
@@ -245,6 +249,7 @@ module Omnibus
 
       patches << patch_path
       options[:in_msys_bash] = true
+      options[:clean_ruby_path] = true
       build_commands << BuildCommand.new("Apply patch `#{source}'") do
         shellout!(patch_cmd, options)
       end
@@ -298,6 +303,7 @@ module Omnibus
     def ruby(command, options = {})
       build_commands << BuildCommand.new("ruby `#{command}'") do
         bin = embedded_bin("ruby")
+        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -315,6 +321,7 @@ module Omnibus
     def gem(command, options = {})
       build_commands << BuildCommand.new("gem `#{command}'") do
         bin = embedded_bin("gem")
+        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -335,6 +342,7 @@ module Omnibus
     def bundle(command, options = {})
       build_commands << BuildCommand.new("bundle `#{command}'") do
         bin = embedded_bin("bundle")
+        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -368,6 +376,7 @@ module Omnibus
         # Ensure the main bin dir exists
         FileUtils.mkdir_p(bin_dir)
 
+        options[:clean_ruby_path] = true
         shellout!("#{appbundler_bin} '#{app_software.project_dir}' '#{bin_dir}'", options)
       end
     end
@@ -386,6 +395,7 @@ module Omnibus
     def rake(command, options = {})
       build_commands << BuildCommand.new("rake `#{command}'") do
         bin = embedded_bin("rake")
+        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -799,14 +809,6 @@ module Omnibus
       # Make sure the PWD is set to the correct directory
       # Also make a clone of options so that we can mangle it safely below.
       options = { cwd: software.project_dir }.merge(options)
-
-      if options.delete(:in_msys_bash) && windows?
-        # Mixlib will handle escaping characters for cmd but our command might
-        # contain '. For now, assume that won't happen because I don't know
-        # whether this command is going to be played via cmd or through
-        # ProcessCreate.
-        command_string = "bash -c \'#{command_string}\'"
-      end
 
       # Set the log level to :info so users will see build commands
       options[:log_level] ||= :info

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -514,6 +514,12 @@ module Omnibus
     # @return [true, false]
     default(:fatal_licensing_warnings, false)
 
+    # Fail the build or warn when build encounters a transitive dependency
+    # licensing warning.
+    #
+    # @return [true, false]
+    default(:fatal_transitive_dependency_licensing_warnings, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -17,6 +17,8 @@
 require "uri"
 require "fileutils"
 require "omnibus/download_helpers"
+require "license_scout/collector"
+require "license_scout/options"
 
 module Omnibus
   class Licensing
@@ -25,6 +27,7 @@ module Omnibus
     include Sugarable
 
     OUTPUT_DIRECTORY = "LICENSES".freeze
+    CACHE_DIRECTORY = "license-cache".freeze
 
     class << self
 
@@ -57,6 +60,7 @@ module Omnibus
 
           yield license_collector
 
+          license_collector.process_transitive_dependency_licensing_info
           license_collector.create_project_license_file
           license_collector.raise_if_warnings_fatal!
         end
@@ -78,12 +82,29 @@ module Omnibus
     attr_reader :licensing_warnings
 
     #
+    # The warnings encountered while preparing the licensing information for
+    # transitive dependencies.
+    #
+    # @return [Array<String>]
+    #
+    attr_reader :transitive_dependency_licensing_warnings
+
+    #
+    # Manifest data of transitive dependency licensing information
+    #
+    # @return Hash
+    #
+    attr_reader :dep_license_map
+
+    #
     # @param [Project] project
     #   the project to create licenses for.
     #
     def initialize(project)
       @project = project
       @licensing_warnings = []
+      @transitive_dependency_licensing_warnings = []
+      @dep_license_map = {}
     end
 
     #
@@ -95,6 +116,8 @@ module Omnibus
       FileUtils.rm_rf(output_dir)
       FileUtils.mkdir_p(output_dir)
       FileUtils.touch(output_dir_gitkeep_file)
+      FileUtils.rm_rf(cache_dir)
+      FileUtils.mkdir_p(cache_dir)
     end
 
     # Required callback to use instances of this class as a build wrapper for
@@ -120,6 +143,10 @@ module Omnibus
     #
     def execute_post_build(software)
       collect_licenses_for(software)
+
+      unless software.skip_transitive_dependency_licensing
+        collect_transitive_dependency_licenses_for(software)
+      end
     end
 
     #
@@ -181,6 +208,8 @@ module Omnibus
         f.puts project_license_content
         f.puts ""
         f.puts components_license_summary
+        f.puts ""
+        f.puts dependencies_license_summary
       end
     end
 
@@ -222,6 +251,41 @@ module Omnibus
           end
         end
         out << "\n"
+      end
+
+      out
+    end
+
+    #
+    # Summary of the licenses of the transitive dependencies of the project.
+    # It is in the form of:
+    # ...
+    # This product includes inifile 3.0.0
+    # which is a 'ruby_bundler' dependency of 'chef',
+    # and which is available under a 'MIT' License.
+    # For details, see:
+    # /opt/opscode/LICENSES/ruby_bundler-inifile-3.0.0-README.md
+    # ...
+    #
+    # @return [String]
+    #
+    def dependencies_license_summary
+      out = "\n\n"
+
+      dep_license_map.each do |dep_mgr_name, data|
+        data.each do |dep_name, data|
+          data.each do |dep_version, dep_data|
+            projects = dep_data["dependency_of"].map { |p| "'#{p}'" }.join(", ")
+            files = dep_data["license_files"].map { |f| File.join(output_dir, f) }
+
+            out << "This product includes #{dep_name} #{dep_version}\n"
+            out << "which is a '#{dep_mgr_name}' dependency of #{projects},\n"
+            out << "and which is available under a '#{dep_data["license"]}' License.\n"
+            out << "For details, see:\n"
+            out << files.join("\n")
+            out << "\n\n"
+          end
+        end
       end
 
       out
@@ -303,6 +367,24 @@ module Omnibus
       File.join(output_dir, ".gitkeep")
     end
 
+    # Cache directory where transitive dependency licenses will be collected in.
+    #
+    # @return [String]
+    #
+    def cache_dir
+      File.expand_path(CACHE_DIRECTORY, project.install_dir)
+    end
+
+    #
+    # Path to a .gitkeep file we create in the cache dir so git caching
+    # doesn't delete the directory.
+    #
+    # @return [String]
+    #
+    def cache_dir_gitkeep_file
+      File.join(cache_dir, ".gitkeep")
+    end
+
     #
     # Returns if the given path to a license is local or a remote url.
     #
@@ -337,13 +419,115 @@ module Omnibus
       log.warn(log_key) { message }
     end
 
+    #
+    # Logs the given message as warning or fails the build depending on the
+    # :fatal_transitive_dependency_licensing_warnings configuration setting.
+    #
+    # @param [String] message
+    #   message to log as warning
+    def transitive_dependency_licensing_warning(message)
+      transitive_dependency_licensing_warnings << message
+      log.warn(log_key) { message }
+    end
+
     def raise_if_warnings_fatal!
+      warnings_to_raise = []
       if Config.fatal_licensing_warnings && !licensing_warnings.empty?
-        raise LicensingError.new(licensing_warnings)
+        warnings_to_raise << licensing_warnings
       end
+
+      if Config.fatal_transitive_dependency_licensing_warnings && !transitive_dependency_licensing_warnings.empty?
+        warnings_to_raise << transitive_dependency_licensing_warnings
+      end
+
+      warnings_to_raise.flatten!
+      raise LicensingError.new(warnings_to_raise) unless warnings_to_raise.empty?
+    end
+
+    # 1. Parse all the licensing information for all software from 'cache_dir'
+    # 2. Merge and drop the duplicates
+    # 3. Add these licenses to the main manifest, to be merged with the main
+    # licensing information from software definitions.
+    def process_transitive_dependency_licensing_info
+      Dir.glob("#{cache_dir}/*/*-dependency-licenses.json").each do |license_manifest_path|
+        license_manifest_data = FFI_Yajl::Parser.parse(File.read(license_manifest_path))
+        project_name = license_manifest_data["project_name"]
+        dependency_license_dir = File.dirname(license_manifest_path)
+
+        license_manifest_data["dependency_managers"].each do |dep_mgr_name, dependencies|
+          dep_license_map[dep_mgr_name] ||= {}
+
+          dependencies.each do |dependency|
+            # Copy dependency files
+            dependency["license_files"].each do |f|
+              license_path = File.join(dependency_license_dir, f)
+              output_path = File.join(output_dir, f)
+              FileUtils.cp(license_path, output_path)
+            end
+
+            dep_name = dependency["name"]
+            dep_version = dependency["version"]
+
+            # If we already have this dependency we do not need to add it again.
+            if dep_license_map[dep_mgr_name][dep_name] && dep_license_map[dep_mgr_name][dep_name][dep_version]
+              dep_license_map[dep_mgr_name][dep_name][dep_version]["dependency_of"] << project_name
+            else
+              dep_license_map[dep_mgr_name][dep_name] ||= {}
+              dep_license_map[dep_mgr_name][dep_name][dep_version] = {
+                "license" => dependency["license"],
+                "license_files" => dependency["license_files"],
+                "dependency_of" => [ project_name ],
+              }
+            end
+          end
+        end
+      end
+
+      FileUtils.rm_rf(cache_dir)
     end
 
     private
+
+    # Uses license_scout to collect the licenses for transitive dependencies
+    # into #{output_dir}/license-cache/#{software.name}
+    def collect_transitive_dependency_licenses_for(software)
+      # We collect the licenses of the transitive dependencies of this software
+      # with LicenseScout. We place these files under
+      # /opt/project-name/license-cache for them to be cached in git_cache. Once
+      # the build completes we will process these license files but we need to
+      # perform this step after build, before git_cache to be able to operate
+      # correctly with the git_cache.
+      license_output_dir = File.join(cache_dir, software.name)
+
+      collector = LicenseScout::Collector.new(
+        software.project.name,
+        software.project_dir,
+        license_output_dir,
+        LicenseScout::Options.new(
+          environment: software.with_embedded_path,
+          ruby_bin: software.embedded_bin("ruby")
+        )
+      )
+
+      begin
+        collector.run
+        collector.issue_report.each { |i| transitive_dependency_licensing_warning(i) }
+      rescue LicenseScout::Exceptions::UnsupportedProjectType => e
+        # Looks like this project is not supported by LicenseScout. Either the
+        # language and the dependency manager used by the project is not
+        # supported, or the software definition does not have any transitive
+        # dependencies.  In the latter case software definition should set
+        # 'skip_transitive_dependency_licensing' to 'true' to correct this
+        # error.
+        transitive_dependency_licensing_warning(<<-EOH)
+Software '#{software.name}' is not supported project type for transitive \
+dependency license collection. See https://github.com/chef/license_scout for \
+the list of supported languages and dependency managers. If this project does \
+not have any transitive dependencies, consider setting \
+'skip_transitive_dependency_licensing' to 'true' in order to correct this error.
+EOH
+      end
+    end
 
     # Collect the license files for the software.
     def collect_licenses_for(software)

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -380,6 +380,26 @@ module Omnibus
     expose :license_file
 
     #
+    # Skip collecting licenses of transitive dependencies for this software
+    #
+    # @example
+    #   skip_transitive_dependency_licensing true
+    #
+    # @param [Boolean] val
+    #   set or reset transitive dependency license collection
+    #
+    # @return [Boolean]
+    #
+    def skip_transitive_dependency_licensing(val = NULL)
+      if null?(val)
+        @skip_transitive_dependency_licensing || false
+      else
+        @skip_transitive_dependency_licensing = val
+      end
+    end
+    expose :skip_transitive_dependency_licensing
+
+    #
     # Evaluate a block only if the version matches.
     #
     # @example
@@ -752,6 +772,20 @@ module Omnibus
       new_env
     end
     expose :with_embedded_path
+
+    #
+    # Returns the platform safe full path under embedded/bin directory to the
+    # given binary
+    #
+    # @param [String] bin
+    #   Name of the binary under embedded/bin
+    #
+    # @return [String]
+    #
+    def embedded_bin(bin)
+      windows_safe_path("#{install_dir}/embedded/bin/#{bin}")
+    end
+    expose :embedded_bin
 
     #
     # A PATH variable format string representing the current PATH with the

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1097,10 +1097,6 @@ module Omnibus
 
     private
 
-    def to_msys2_path(path)
-      path.sub(/^([A-Za-z]):\//, "/\\1/")
-    end
-
     #
     # The git caching implementation for this software.
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -76,6 +76,7 @@ module Omnibus
     include Logging
     include NullArgumentable
     include Sugarable
+    include Util
 
     attr_reader :manifest
 
@@ -653,7 +654,7 @@ module Omnibus
           arch_flag = windows_arch_i386? ? "-m32" : "-m64"
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"
           {
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -fno-lto",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -Wl,-rpath,#{install_dir}/embedded/lib",
             # We do not wish to enable SSE even though we target i686 because
             # of a stack alignment issue with some libraries. We have not
             # exactly ascertained the cause but some compiled library/binary
@@ -667,9 +668,7 @@ module Omnibus
             # TODO: This was true of our old TDM gcc 4.7 compilers. Is it still
             # true with mingw-w64?
             #
-            # XXX: Temporarily turning -O3 into -O2 -fno-lto to work around some
-            # weird linker issues.
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O2 -fno-lto #{opt_flag}",
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 #{opt_flag}",
           }
         else
           {
@@ -708,12 +707,23 @@ module Omnibus
         extra_linker_flags["LD_OPTIONS"] = ld_options
       end
 
+      # Always want to favor pkg-config from embedded location to not hose
+      # configure scripts which try to be too clever and ignore our explicit
+      # CFLAGS and LDFLAGS in favor of pkg-config info.
+      pkg_config_flags = {
+        "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+      }
+
+      # On windows, make this an msys style path because autotools don't grok
+      # windows paths and use : as a path separator. See the mingw cookbook for
+      # how the flag gets passed into the msys2 shell.
+      if windows?
+        pkg_config_flags["PREMSYS2_PKG_CONFIG_PATH"] = to_msys2_path(pkg_config_flags["PKG_CONFIG_PATH"])
+      end
+
       env.merge(compiler_flags).
         merge(extra_linker_flags).
-        # always want to favor pkg-config from embedded location to not hose
-        # configure scripts which try to be too clever and ignore our explicit
-        # CFLAGS and LDFLAGS in favor of pkg-config info
-        merge({ "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig" }).
+        merge(pkg_config_flags).
         # Set default values for CXXFLAGS and CPPFLAGS.
         merge("CXXFLAGS" => compiler_flags["CFLAGS"]).
         merge("CPPFLAGS" => compiler_flags["CFLAGS"])
@@ -732,7 +742,14 @@ module Omnibus
     def with_embedded_path(env = {})
       paths = ["#{install_dir}/bin", "#{install_dir}/embedded/bin"]
       path_value = prepend_path(paths)
-      env.merge(path_key => path_value)
+      new_env = env.merge(path_key => path_value)
+
+      # Extra path elements for msys2.
+      if windows?
+        msys2_paths = paths.map { |x| to_msys2_path(x) }
+        new_env["PREMSYS2_PATH"] = msys2_paths.join(":")
+      end
+      new_env
     end
     expose :with_embedded_path
 
@@ -1080,6 +1097,10 @@ module Omnibus
 
     private
 
+    def to_msys2_path(path)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
     #
     # The git caching implementation for this software.
     #
@@ -1087,28 +1108,6 @@ module Omnibus
     #
     def git_cache
       @git_cache ||= GitCache.new(self)
-    end
-
-    #
-    # The proper platform-specific "$PATH" key.
-    #
-    # @return [String]
-    #
-    def path_key
-      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
-      # $WINDOWSRAGE, and if you don't set that your native gem compiles
-      # will fail because the magic fixup it does to add the mingw compiler
-      # stuff won't work.
-      #
-      # Turns out there is other build environments that only set ENV['PATH'] and if we
-      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
-      # one that we find.
-      #
-      if Ohai["platform"] == "windows"
-        ENV.keys.grep(/\Apath\Z/i).first
-      else
-        "PATH"
-      end
     end
 
     #

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -114,7 +114,7 @@ module Omnibus
         path_dirs = path_dirs.map { |p| windows_safe_path(p) }
         safe_install_dir = windows_safe_path(install_dir)
         path_dirs = path_dirs.reject do |p|
-          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| safe_p.start_with?(f) }
+          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| p.start_with?(f) }
         end
         options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
       end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -21,6 +21,7 @@ module Omnibus
     def self.included(base)
       # This module requires logging is also available
       base.send(:include, Logging)
+      base.send(:include, Sugarable)
     end
 
     #
@@ -33,6 +34,31 @@ module Omnibus
       timeout: 7200, # 2 hours
       environment: {},
     }.freeze
+
+    #
+    # The proper platform-specific "$PATH" key.
+    #
+    # @return [String]
+    #
+    def path_key
+      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
+      # $WINDOWSRAGE, and if you don't set that your native gem compiles
+      # will fail because the magic fixup it does to add the mingw compiler
+      # stuff won't work.
+      #
+      # Turns out there is other build environments that only set ENV['PATH'] and if we
+      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
+      # one that we find.
+      #
+      if windows?
+        result = ENV.keys.grep(/\Apath\Z/i)
+        raise "The current omnibus environment has no PATH" if result.length == 0
+        raise "The current omnibus environment has duplicate PATHs" if result.length > 1
+        result.first
+      else
+        "PATH"
+      end
+    end
 
     #
     # Shells out and runs +command+.
@@ -53,6 +79,14 @@ module Omnibus
       options = args.last.kind_of?(Hash) ? args.pop : {}
       options = SHELLOUT_OPTIONS.merge(options)
 
+      command_string = args.join(" ")
+      in_msys = options.delete(:in_msys_bash) && windows?
+      # Mixlib will handle escaping characters for cmd but our command might
+      # contain '. For now, assume that won't happen because I don't know
+      # whether this command is going to be played via cmd or through
+      # ProcessCreate.
+      command_string = "bash -c \'#{command_string}\'" if in_msys
+
       # Grab the log_level
       log_level = options.delete(:log_level)
 
@@ -65,18 +99,54 @@ module Omnibus
         options[:environment] = options.fetch(:environment, {}).merge(options[:env])
       end
 
+      # Double check that we don't have conflicting PATH definitions.
+      path_keys = options[:environment].keys.grep(/\Apath\Z/i)
+      if path_keys.length > 1
+        raise InvalidValue.new("shellout", "receive environment without duplicate PATH values")
+      elsif path_keys.length == 1 && path_keys.first != path_key
+        options[:environment][path_key] = options[:environment].delete(path_keys.first)
+      end
+
+      # Try our best to get rid of the "outer" omnibus ruby and any current
+      # chef-client/chef-dk installations from the path.
+      if options.delete(:clean_ruby_path)
+        path_dirs = options[:environment].fetch(path_key, "").split(File::PATH_SEPARATOR || ":")
+        path_dirs = path_dirs.reject do |p|
+          filter_paths.any? { |f| windows_safe_path(p).start_with?(f) }
+        end
+        options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
+      end
+
       # Log any environment options given
       unless options[:environment].empty?
         log.public_send(log_level, log_key) { "Environment:" }
-        options[:environment].sort.each do |key, value|
-          log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+        if in_msys
+          # Run a command to log the actual environment variables inside the
+          # msys shell. Live stream at the same level we would have otherwise
+          # logged the environment at.
+          env_options = options.dup
+          env_options[:live_stream] = log.live_stream(log_level || :info)
+          env_cmds = options[:environment].keys.sort.map do |key|
+            # Special case "PATH" because it's capitalized and handled differently.
+            key = "PATH" if key == path_key
+            "echo #{key}=$#{key}"
+          end
+          env_cmds << "echo PWD=$PWD"
+
+          cmd = Mixlib::ShellOut.new("bash -c \'#{env_cmds.join(';')}\'", env_options)
+          cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
+          cmd.run_command
+        else
+          options[:environment].sort.each do |key, value|
+            log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+          end
         end
       end
 
       # Log the actual command
-      log.public_send(log_level, log_key) { "$ #{args.join(' ')}" }
+      log.public_send(log_level, log_key) { "$ #{command_string}" }
 
-      cmd = Mixlib::ShellOut.new(*args, options)
+      cmd = Mixlib::ShellOut.new(command_string, options)
       cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
       cmd.run_command
       cmd
@@ -219,6 +289,25 @@ module Omnibus
     def create_link(a, b)
       log.debug(log_key) { "Linking `#{a}' to `#{b}'" }
       FileUtils.ln_s(a, b)
+    end
+
+    private
+
+    def filter_paths
+      @filter_paths ||=
+        begin
+          # Any alternate binaries or gems from the users environment.
+          filters = Gem.paths.path.dup
+          # Any possible embedded ruby in chef products.
+          if windows?
+            filters << "C:/opscode"
+          else
+            filters << "/opt/chef" << "/opt/chefdk" << "/opt/delivery-cli"
+          end
+          # Current ruby - this is the ruby that omnibus itself uses.
+          filters << File.expand_path(File.join(RbConfig.ruby, "../.."))
+          filters.map { |p| windows_safe_path(p) }
+        end
     end
   end
 end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -192,6 +192,18 @@ module Omnibus
     end
 
     #
+    # Takes a ruby style path (e.g. C:/foo/bar) and coverts it to an msys path (/C/foo/bar).
+    #
+    # @param [String, Array<String>] pieces
+    #   the pieces of the path to join and fix
+    # @return [String]
+    #
+    def to_msys2_path(*pieces)
+      path = File.join(*pieces)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
+    #
     # Create a directory at the given +path+.
     #
     # @param [String, Array<String>] paths

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk",          "~> 2"
   gem.add_dependency "thor",             "~> 0.18"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
+  # FIXME: Release license_scout and version pin.
+  gem.add_dependency "license_scout"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"

--- a/spec/fixtures/licensing/license_scout/snoopy/ruby_bundler-bundler-audit-0.5.0-COPYING.txt
+++ b/spec/fixtures/licensing/license_scout/snoopy/ruby_bundler-bundler-audit-0.5.0-COPYING.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/spec/fixtures/licensing/license_scout/snoopy/ruby_bundler-inifile-3.0.0-README.md
+++ b/spec/fixtures/licensing/license_scout/snoopy/ruby_bundler-inifile-3.0.0-README.md
@@ -1,0 +1,215 @@
+inifile [![Build Status](https://secure.travis-ci.org/TwP/inifile.png)](http://travis-ci.org/TwP/inifile)
+=======
+
+This is a native Ruby package for reading and writing INI files.
+
+
+Description
+-----------
+
+Although made popular by Windows, INI files can be used on any system thanks
+to their flexibility. They allow a program to store configuration data, which
+can then be easily parsed and changed. Two notable systems that use the INI
+format are Samba and Trac.
+
+More information about INI files can be found on the [Wikipedia Page](http://en.wikipedia.org/wiki/INI_file).
+
+### Properties
+
+The basic element contained in an INI file is the property. Every property has
+a name and a value, delimited by an equals sign *=*. The name appears to the
+left of the equals sign and the value to the right.
+
+    name=value
+
+### Sections
+
+Section declarations start with *[* and end with *]* as in `[section1]` and
+`[section2]` shown in the example below. The section declaration marks the
+beginning of a section. All properties after the section declaration will be
+associated with that section.
+
+### Comments
+
+All lines beginning with a semicolon *;* or a number sign *#* are considered
+to be comments. Comment lines are ignored when parsing INI files.
+
+### Example File Format
+
+A typical INI file might look like this:
+
+    [section1]
+    ; some comment on section1
+    var1 = foo
+    var2 = doodle
+    var3 = multiline values \
+    are also possible
+
+    [section2]
+    # another comment
+    var1 = baz
+    var2 = shoodle
+
+
+Implementation
+--------------
+
+The format of INI files is not well defined. Several assumptions are made by
+the **inifile** gem when parsing INI files. Most of these assumptions can be
+modified at, but the defaults are listed below.
+
+### Global Properties
+
+If the INI file lacks any section declarations, or if there are properties
+decalared before the first section, then these properties will be placed into
+a default "global" section. The name of this section can be configured when
+creating an `IniFile` instance.
+
+### Duplicate Properties
+
+Duplicate properties are allowed in a single section. The last property value
+set is the one that will be stored in the `IniFile` instance.
+
+    [section1]
+    var1 = foo
+    var2 = bar
+    var1 = poodle
+
+The resulting value of `var1` will be `poodle`.
+
+### Duplicate Sections
+
+If you have more than one section with the same name then the sections will be
+merged. Duplicate properties between the two sections will follow the rules
+discussed above. Properties in the latter section will override properties in
+the earlier section.
+
+### Comments
+
+The comment character can be either a semicolon *;* or a number sign *#*. The
+comment character can appear anywhere on a line including at the end of a
+name/value pair declaration. If you wish to use a comment character in your
+value then you will need to either escape the character or put the value in
+double quotations.
+
+    [section1]
+    var1 = foo  # a comment
+    var2 = "foo # this is not a comment"
+    var3 = foo \# this is not a comment either
+
+### Multi-Line Values
+
+Values can be continued onto multiple lines in two separate ways. Putting a
+slash at the end of a line will continue the value declaration to the next
+line. When parsing, the trailing slash will be consumed and **will not**
+appear in the resulting value. Comments can appear to the right of the
+trailing slash.
+
+    var1 = this is a \  # these comments will
+    multiline value     # be ignored by the parser
+
+In the above example the resulting value for `var1` will be `this is a
+multiline value`. If you want to preserve newline characters in the value then
+quotations should be used.
+
+    var2 = "this is a
+    multiline value"
+
+The resulting value for `var2` will be `this is a\nmultiline value`.
+
+### Escape Characters
+
+Several escape characters are supported within the **value** for a property.
+These escape sequences will be applied to quoted and unquoted values alike.
+You can enable or disable escaping by setting the **escape** flag to true or
+false when creating an IniFile instance.
+
+* \0 -- null character
+* \n -- newline character
+* \r -- carriage return character
+* \t -- tab character
+* \\\\ -- backslash character
+
+The backslash escape sequence is only needed if you want one of the escape
+sequences to appear literally in your value. For example:
+
+    property = this is not a tab \\t character
+
+### Value Type Casting
+
+Some values will be type cast when parsed by the code. Those values are
+booleans, integers, floats, and empty strings are cast to `nil`.
+
+* ""  -->  nil
+* "42"  -->  42
+* "3.14159"  -->  3.14159
+* "true"  -->  true
+* "false"  -->  false
+* "normal string"  -->  "normal string"
+
+Pretty basic stuff.
+
+Install
+-------
+
+    gem install inifile
+
+
+Testing
+-------
+
+To run the tests:
+
+    $ rake
+
+
+Examples
+--------
+
+    require 'inifile'
+    myini = IniFile.load('mytest.ini')
+    myini.each_section do |section|
+      puts "I want #{myini[section]['somevar']} printed here!"
+    end
+
+Contributing
+------------
+
+Contributions are gladly welcome! For small modifications (fixing typos,
+improving documentation) you can use GitHub's in-browser editing capabilities
+to create a pull request. For larger modifications I would recommend forking
+the project, creating your patch, and then submitting a pull request.
+
+Mr Bones is used to manage rake tasks and to install dependent files. To setup
+your environment ...
+
+    $ gem install bones
+    $ rake gem:install_dependencies
+
+And always remember that `rake -T` will show you the list of available tasks.
+
+
+License
+-------
+
+MIT License
+Copyright (c) 2006 - 2014
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/spec/fixtures/licensing/license_scout/snoopy/snoopy-dependency-licenses.json
+++ b/spec/fixtures/licensing/license_scout/snoopy/snoopy-dependency-licenses.json
@@ -1,0 +1,24 @@
+{
+  "license_manifest_version": 1,
+  "project_name": "snoopy",
+  "dependency_managers": {
+    "ruby_bundler": [
+      {
+        "name": "inifile",
+        "version": "3.0.0",
+        "license": "MIT",
+        "license_files": [
+          "ruby_bundler-inifile-3.0.0-README.md"
+        ]
+      },
+      {
+        "name": "bundler-audit",
+        "version": "0.5.0",
+        "license": "GPLv3",
+        "license_files": [
+          "ruby_bundler-bundler-audit-0.5.0-COPYING.txt"
+        ]
+      }
+    ]
+  }
+}

--- a/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-inifile-3.0.0-README.md
+++ b/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-inifile-3.0.0-README.md
@@ -1,0 +1,215 @@
+inifile [![Build Status](https://secure.travis-ci.org/TwP/inifile.png)](http://travis-ci.org/TwP/inifile)
+=======
+
+This is a native Ruby package for reading and writing INI files.
+
+
+Description
+-----------
+
+Although made popular by Windows, INI files can be used on any system thanks
+to their flexibility. They allow a program to store configuration data, which
+can then be easily parsed and changed. Two notable systems that use the INI
+format are Samba and Trac.
+
+More information about INI files can be found on the [Wikipedia Page](http://en.wikipedia.org/wiki/INI_file).
+
+### Properties
+
+The basic element contained in an INI file is the property. Every property has
+a name and a value, delimited by an equals sign *=*. The name appears to the
+left of the equals sign and the value to the right.
+
+    name=value
+
+### Sections
+
+Section declarations start with *[* and end with *]* as in `[section1]` and
+`[section2]` shown in the example below. The section declaration marks the
+beginning of a section. All properties after the section declaration will be
+associated with that section.
+
+### Comments
+
+All lines beginning with a semicolon *;* or a number sign *#* are considered
+to be comments. Comment lines are ignored when parsing INI files.
+
+### Example File Format
+
+A typical INI file might look like this:
+
+    [section1]
+    ; some comment on section1
+    var1 = foo
+    var2 = doodle
+    var3 = multiline values \
+    are also possible
+
+    [section2]
+    # another comment
+    var1 = baz
+    var2 = shoodle
+
+
+Implementation
+--------------
+
+The format of INI files is not well defined. Several assumptions are made by
+the **inifile** gem when parsing INI files. Most of these assumptions can be
+modified at, but the defaults are listed below.
+
+### Global Properties
+
+If the INI file lacks any section declarations, or if there are properties
+decalared before the first section, then these properties will be placed into
+a default "global" section. The name of this section can be configured when
+creating an `IniFile` instance.
+
+### Duplicate Properties
+
+Duplicate properties are allowed in a single section. The last property value
+set is the one that will be stored in the `IniFile` instance.
+
+    [section1]
+    var1 = foo
+    var2 = bar
+    var1 = poodle
+
+The resulting value of `var1` will be `poodle`.
+
+### Duplicate Sections
+
+If you have more than one section with the same name then the sections will be
+merged. Duplicate properties between the two sections will follow the rules
+discussed above. Properties in the latter section will override properties in
+the earlier section.
+
+### Comments
+
+The comment character can be either a semicolon *;* or a number sign *#*. The
+comment character can appear anywhere on a line including at the end of a
+name/value pair declaration. If you wish to use a comment character in your
+value then you will need to either escape the character or put the value in
+double quotations.
+
+    [section1]
+    var1 = foo  # a comment
+    var2 = "foo # this is not a comment"
+    var3 = foo \# this is not a comment either
+
+### Multi-Line Values
+
+Values can be continued onto multiple lines in two separate ways. Putting a
+slash at the end of a line will continue the value declaration to the next
+line. When parsing, the trailing slash will be consumed and **will not**
+appear in the resulting value. Comments can appear to the right of the
+trailing slash.
+
+    var1 = this is a \  # these comments will
+    multiline value     # be ignored by the parser
+
+In the above example the resulting value for `var1` will be `this is a
+multiline value`. If you want to preserve newline characters in the value then
+quotations should be used.
+
+    var2 = "this is a
+    multiline value"
+
+The resulting value for `var2` will be `this is a\nmultiline value`.
+
+### Escape Characters
+
+Several escape characters are supported within the **value** for a property.
+These escape sequences will be applied to quoted and unquoted values alike.
+You can enable or disable escaping by setting the **escape** flag to true or
+false when creating an IniFile instance.
+
+* \0 -- null character
+* \n -- newline character
+* \r -- carriage return character
+* \t -- tab character
+* \\\\ -- backslash character
+
+The backslash escape sequence is only needed if you want one of the escape
+sequences to appear literally in your value. For example:
+
+    property = this is not a tab \\t character
+
+### Value Type Casting
+
+Some values will be type cast when parsed by the code. Those values are
+booleans, integers, floats, and empty strings are cast to `nil`.
+
+* ""  -->  nil
+* "42"  -->  42
+* "3.14159"  -->  3.14159
+* "true"  -->  true
+* "false"  -->  false
+* "normal string"  -->  "normal string"
+
+Pretty basic stuff.
+
+Install
+-------
+
+    gem install inifile
+
+
+Testing
+-------
+
+To run the tests:
+
+    $ rake
+
+
+Examples
+--------
+
+    require 'inifile'
+    myini = IniFile.load('mytest.ini')
+    myini.each_section do |section|
+      puts "I want #{myini[section]['somevar']} printed here!"
+    end
+
+Contributing
+------------
+
+Contributions are gladly welcome! For small modifications (fixing typos,
+improving documentation) you can use GitHub's in-browser editing capabilities
+to create a pull request. For larger modifications I would recommend forking
+the project, creating your patch, and then submitting a pull request.
+
+Mr Bones is used to manage rake tasks and to install dependent files. To setup
+your environment ...
+
+    $ gem install bones
+    $ rake gem:install_dependencies
+
+And always remember that `rake -T` will show you the list of available tasks.
+
+
+License
+-------
+
+MIT License
+Copyright (c) 2006 - 2014
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-mime-types-3.1-Licence.rdoc
+++ b/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-mime-types-3.1-Licence.rdoc
@@ -1,0 +1,25 @@
+== Licence
+
+*   Copyright 2003–2015 Austin Ziegler and contributors.
+
+The software in this repository is made available under the MIT license.
+
+=== MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
+++ b/spec/fixtures/licensing/license_scout/zlib/ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2011-2016 Luis Lavena and Mike Dalessio
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/spec/fixtures/licensing/license_scout/zlib/zlib-dependency-licenses.json
+++ b/spec/fixtures/licensing/license_scout/zlib/zlib-dependency-licenses.json
@@ -1,0 +1,32 @@
+{
+  "license_manifest_version": 1,
+  "project_name": "zlib",
+  "dependency_managers": {
+    "ruby_bundler": [
+      {
+        "name": "inifile",
+        "version": "3.0.0",
+        "license": "MIT",
+        "license_files": [
+          "ruby_bundler-inifile-3.0.0-README.md"
+        ]
+      },
+      {
+        "name": "mime-types",
+        "version": "3.1",
+        "license": "MIT",
+        "license_files": [
+          "ruby_bundler-mime-types-3.1-Licence.rdoc"
+        ]
+      },
+      {
+        "name": "mini_portile2",
+        "version": "2.1.0",
+        "license": "MIT",
+        "license_files": [
+          "ruby_bundler-mini_portile2-2.1.0-LICENSE.txt"
+        ]
+      }
+    ]
+  }
+}

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -102,6 +102,7 @@ module Omnibus
       Software.new(project, "private_code.rb").evaluate do
         name "private_code"
         default_version "1.7.2"
+        skip_transitive_dependency_licensing true
       end
     end
 
@@ -109,6 +110,8 @@ module Omnibus
       Software.new(project, "zlib.rb").evaluate do
         name "zlib"
         default_version "1.7.2"
+        skip_transitive_dependency_licensing true
+
         license "Zlib"
         license_file "LICENSE"
 
@@ -123,6 +126,8 @@ module Omnibus
       Software.new(project, "snoopy.rb").evaluate do
         name "snoopy"
         default_version "1.0.0"
+        skip_transitive_dependency_licensing true
+
         license "GPL v2"
         license_file "http://dev.perl.org/licenses/artistic.html"
         license_file "NOTICE"
@@ -134,17 +139,20 @@ module Omnibus
         name "preparation"
         default_version "1.0.0"
         license :project_license
+        skip_transitive_dependency_licensing true
       end
     end
 
     let(:software_with_warnings) { nil }
 
+    let(:softwares) do
+      s = [preparation, snoopy, zlib, private_code]
+      s << software_with_warnings if software_with_warnings
+      s
+    end
+
     def create_licenses
-      project.library.component_added(preparation)
-      project.library.component_added(snoopy)
-      project.library.component_added(zlib)
-      project.library.component_added(private_code)
-      project.library.component_added(software_with_warnings) if software_with_warnings
+      softwares.each { |s| project.library.component_added(s) }
 
       Licensing.create_incrementally(project) do |licensing|
         project.softwares.each do |software|
@@ -156,13 +164,20 @@ module Omnibus
     describe "prepare step" do
 
       let(:licenses_dir) { File.join(install_dir, "LICENSES") }
-
       let(:dot_gitkeep) { File.join(licenses_dir, ".gitkeep") }
+      let(:cache_dir) { File.join(install_dir, "license-cache") }
+      let(:cache_dot_gitkeep) { File.join(licenses_dir, ".gitkeep") }
 
       it "creates a LICENSES dir with a .gitkeep file inside the install directory" do
         Licensing.new(project).prepare
         expect(File).to exist(licenses_dir)
         expect(File).to exist(dot_gitkeep)
+      end
+
+      it "creates a licenses-cache dir with a .gitkeep file inside the install directory" do
+        Licensing.new(project).prepare
+        expect(File).to exist(cache_dir)
+        expect(File).to exist(cache_dot_gitkeep)
       end
 
     end
@@ -215,6 +230,7 @@ module Omnibus
           name "problematic"
           default_version "0.10.2"
           license_file "NOT_EXISTS"
+          skip_transitive_dependency_licensing true
         end
       end
 
@@ -236,6 +252,7 @@ module Omnibus
           name "problematic"
           default_version "0.10.2"
           license_file "https://downloads.chef.io/LICENSE"
+          skip_transitive_dependency_licensing true
         end
       end
 
@@ -254,6 +271,7 @@ module Omnibus
           name "problematic"
           default_version "0.10.2"
           license "Zlib"
+          skip_transitive_dependency_licensing true
         end
       end
 
@@ -288,6 +306,241 @@ module Omnibus
       it "fails the omnibus build" do
         expect { create_licenses }.to raise_error(Omnibus::LicensingError, /Project 'test-project' does not contain licensing information.\s{1,}Software 'private_code' does not contain licensing information./)
       end
+    end
+
+    describe "when all software is setting skip_transitive_dependency_licensing " do
+      # This is achieved by the default values of the let() parameters
+
+      it "does not collect transitive licensing info for any software" do
+        softwares.each { |s| project.library.component_added(s) }
+
+        Licensing.create_incrementally(project) do |licensing|
+          expect(licensing).not_to receive(:collect_transitive_dependency_licenses_for)
+
+          project.softwares.each do |software|
+            licensing.execute_post_build(software)
+          end
+        end
+      end
+    end
+
+    describe "when a project has transitive dependencies" do
+      let(:license) { "Custom Chef" }
+      let(:license_file_path) { "CHEF.LICENSE" }
+      let(:license_file) { "CUSTOM_CHEF" }
+
+      let(:expected_project_license_path) { license_file_path }
+
+      let(:softwares) { [zlib] }
+
+      before do
+        File.open(File.join(Config.project_root, license_file), "w+") do |f|
+          f.puts "Chef Custom License is awesome."
+        end
+      end
+
+      after do
+        FileUtils.rm_rf(license_file)
+      end
+
+      let(:zlib) do
+        Software.new(project, "zlib.rb").evaluate do
+          name "zlib"
+          default_version "1.7.2"
+
+          license "Zlib"
+          license_file "LICENSE"
+        end
+      end
+
+      let(:snoopy) do
+        Software.new(project, "snoopy.rb").evaluate do
+          name "snoopy"
+          default_version "1.0.0"
+
+          license "GPL v2"
+          license_file "NOTICE"
+        end
+      end
+
+      let(:license_fixtures_path) { File.join(fixtures_path, "licensing/license_scout") }
+
+      describe "when project type is not supported" do
+
+        before do
+          allow_any_instance_of(LicenseScout::Collector).to receive(:run) do
+            raise LicenseScout::Exceptions::UnsupportedProjectType.new("/path/to/project")
+          end
+        end
+
+        it "does not raise an error" do
+          expect { create_licenses }.not_to raise_error
+        end
+
+        it "logs a warning message" do
+          output = capture_logging { create_licenses }
+          expect(output).to include("is not supported project type for transitive dependency license collection")
+        end
+
+        context "with :fatal_licensing_warnings" do
+
+          before do
+            Omnibus::Config.fatal_licensing_warnings(true)
+          end
+
+          it "does not fail omnibus build" do
+            expect { create_licenses }.not_to raise_error
+          end
+        end
+
+        context "with :fatal_transitive_dependency_licensing_warnings" do
+
+          before do
+            Omnibus::Config.fatal_transitive_dependency_licensing_warnings(true)
+          end
+
+          it "fails omnibus build" do
+            expect { create_licenses }.to raise_error(Omnibus::LicensingError, /is not supported project type for transitive dependency license collection/)
+          end
+        end
+      end
+
+      describe "when there are warnings in the licensing info" do
+        before do
+          allow_any_instance_of(LicenseScout::Collector).to receive(:run)
+          allow_any_instance_of(LicenseScout::Collector).to receive(:issue_report).and_return(["This is a licensing warning!!!"])
+        end
+
+        it "logs the warnings" do
+          output = capture_logging { create_licenses }
+          expect(output).to include("This is a licensing warning!!!")
+        end
+      end
+
+      describe "when there are no warnings in the licensing info" do
+        before do
+          allow_any_instance_of(LicenseScout::Collector).to receive(:run) do
+            FileUtils.cp_r(File.join(license_fixtures_path, "zlib"), File.join(install_dir, "license-cache/"))
+          end
+
+          allow_any_instance_of(LicenseScout::Collector).to receive(:issue_report).and_return([])
+        end
+
+        let(:expected_license_files) {
+          %w{
+            ruby_bundler-inifile-3.0.0-README.md
+            ruby_bundler-mime-types-3.1-Licence.rdoc
+            ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
+          }
+        }
+
+        let(:expected_license_texts) {
+          [
+            <<-EOH,
+This product includes inifile 3.0.0
+which is a 'ruby_bundler' dependency of 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-inifile-3.0.0-README.md
+EOH
+            <<-EOH,
+This product includes mime-types 3.1
+which is a 'ruby_bundler' dependency of 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-mime-types-3.1-Licence.rdoc
+EOH
+            <<-EOH,
+This product includes mini_portile2 2.1.0
+which is a 'ruby_bundler' dependency of 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
+EOH
+          ]
+        }
+
+        it "includes transitive dependency license information in the project license information" do
+          create_licenses
+
+          project_license = File.join(install_dir, expected_project_license_path)
+          expect(File.exist?(project_license)).to be(true)
+          project_license_content = File.read(project_license)
+
+          expected_license_texts.each { |t| expect(project_license_content).to include(t) }
+          expected_license_files.each { |f| expect(File).to exist(File.join(install_dir, "LICENSES", f)) }
+          expect(File).not_to exist(File.join(install_dir, "license-cache"))
+        end
+      end
+
+      describe "with multiple softwares that have dependencies" do
+        let(:softwares) { [zlib, snoopy] }
+
+        before do
+          allow_any_instance_of(LicenseScout::Collector).to receive(:run) do
+            FileUtils.cp_r(File.join(license_fixtures_path, "zlib"), File.join(install_dir, "license-cache/"))
+            FileUtils.cp_r(File.join(license_fixtures_path, "snoopy"), File.join(install_dir, "license-cache/"))
+          end
+
+          allow_any_instance_of(LicenseScout::Collector).to receive(:issue_report).and_return([])
+        end
+
+        let(:expected_license_files) {
+          %w{
+            ruby_bundler-inifile-3.0.0-README.md
+            ruby_bundler-mime-types-3.1-Licence.rdoc
+            ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
+          }
+        }
+
+        let(:expected_license_texts) {
+          [
+            <<-EOH,
+This product includes inifile 3.0.0
+which is a 'ruby_bundler' dependency of 'snoopy', 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-inifile-3.0.0-README.md
+EOH
+            <<-EOH,
+This product includes mime-types 3.1
+which is a 'ruby_bundler' dependency of 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-mime-types-3.1-Licence.rdoc
+EOH
+            <<-EOH,
+This product includes mini_portile2 2.1.0
+which is a 'ruby_bundler' dependency of 'zlib',
+and which is available under a 'MIT' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
+EOH
+            <<-EOH,
+This product includes bundler-audit 0.5.0
+which is a 'ruby_bundler' dependency of 'snoopy',
+and which is available under a 'GPLv3' License.
+For details, see:
+#{install_dir}/LICENSES/ruby_bundler-bundler-audit-0.5.0-COPYING.txt
+EOH
+
+          ]
+        }
+
+        it "includes merged licensing information from multiple software definitions" do
+          create_licenses
+
+          project_license = File.join(install_dir, expected_project_license_path)
+          expect(File.exist?(project_license)).to be(true)
+          project_license_content = File.read(project_license)
+
+          expected_license_texts.each { |t| expect(project_license_content).to include(t) }
+          expected_license_files.each { |f| expect(File).to exist(File.join(install_dir, "LICENSES", f)) }
+          expect(File).not_to exist(File.join(install_dir, "license-cache"))
+        end
+
+      end
+
     end
   end
 end

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -303,28 +303,28 @@ module Omnibus
       it "invokes patch with patch level 1 unless specified" do
         expect { subject.patch(source: "good_patch") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch with patch level provided" do
         expect { subject.patch(source: "good_patch", plevel: 0) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch differently if target is provided" do
         expect { subject.patch(source: "good_patch", target: "target/path") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true)
+          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "persists other options" do
         expect { subject.patch(source: "good_patch", timeout: 3600) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
     end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -41,6 +41,7 @@ module Omnibus
     it_behaves_like "a cleanroom setter", :version, %{version '1.2.3'}
     it_behaves_like "a cleanroom setter", :license, %{license 'Apache 2.0'}
     it_behaves_like "a cleanroom setter", :license_file, %{license_file 'LICENSES/artistic.txt'}
+    it_behaves_like "a cleanroom setter", :skip_transitive_dependency_licensing, %{skip_transitive_dependency_licensing true}
     it_behaves_like "a cleanroom setter", :whitelist_file, %{whitelist_file '/opt/whatever'}
     it_behaves_like "a cleanroom setter", :relative_path, %{relative_path '/path/to/extracted'}
     it_behaves_like "a cleanroom setter", :build, %|build {}|

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -334,12 +334,13 @@ module Omnibus
         context "in 32-bit mode" do
           it "sets the default" do
             expect(subject.with_standard_compiler_flags).to eq(
-              "CFLAGS"          => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
-              "LDFLAGS"         => "-L/opt/project/embedded/lib -m32 -fno-lto",
+              "CFLAGS"          => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+              "LDFLAGS"         => "-L/opt/project/embedded/lib -m32 -Wl,-rpath,/opt/project/embedded/lib",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
             )
           end
         end
@@ -349,12 +350,13 @@ module Omnibus
 
           it "sets the default" do
             expect(subject.with_standard_compiler_flags).to eq(
-              "CFLAGS"          => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
-              "LDFLAGS"         => "-L/opt/project/embedded/lib -m64 -fno-lto",
+              "CFLAGS"          => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+              "LDFLAGS"         => "-L/opt/project/embedded/lib -m64 -Wl,-rpath,/opt/project/embedded/lib",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
             )
           end
         end
@@ -413,21 +415,28 @@ module Omnibus
         let(:separator) { ";" }
         let(:path) { "c:/Ruby193/bin;c:/Windows/system32;c:/Windows;c:/Windows/System32/Wbem" }
         let(:install_dir) { "c:/opt/project" }
-        let(:prepended_path_msys) do
-          [ "#{install_dir}/bin", separator, "#{install_dir}/embedded/bin", separator,
-            "#{install_dir}/embedded/msys/1.0/bin", separator, path].join
+
+        context "`Path` exists in the environment instead of PATH" do
+          before do
+            stub_env("Path", path)
+            allow(ENV).to receive(:keys).and_return(%w{ Path })
+          end
+
+          it "returns a path key of `Path`" do
+            expect(subject.with_embedded_path).to include(
+              "Path" => prepended_path
+            )
+          end
         end
 
-        context "`Path` exists in the environment" do
+        context "Multiple Paths exist" do
           before do
             stub_env("Path", path)
             allow(ENV).to receive(:keys).and_return(%w{ Path PATH })
           end
 
-          it "returns a path key of `Path`" do
-            expect(subject.with_embedded_path).to eq(
-              "Path" => prepended_path
-            )
+          it "raises an error" do
+            expect { subject.with_embedded_path }.to raise_error("The current omnibus environment has duplicate PATHs")
           end
         end
 
@@ -437,7 +446,7 @@ module Omnibus
           end
 
           it "returns a path key of `PATH`" do
-            expect(subject.with_embedded_path).to eq(
+            expect(subject.with_embedded_path).to include(
               "PATH" => prepended_path
             )
           end


### PR DESCRIPTION
🚧 👷 

This branch (and PR) is being used to test Chef Client with transitive dependency licensing code. 

- [ ] Separately merge @ksubrama's changes (We need them in order to be able to test these changes with Chef Client, the first project to use this feature).
- [x] Run an ad_hoc build of Chef Client from this branch and make sure we have a successful build: http://manhattan.ci.chef.co/job/chef-trigger-ad_hoc/157/downstreambuildview/

--------------------------------------------------
/cc @chef/omnibus-maintainers
