### PR TITLE
Add a checklist for reviewers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,3 +4,14 @@ Briefly describe the new feature or fix here
 
 --------------------------------------------------
 /cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
+
+#### Maintainers
+
+Please ensure that you check for:
+
+- [] If this change impacts git cache validity, it bumps the git cache
+  serial number
+- [] If this change impacts compatibility with omnibus-software, the
+  corresponding change is reviewed and there is a release plan
+- [] If this change impacts compatibility with the omnibus cookbook, the
+  corresponding change is reviewed and there is a release plan


### PR DESCRIPTION
### Description

Opening this up for discussion. My primary concern is to make it more likely that we bump the git cache serial number when we're supposed to. Are there other things we should look for? Is this a smart way to go about it?

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
