### PR TITLE
Ensure compatibility of code and git cache entries

### DIFF
--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -22,6 +22,18 @@ module Omnibus
     include Util
     include Logging
 
+    # The serial number represents compatibility of a cache entry with the
+    # current version of the omnibus code base. Any time a change is made to
+    # omnibus that makes the code incompatible with any cache entries created
+    # before the code change, the serial number should be incremented.
+    #
+    # For example, if a code change generates content in the `install_dir`
+    # before cache snapshots are taken, any snapshots created before upgrade
+    # will not have the generated content, so these snapshots would be
+    # incompatible with the current omnibus codebase. Incrementing the serial
+    # number ensures these old shapshots will not be used in subsequent builds.
+    SERIAL_NUMBER = 1
+
     REQUIRED_GIT_FILES = %w{
 HEAD
 description
@@ -98,7 +110,7 @@ refs}.freeze
       # dependencies, including the on currently being acted upon.
       shasums = [dep_list.map(&:shasum), software.shasum].flatten
       suffix  = Digest::SHA256.hexdigest(shasums.join("|"))
-      @tag    = "#{software.name}-#{suffix}"
+      @tag    = "#{software.name}-#{suffix}-#{SERIAL_NUMBER}"
 
       log.internal(log_key) { "tag: #{@tag}" }
 

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -43,6 +43,8 @@ module Omnibus
 
     let(:cache_path) { File.join("/var/cache/omnibus/cache/git_cache", install_dir) }
 
+    let(:cache_serial_number) { described_class::SERIAL_NUMBER }
+
     let(:ipc) do
       project.library.component_added(preparation)
       project.library.component_added(snoopy)
@@ -58,7 +60,7 @@ module Omnibus
 
     describe '#tag' do
       it "returns the correct tag" do
-        expect(ipc.tag).to eql("zlib-24a8ec71da04059dcf7ed3c6e8e0fd9d155476abe4b5156d1f13c42e85478c2b")
+        expect(ipc.tag).to eql("zlib-24a8ec71da04059dcf7ed3c6e8e0fd9d155476abe4b5156d1f13c42e85478c2b-#{cache_serial_number}")
       end
 
       describe "with no deps" do
@@ -67,7 +69,7 @@ module Omnibus
         end
 
         it "returns the correct tag" do
-          expect(ipc.tag).to eql("zlib-ee71fc1a512f03b9dd46c1fd9b5ab71fcc51b638857bf328496a31abb2654c2b")
+          expect(ipc.tag).to eql("zlib-ee71fc1a512f03b9dd46c1fd9b5ab71fcc51b638857bf328496a31abb2654c2b-#{cache_serial_number}")
         end
       end
     end


### PR DESCRIPTION
### Description

Some code changes in omnibus can be incompatible with previously
existing git cache entries, such that builds are incorrect or fail if
the older git cache snapshot is restored in a build that is run after
upgrading omnibus. Adding a serial number to the git cache allows
omnibus to determine whether a git cache snapshot is compatible with the
current version of omnibus in use.

Note: merging this change will effectively clear the cache for every project once the project upgrades.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
