### PR TITLE
Update chefstyle and fix issues

### DIFF
--- a/lib/omnibus/core_extensions/open_uri.rb
+++ b/lib/omnibus/core_extensions/open_uri.rb
@@ -64,6 +64,7 @@ module OpenURI
   #
   # @see http://winstonyw.com/2013/10/02/openuris_open_tempfile_and_stringio/
   #
+  # rubocop:disable Style/ConstantName
   class Buffer
     remove_const :StringMax
     StringMax = 0

--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -67,14 +67,14 @@ module Omnibus
             rate_scale: ->(rate) { rate / 1024 }
           )
 
-          options[:content_length_proc] = ->(total) {
+          options[:content_length_proc] = ->(total) do
             reported_total = total
             progress_bar.total = total
-          }
-          options[:progress_proc] = ->(step) {
+          end
+          options[:progress_proc] = ->(step) do
             downloaded_amount = reported_total ? [step, reported_total].min : step
             progress_bar.progress = downloaded_amount
-          }
+          end
         end
 
         file = open(from_url, options)

--- a/lib/omnibus/fetchers/git_fetcher.rb
+++ b/lib/omnibus/fetchers/git_fetcher.rb
@@ -214,7 +214,6 @@ module Omnibus
     end
 
     # Class methods
-    public
 
     # Return the SHA1 corresponding to a ref as determined by the remote source.
     #

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -144,8 +144,7 @@ module Omnibus
             end
           end
         else
-          raise RuntimeError,
-            "Unknown file type: `File.ftype(source_file)' at `#{source_file}'!"
+          raise "Unknown file type: `File.ftype(source_file)' at `#{source_file}'!"
         end
       end
 

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -128,8 +128,6 @@ module Omnibus
       from_hash(hash)
     end
 
-    private
-
     #
     # Utility function to convert a Hash with String keys to a Hash
     # with Symbol keys, recursively.

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -368,7 +368,7 @@ module Omnibus
     def build_version(val = NULL, &block)
       if block && !null?(val)
         raise Error, "You cannot specify additional parameters to " \
-          '#build_version when a block is given!'
+          "#build_version when a block is given!"
       end
 
       if block

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -454,7 +454,7 @@ module Omnibus
       rescue ArgumentError
         log.warn(log_key) do
           "Version #{final_version} for software #{name} was not parseable. " \
-          'Comparison methods such as #satisfies? will not be available for this version.'
+          "Comparison methods such as #satisfies? will not be available for this version."
         end
         final_version
       end

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -100,7 +100,7 @@ module Omnibus
     let(:project_name) { "example" }
     let(:project_dir) { File.join(source_dir, project_name) }
 
-    describe '#command' do
+    describe "#command" do
       it "executes the command" do
         subject.command("echo 'Hello World!'")
 
@@ -109,13 +109,13 @@ module Omnibus
       end
     end
 
-    describe '#make' do
+    describe "#make" do
       it "is waiting for a good samaritan to write tests" do
         skip
       end
     end
 
-    describe '#patch' do
+    describe "#patch" do
       it "applies the patch" do
         configure = File.join(project_dir, "configure")
         File.open(configure, "w") do |f|
@@ -149,7 +149,7 @@ module Omnibus
       end
     end
 
-    describe '#ruby' do
+    describe "#ruby" do
       it "executes the command as the embdedded ruby" do
         ruby = File.join(scripts_dir, "setup.rb")
         File.open(ruby, "w") do |f|
@@ -169,7 +169,7 @@ module Omnibus
       end
     end
 
-    describe '#gem' do
+    describe "#gem" do
       it "executes the command as the embedded gem" do
         make_gemspec
         fake_embedded_bin("gem")
@@ -186,7 +186,7 @@ module Omnibus
       end
     end
 
-    describe '#bundler' do
+    describe "#bundler" do
       it "executes the command as the embedded bundler" do
         make_gemspec
         make_gemfile
@@ -200,7 +200,7 @@ module Omnibus
       end
     end
 
-    describe '#appbundle' do
+    describe "#appbundle" do
       let(:project) { double("Project") }
       let(:project_softwares) { [ double("Software", name: project_name, project_dir: project_dir) ] }
       it "executes the command as the embedded appbundler" do
@@ -226,7 +226,7 @@ module Omnibus
       end
     end
 
-    describe '#rake' do
+    describe "#rake" do
       it "executes the command as the embedded rake" do
         rakefile = File.join(project_dir, "Rakefile")
         File.open(rakefile, "w") do |f|
@@ -246,7 +246,7 @@ module Omnibus
       end
     end
 
-    describe '#block' do
+    describe "#block" do
       it "executes the command as a block" do
         subject.block("A complex operation") do
           FileUtils.touch("#{project_dir}/bacon")
@@ -258,7 +258,7 @@ module Omnibus
       end
     end
 
-    describe '#erb' do
+    describe "#erb" do
       it "renders the erb" do
         erb = File.join(templates_dir, "example.erb")
         File.open(erb, "w") do |f|
@@ -282,7 +282,7 @@ module Omnibus
       end
     end
 
-    describe '#mkdir' do
+    describe "#mkdir" do
       it "creates the directory" do
         path = File.join(tmp_path, "scratch")
         remove_directory(path)
@@ -294,7 +294,7 @@ module Omnibus
       end
     end
 
-    describe '#touch' do
+    describe "#touch" do
       it "creates the file" do
         path = File.join(tmp_path, "file")
         remove_file(path)
@@ -316,7 +316,7 @@ module Omnibus
       end
     end
 
-    describe '#delete' do
+    describe "#delete" do
       it "deletes the directory" do
         path = File.join(tmp_path, "scratch")
         create_directory(path)
@@ -351,7 +351,7 @@ module Omnibus
       end
     end
 
-    describe '#copy' do
+    describe "#copy" do
       it "copies the file" do
         path_a = File.join(tmp_path, "file1")
         path_b = File.join(tmp_path, "file2")
@@ -404,7 +404,7 @@ module Omnibus
       end
     end
 
-    describe '#move' do
+    describe "#move" do
       it "moves the file" do
         path_a = File.join(tmp_path, "file1")
         path_b = File.join(tmp_path, "file2")
@@ -461,7 +461,7 @@ module Omnibus
       end
     end
 
-    describe '#link', :not_supported_on_windows do
+    describe "#link", :not_supported_on_windows do
       it "links the file" do
         path_a = File.join(tmp_path, "file1")
         path_b = File.join(tmp_path, "file2")
@@ -504,7 +504,7 @@ module Omnibus
       end
     end
 
-    describe '#sync' do
+    describe "#sync" do
       let(:source) do
         source = File.join(tmp_path, "source")
         FileUtils.mkdir_p(source)
@@ -607,7 +607,7 @@ module Omnibus
       end
     end
 
-    describe '#update_config_guess', :not_supported_on_windows do
+    describe "#update_config_guess", :not_supported_on_windows do
       let(:config_guess_dir) { "#{install_dir}/embedded/lib/config_guess" }
 
       before do

--- a/spec/functional/fetchers/git_fetcher_spec.rb
+++ b/spec/functional/fetchers/git_fetcher_spec.rb
@@ -24,7 +24,7 @@ module Omnibus
 
     let(:revision) { shellout!("git rev-parse HEAD", cwd: project_dir).stdout.strip }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
       context "when the repo is not cloned" do
         it "return true" do
           expect(subject.fetch_required?).to be_truthy
@@ -56,13 +56,13 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       it "includes the current revision" do
         expect(subject.version_guid).to match(/^git:[0-9a-f]{40}/)
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       before do
         subject.fetch
       end
@@ -105,7 +105,7 @@ module Omnibus
       end
     end
 
-    describe '#fetch'  do
+    describe "#fetch"  do
       let(:version)  { "v1.2.4" }
       let(:remote)   { remote_git_repo("zlib", annotated_tags: [version]) }
       let(:manifest_entry) do
@@ -124,7 +124,7 @@ module Omnibus
       end
     end
 
-    describe '#resolve_version' do
+    describe "#resolve_version" do
       context "when the version is a tag" do
         let(:version)  { "v1.2.3" }
         let(:remote)   { remote_git_repo("zlib", tags: [version]) }
@@ -180,7 +180,7 @@ module Omnibus
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       it "includes the resolved revision" do
         expect(subject.version_for_cache).to eq("revision:45ded6d3b1a35d66ed866b2c3eb418426e6382b0")
       end

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -37,7 +37,7 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
       context "when the file is not downloaded" do
         it "return true" do
           expect(subject.fetch_required?).to be_truthy
@@ -62,7 +62,7 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       context "source with md5" do
         it "includes the md5 digest" do
           expect(subject.version_guid).to eq("md5:#{source_md5}")
@@ -100,7 +100,7 @@ module Omnibus
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       before { fetch! }
 
       context "when the project directory exists" do
@@ -157,7 +157,7 @@ module Omnibus
       end
     end
 
-    describe '#fetch' do
+    describe "#fetch" do
       context "source with md5" do
         it "downloads the file" do
           fetch!
@@ -265,7 +265,7 @@ module Omnibus
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       before do
         create_file("#{project_dir}/file_a")
         create_file("#{project_dir}/file_b")

--- a/spec/functional/fetchers/path_fetcher_spec.rb
+++ b/spec/functional/fetchers/path_fetcher_spec.rb
@@ -24,7 +24,7 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
       context "when the directories have different files" do
         before do
           create_file("#{source_path}/directory/file") { "different" }
@@ -48,7 +48,7 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       it "includes the source path" do
         expect(subject.version_guid).to eq("path:#{source_path}")
       end
@@ -82,13 +82,13 @@ module Omnibus
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       it "returns true" do
         expect(subject.clean).to be_truthy
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       before do
         create_file("#{source_path}/file_a")
         create_file("#{source_path}/file_b")
@@ -102,7 +102,7 @@ module Omnibus
       end
     end
 
-    describe '#resolve_version' do
+    describe "#resolve_version" do
       it "just returns the version" do
         expect(NetFetcher.resolve_version("1.2.3", source)).to eq("1.2.3")
       end

--- a/spec/functional/file_syncer_spec.rb
+++ b/spec/functional/file_syncer_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 module Omnibus
   describe FileSyncer do
-    describe '#glob' do
+    describe "#glob" do
       before do
         FileUtils.mkdir_p(File.join(tmp_path, "folder"))
         FileUtils.mkdir_p(File.join(tmp_path, ".hidden_folder"))
@@ -39,7 +39,7 @@ module Omnibus
       end
     end
 
-    describe '#sync' do
+    describe "#sync" do
       let(:source) do
         source = File.join(tmp_path, "source")
         FileUtils.mkdir_p(source)
@@ -77,21 +77,21 @@ module Omnibus
 
       context "when destination file exists" do
 
-        let(:source) {
+        let(:source) do
           s = File.join(tmp_path, "source")
           FileUtils.mkdir_p(s)
           p = create_file(s, "read-only-file") { "new" }
           FileUtils.chmod(0400, p)
           s
-        }
+        end
 
-        let(:destination) {
+        let(:destination) do
           dest = File.join(tmp_path, "destination")
           FileUtils.mkdir_p(dest)
           create_file(dest, "read-only-file") { "old" }
           FileUtils.chmod(0400, File.join(dest, "read-only-file"))
           dest
-        }
+        end
 
         it "copies over a read-only file" do
           described_class.sync(source, destination)

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -426,15 +426,15 @@ module Omnibus
           allow_any_instance_of(LicenseScout::Collector).to receive(:issue_report).and_return([])
         end
 
-        let(:expected_license_files) {
+        let(:expected_license_files) do
           %w{
             ruby_bundler-inifile-3.0.0-README.md
             ruby_bundler-mime-types-3.1-Licence.rdoc
             ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
           }
-        }
+        end
 
-        let(:expected_license_texts) {
+        let(:expected_license_texts) do
           [
             <<-EOH,
 This product includes inifile 3.0.0
@@ -458,7 +458,7 @@ For details, see:
 #{install_dir}/LICENSES/ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
 EOH
           ]
-        }
+        end
 
         it "includes transitive dependency license information in the project license information" do
           create_licenses
@@ -485,15 +485,15 @@ EOH
           allow_any_instance_of(LicenseScout::Collector).to receive(:issue_report).and_return([])
         end
 
-        let(:expected_license_files) {
+        let(:expected_license_files) do
           %w{
             ruby_bundler-inifile-3.0.0-README.md
             ruby_bundler-mime-types-3.1-Licence.rdoc
             ruby_bundler-mini_portile2-2.1.0-LICENSE.txt
           }
-        }
+        end
 
-        let(:expected_license_texts) {
+        let(:expected_license_texts) do
           [
             <<-EOH,
 This product includes inifile 3.0.0
@@ -525,7 +525,7 @@ For details, see:
 EOH
 
           ]
-        }
+        end
 
         it "includes merged licensing information from multiple software definitions" do
           create_licenses

--- a/spec/functional/templating_spec.rb
+++ b/spec/functional/templating_spec.rb
@@ -8,7 +8,7 @@ module Omnibus
   describe Templating do
     subject { RandomClass.new }
 
-    describe '#render_template' do
+    describe "#render_template" do
       let(:source)      { File.join(tmp_path, "source.erb") }
       let(:destination) { File.join(tmp_path, "final") }
       let(:mode)        { 0644 }

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -185,7 +185,7 @@ module Omnibus
       end
     end
 
-    describe '#initialize `path` parameter' do
+    describe "#initialize `path` parameter" do
       let(:path) { "/some/fake/path" }
       subject(:build_version) { BuildVersion.new(path) }
 

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -28,121 +28,121 @@ module Omnibus
       end
     end
 
-    describe '#command' do
+    describe "#command" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:command)
       end
     end
 
-    describe '#workers' do
+    describe "#workers" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:workers)
       end
     end
 
-    describe '#ruby' do
+    describe "#ruby" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:ruby)
       end
     end
 
-    describe '#gem' do
+    describe "#gem" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:gem)
       end
     end
 
-    describe '#bundle' do
+    describe "#bundle" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:bundle)
       end
     end
 
-    describe '#appbundle' do
+    describe "#appbundle" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:appbundle)
       end
     end
 
-    describe '#block' do
+    describe "#block" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:block)
       end
     end
 
-    describe '#erb' do
+    describe "#erb" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:erb)
       end
     end
 
-    describe '#mkdir' do
+    describe "#mkdir" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:mkdir)
       end
     end
 
-    describe '#touch' do
+    describe "#touch" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:touch)
       end
     end
 
-    describe '#delete' do
+    describe "#delete" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:delete)
       end
     end
 
-    describe '#copy' do
+    describe "#copy" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:copy)
       end
     end
 
-    describe '#move' do
+    describe "#move" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:move)
       end
     end
 
-    describe '#link' do
+    describe "#link" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:link)
       end
     end
 
-    describe '#sync' do
+    describe "#sync" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:sync)
       end
     end
 
-    describe '#update_config_guess' do
+    describe "#update_config_guess" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:update_config_guess)
       end
     end
 
-    describe '#windows_safe_path' do
+    describe "#windows_safe_path" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:windows_safe_path)
       end
     end
 
-    describe '#project_dir' do
+    describe "#project_dir" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:project_dir)
       end
     end
 
-    describe '#install_dir' do
+    describe "#install_dir" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:install_dir)
       end
     end
 
-    describe '#make' do
+    describe "#make" do
       before do
         allow(subject).to receive(:command)
       end
@@ -205,7 +205,7 @@ module Omnibus
       end
     end
 
-    describe '#configure' do
+    describe "#configure" do
       before do
         allow(subject).to receive(:command)
       end
@@ -287,7 +287,7 @@ module Omnibus
       end
     end
 
-    describe '#patch' do
+    describe "#patch" do
       before do
         allow(subject).to receive(:find_file)
           .with("config/patches", "good_patch")
@@ -331,11 +331,11 @@ module Omnibus
 
     describe "#shasum" do
       let(:build_step) do
-        Proc.new {
+        Proc.new do
           block do
             command("true")
           end
-        }
+        end
       end
 
       let(:tmp_dir) { Dir.mktmpdir }

--- a/spec/unit/changelogprinter_spec.rb
+++ b/spec/unit/changelogprinter_spec.rb
@@ -14,30 +14,32 @@ module Omnibus
         })
       end
 
-      let(:changelog) { double(ChangeLog,
+      let(:changelog) do
+        double(ChangeLog,
                                changelog_entries: %w{entry1 entry2},
-                               authors: %w{alice bob}) }
-      let(:git_changelog) { double(ChangeLog,
+                               authors: %w{alice bob}) end
+      let(:git_changelog) do
+        double(ChangeLog,
                                    changelog_entries:
-                                   %w{sub-entry1 sub-entry2}) }
+                                   %w{sub-entry1 sub-entry2}) end
       let(:now) { double(Time) }
       let(:emptydiff) { EmptyManifestDiff.new }
-      let(:old_manifest) {
+      let(:old_manifest) do
         m = Manifest.new()
         m.add("updated-comp", manifest_entry_for("updated-comp", "v9", "v9"))
         m.add("updated-comp-2", manifest_entry_for("updated-comp-2", "someref0", "someref0", :git))
         m.add("removed-comp", manifest_entry_for("removed-comp", "v9", "v9"))
         m.add("removed-comp-2", manifest_entry_for("removed-comp-2", "v10", "v10"))
         m
-      }
-      let(:new_manifest) {
+      end
+      let(:new_manifest) do
         m = Manifest.new()
         m.add("updated-comp", manifest_entry_for("updated-comp", "v10", "v10"))
         m.add("updated-comp-2", manifest_entry_for("updated-comp-2", "someotherref", "someotherref", :git))
         m.add("added-comp", manifest_entry_for("added-comp", "v100", "v100"))
         m.add("added-comp-2", manifest_entry_for("added-comp-2", "v101", "v101"))
         m
-      }
+      end
       let(:diff) { ManifestDiff.new(old_manifest, new_manifest) }
 
       it "starts with a changelog version header including the time" do

--- a/spec/unit/cleanroom_spec.rb
+++ b/spec/unit/cleanroom_spec.rb
@@ -17,11 +17,11 @@ module Omnibus
 
     let(:instance) { klass.new }
 
-    describe '#evaluate' do
+    describe "#evaluate" do
       it "exposes public methods" do
-        expect {
+        expect do
           instance.evaluate("exposed_method")
-        }.to_not raise_error
+        end.to_not raise_error
       end
 
       it "calls exposed methods on the instance" do
@@ -30,13 +30,13 @@ module Omnibus
       end
 
       it "does not expose unexposed methods" do
-        expect {
+        expect do
           instance.evaluate("unexposed_method")
-        }.to raise_error(NameError)
+        end.to raise_error(NameError)
       end
     end
 
-    describe '#evaluate_file' do
+    describe "#evaluate_file" do
       let(:contents) do
         <<-EOH.gsub(/^ {10}/, "")
           exposed_method

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -33,7 +33,7 @@ module Omnibus
       allow(subject).to receive(:shellout!)
     end
 
-    describe '#window_bounds' do
+    describe "#window_bounds" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:window_bounds)
       end
@@ -43,7 +43,7 @@ module Omnibus
       end
     end
 
-    describe '#pkg_position' do
+    describe "#pkg_position" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:pkg_position)
       end
@@ -53,19 +53,19 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :dmg" do
         expect(subject.id).to eq(:dmg)
       end
     end
 
-    describe '#resources_dir' do
+    describe "#resources_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.resources_dir).to eq("#{staging_dir}/Resources")
       end
     end
 
-    describe '#clean_disks' do
+    describe "#clean_disks" do
       it "logs a message" do
         allow(subject).to receive(:shellout!)
           .and_return(double(Mixlib::ShellOut, stdout: ""))
@@ -75,7 +75,7 @@ module Omnibus
       end
     end
 
-    describe '#create_writable_dmg' do
+    describe "#create_writable_dmg" do
       it "logs a message" do
         output = capture_logging { subject.create_writable_dmg }
         expect(output).to include("Creating writable dmg")
@@ -98,7 +98,7 @@ module Omnibus
       end
     end
 
-    describe '#attach_dmg' do
+    describe "#attach_dmg" do
       before do
         allow(subject).to receive(:shellout!)
           .and_return(shellout)
@@ -129,7 +129,7 @@ module Omnibus
       end
     end
 
-    describe '#set_volume_icon' do
+    describe "#set_volume_icon" do
       it "logs a message" do
         output = capture_logging { subject.set_volume_icon }
         expect(output).to include("Setting volume icon")
@@ -165,7 +165,7 @@ module Omnibus
       end
     end
 
-    describe '#prettify_dmg' do
+    describe "#prettify_dmg" do
       it "logs a message" do
         output = capture_logging { subject.prettify_dmg }
         expect(output).to include("Making the dmg all pretty and stuff")
@@ -209,7 +209,7 @@ module Omnibus
       end
     end
 
-    describe '#compress_dmg' do
+    describe "#compress_dmg" do
       it "logs a message" do
         output = capture_logging { subject.compress_dmg }
         expect(output).to include("Compressing dmg")
@@ -237,7 +237,7 @@ module Omnibus
       end
     end
 
-    describe '#set_dmg_icon' do
+    describe "#set_dmg_icon" do
       it "logs a message" do
         output = capture_logging { subject.set_dmg_icon }
         expect(output).to include("Setting dmg icon")
@@ -265,7 +265,7 @@ module Omnibus
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it 'reflects the packager\'s unmodified package_name' do
         expect(subject.package_name).to eq("project-1.2.3-2.dmg")
       end
@@ -279,7 +279,7 @@ module Omnibus
       end
     end
 
-    describe '#writable_dmg' do
+    describe "#writable_dmg" do
       it "is in the staging_dir" do
         expect(subject.writable_dmg).to include(staging_dir)
       end
@@ -289,7 +289,7 @@ module Omnibus
       end
     end
 
-    describe '#volume_name' do
+    describe "#volume_name" do
       it "is the project friendly_name" do
         project.friendly_name("Friendly Bacon Bits")
         expect(subject.volume_name).to eq("Friendly Bacon Bits")

--- a/spec/unit/compressors/null_spec.rb
+++ b/spec/unit/compressors/null_spec.rb
@@ -7,13 +7,13 @@ module Omnibus
 
     subject { described_class.new(project) }
 
-    describe '#id' do
+    describe "#id" do
       it "is :dmg" do
         expect(subject.id).to eq(:null)
       end
     end
 
-    describe '#run!' do
+    describe "#run!" do
       it "does nothing" do
         expect(subject).to_not receive(:instance_eval)
         subject.run!

--- a/spec/unit/compressors/tgz_spec.rb
+++ b/spec/unit/compressors/tgz_spec.rb
@@ -36,13 +36,13 @@ module Omnibus
       allow(subject).to receive(:shellout!)
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it "returns the name of the packager" do
         expect(subject.package_name).to eq("project-1.2.3-2.pkg.tar.gz")
       end
     end
 
-    describe '#write_tgz' do
+    describe "#write_tgz" do
       before do
         File.open("#{staging_dir}/project-1.2.3-2.pkg", "wb") do |f|
           f.write " " * 1_000_000

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -46,7 +46,7 @@ module Omnibus
     include_examples "a configurable", :fetcher_retries, 5
     include_examples "a configurable", :fatal_licensing_warnings, false
 
-    describe '#workers' do
+    describe "#workers" do
       context "when the Ohai data is not present" do
         before do
           stub_ohai(platform: "ubuntu", version: "12.04") do |data|

--- a/spec/unit/digestable_spec.rb
+++ b/spec/unit/digestable_spec.rb
@@ -7,14 +7,14 @@ module Omnibus
 
     subject { Class.new { include Digestable }.new }
 
-    describe '#digest' do
+    describe "#digest" do
       it "reads the IO in chunks" do
         expect(File).to receive(:open).with(path).and_yield(io)
         expect(subject.digest(path)).to eq("d41d8cd98f00b204e9800998ecf8427e")
       end
     end
 
-    describe '#digest_directory' do
+    describe "#digest_directory" do
       let(:path)    { "/path/to/dir" }
       let(:glob)    { "#{path}/**/*" }
       let(:subdir)  { "/path/to/dir/subdir" }

--- a/spec/unit/fetchers/git_fetcher_spec.rb
+++ b/spec/unit/fetchers/git_fetcher_spec.rb
@@ -16,7 +16,7 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
 
       context "when the repository is not cloned" do
         before { allow(subject).to receive(:cloned?).and_return(false) }
@@ -47,7 +47,7 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       let(:revision) { "abcd1234" }
 
       before do
@@ -59,7 +59,7 @@ module Omnibus
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       before do
         allow(subject).to receive(:git)
         allow(subject).to receive(:resolved_version).and_return("12341235")
@@ -80,7 +80,7 @@ module Omnibus
       end
     end
 
-    describe '#fetch' do
+    describe "#fetch" do
       before do
         allow(subject).to receive(:create_required_directories)
       end
@@ -118,7 +118,7 @@ module Omnibus
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       it "returns the shasum of the commit that we expect to be at" do
         expect(subject.version_for_cache).to eq("revision:123abcd1234")
       end

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -25,7 +25,7 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
       context "when file is not downloaded" do
         before { allow(File).to receive(:exist?).and_return(false) }
 
@@ -61,7 +61,7 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       context "source with md5" do
         it "returns the shasum" do
           expect(subject.version_guid).to eq("md5:abcd1234")
@@ -99,7 +99,7 @@ module Omnibus
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       before do
         allow(FileUtils).to receive(:rm_rf)
         allow(subject).to receive(:deploy)
@@ -138,7 +138,7 @@ module Omnibus
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       context "source with md5" do
         it "returns the download URL and md5" do
           expect(subject.version_for_cache).to eq("download_url:https://get.example.com/file.tar.gz|md5:abcd1234")
@@ -274,7 +274,7 @@ module Omnibus
       end
     end
 
-    describe '#deploy' do
+    describe "#deploy" do
       before do
         described_class.send(:public, :deploy)
       end
@@ -322,7 +322,7 @@ module Omnibus
       end
     end
 
-    describe '#extract' do
+    describe "#extract" do
 
       context "on Windows" do
         let(:root_prefix) { "C:" }

--- a/spec/unit/fetchers/path_fetcher_spec.rb
+++ b/spec/unit/fetchers/path_fetcher_spec.rb
@@ -16,7 +16,7 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
-    describe '#fetch_required?' do
+    describe "#fetch_required?" do
       context "when the SHAs match" do
         before do
           allow(subject).to receive(:target_shasum).and_return("abcd1234")
@@ -40,19 +40,19 @@ module Omnibus
       end
     end
 
-    describe '#version_guid' do
+    describe "#version_guid" do
       it "returns the path" do
         expect(subject.version_guid).to eq("path:#{source_path}")
       end
     end
 
-    describe '#clean' do
+    describe "#clean" do
       it "returns true" do
         expect(subject.clean).to be_truthy
       end
     end
 
-    describe '#fetch' do
+    describe "#fetch" do
       before do
         allow(subject).to receive(:create_required_directories)
         allow(FileSyncer).to receive(:sync)
@@ -64,7 +64,7 @@ module Omnibus
       end
     end
 
-    describe '#version_for_cache' do
+    describe "#version_for_cache" do
       let(:shasum) { "abcd1234" }
 
       before do

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -52,13 +52,13 @@ module Omnibus
       described_class.new(zlib)
     end
 
-    describe '#cache_path' do
+    describe "#cache_path" do
       it "returns the install path appended to the install_cache path" do
         expect(ipc.cache_path).to eq(cache_path)
       end
     end
 
-    describe '#tag' do
+    describe "#tag" do
       it "returns the correct tag" do
         expect(ipc.tag).to eql("zlib-24a8ec71da04059dcf7ed3c6e8e0fd9d155476abe4b5156d1f13c42e85478c2b-#{cache_serial_number}")
       end
@@ -74,7 +74,7 @@ module Omnibus
       end
     end
 
-    describe '#create_cache_path' do
+    describe "#create_cache_path" do
       it "runs git init if the cache path does not exist" do
         allow(File).to receive(:directory?)
           .with(ipc.cache_path)
@@ -101,7 +101,7 @@ module Omnibus
       end
     end
 
-    describe '#incremental' do
+    describe "#incremental" do
       before(:each) do
         allow(ipc).to receive(:shellout!)
         allow(ipc).to receive(:create_cache_path)
@@ -132,7 +132,7 @@ module Omnibus
       end
     end
 
-    describe '#remove_git_dirs' do
+    describe "#remove_git_dirs" do
       let(:git_files) { ["git/HEAD", "git/description", "git/hooks", "git/info", "git/objects", "git/refs" ] }
       it "removes bare git directories" do
         allow(Dir).to receive(:glob).and_return(["git/config"])
@@ -155,7 +155,7 @@ module Omnibus
       end
     end
 
-    describe '#restore' do
+    describe "#restore" do
       let(:git_tag_output) { "#{ipc.tag}\n" }
 
       let(:tag_cmd) do

--- a/spec/unit/library_spec.rb
+++ b/spec/unit/library_spec.rb
@@ -55,7 +55,7 @@ module Omnibus
     let(:yajl)        { generate_software("yajl", "1.1.0", %w{rubygems}) }
     let(:zlib)        { generate_software("zlib", "1.2.6", %w{libgcc}) }
 
-    describe '#component_added' do
+    describe "#component_added" do
       it "adds the software to the component list" do
         library.component_added(erchef)
         expect(library.components).to eql([erchef])
@@ -68,7 +68,7 @@ module Omnibus
       end
     end
 
-    describe '#build_order' do
+    describe "#build_order" do
       let(:library) do
         library = Library.new(project)
         library.component_added(preparation)

--- a/spec/unit/manifest_spec.rb
+++ b/spec/unit/manifest_spec.rb
@@ -78,7 +78,7 @@ module Omnibus
     end
 
     describe "#from_hash" do
-      let(:manifest) {
+      let(:manifest) do
         { manifest_format: 1,
           build_version: "12.4.0+20150629082811",
           build_git_revision: "2e763ac957b308ba95cef256c2491a5a55a163cc",
@@ -93,7 +93,7 @@ module Omnibus
             },
           },
         }
-      }
+      end
 
       it "has a build_version" do
         expect(Manifest.from_hash(manifest).build_version).to eq("12.4.0+20150629082811")
@@ -112,7 +112,7 @@ module Omnibus
       end
 
       context "v2 manifest" do
-        let(:manifest) {
+        let(:manifest) do
           { manifest_format: 2,
             build_version: "12.4.0+20150629082811",
             build_git_revision: "2e763ac957b308ba95cef256c2491a5a55a163cc",
@@ -129,7 +129,7 @@ module Omnibus
               },
             },
           }
-        }
+        end
 
         it "has a license" do
           expect(Manifest.from_hash(manifest).license).to eq("Unspecified")
@@ -137,11 +137,11 @@ module Omnibus
       end
 
       context "unsupported manifest" do
-        let(:manifest) {
+        let(:manifest) do
           {
             manifest_format: 99,
           }
-        }
+        end
 
         it "raises an error if it doesn't recognize the manifest version" do
           expect { Manifest.from_hash(manifest) }.to raise_error Manifest::InvalidManifestFormat

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -329,20 +329,20 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       end
     end
 
-    describe '#name' do
+    describe "#name" do
       it "returns the basename of the package" do
         expect(subject.name).to eq("package.deb.metadata.json")
       end
     end
 
-    describe '#path' do
+    describe "#path" do
       it "delegates to .path_for" do
         expect(described_class).to receive(:path_for).once
         subject.path
       end
     end
 
-    describe '#save' do
+    describe "#save" do
       let(:file) { double(File) }
 
       before { allow(File).to receive(:open).and_yield(file) }
@@ -353,7 +353,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       end
     end
 
-    describe '#to_json' do
+    describe "#to_json" do
       it "generates pretty JSON" do
         expect(subject.to_json.strip).to eq <<-EOH.gsub(/^ {10}/, "").strip
           {

--- a/spec/unit/omnibus_spec.rb
+++ b/spec/unit/omnibus_spec.rb
@@ -18,7 +18,7 @@ describe Omnibus do
     Omnibus::Config.software_gems(["omnibus-software", "custom-omnibus-software"])
   end
 
-  describe '#which' do
+  describe "#which" do
     it "returns nil when the file does not exist" do
       stub_env("PATH", nil)
       expect(subject.which("not_a_real_executable")).to be nil
@@ -33,7 +33,7 @@ describe Omnibus do
     end
   end
 
-  describe '#project_path' do
+  describe "#project_path" do
     before do
       allow(Omnibus).to receive(:project_map)
         .and_return("chef" => "/projects/chef")
@@ -52,7 +52,7 @@ describe Omnibus do
     end
   end
 
-  describe '#software_path' do
+  describe "#software_path" do
     before do
       allow(Omnibus).to receive(:software_map)
         .and_return("chef" => "/software/chef")
@@ -71,7 +71,7 @@ describe Omnibus do
     end
   end
 
-  describe '#possible_paths_for' do
+  describe "#possible_paths_for" do
     it "searches all paths" do
       expect(subject.possible_paths_for("file")).to eq(%w{
         /foo/bar/file

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -12,13 +12,13 @@ module Omnibus
       end
     end
 
-    describe '#name' do
+    describe "#name" do
       it "returns the basename of the file" do
         expect(subject.name).to eq("thing.deb")
       end
     end
 
-    describe '#md5' do
+    describe "#md5" do
       let(:md5) { "abcdef123456" }
 
       before { allow(subject).to receive(:digest).with(path, :md5).and_return(md5) }
@@ -28,7 +28,7 @@ module Omnibus
       end
     end
 
-    describe '#sha256' do
+    describe "#sha256" do
       let(:sha256) { "abcdef123456" }
 
       before { allow(subject).to receive(:digest).with(path, :sha256).and_return(sha256) }
@@ -38,7 +38,7 @@ module Omnibus
       end
     end
 
-    describe '#sha512' do
+    describe "#sha512" do
       let(:sha512) { "abcdef123456" }
 
       before { allow(subject).to receive(:digest).with(path, :sha512).and_return(sha512) }
@@ -48,7 +48,7 @@ module Omnibus
       end
     end
 
-    describe '#content' do
+    describe "#content" do
       context "when the file exists" do
         let(:content) { "BINARY" }
 
@@ -68,7 +68,7 @@ module Omnibus
       end
     end
 
-    describe '#metadata' do
+    describe "#metadata" do
       let(:content) { '{ "platform": "ubuntu" }' }
 
       before { allow(IO).to receive(:read).and_return(content) }

--- a/spec/unit/packagers/appx_spec.rb
+++ b/spec/unit/packagers/appx_spec.rb
@@ -34,19 +34,19 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :pkg" do
         expect(subject.id).to eq(:appx)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it "includes the name, version, and build iteration" do
         expect(subject.package_name).to eq("project-1.2.3-2.appx")
       end
     end
 
-    describe '#write_manifest_file' do
+    describe "#write_manifest_file" do
       before do
         allow(subject).to receive(:shellout!).and_return(double("output", stdout: "CN=Chef "))
         allow(subject).to receive(:signing_identity).and_return({})
@@ -71,7 +71,7 @@ module Omnibus
       end
     end
 
-    describe '#windows_package_version' do
+    describe "#windows_package_version" do
       context "when the project build_version semver" do
         it "returns the right value" do
           expect(subject.windows_package_version).to eq("1.2.3.2")
@@ -87,7 +87,7 @@ module Omnibus
       end
     end
 
-    describe '#pack_command' do
+    describe "#pack_command" do
       it "returns a String" do
         expect(subject.pack_command("foo")).to be_a(String)
       end
@@ -125,7 +125,7 @@ module Omnibus
           allow(subject).to receive(:shellout!)
         end
 
-        describe '#timestamp_servers' do
+        describe "#timestamp_servers" do
           it "defaults to using ['http://timestamp.digicert.com','http://timestamp.verisign.com/scripts/timestamp.dll']" do
             subject.signing_identity("foo")
             expect(subject).to receive(:try_sign).with(appx, "http://timestamp.digicert.com").and_return(false)
@@ -133,20 +133,20 @@ module Omnibus
             subject.sign_package(appx)
           end
 
-          it 'uses the timestamp server if provided through the #timestamp_server dsl' do
+          it "uses the timestamp server if provided through the #timestamp_server dsl" do
             subject.signing_identity("foo", timestamp_servers: "http://fooserver")
             expect(subject).to receive(:try_sign).with(appx, "http://fooserver").and_return(true)
             subject.sign_package(appx)
           end
 
-          it 'tries all timestamp server if provided through the #timestamp_server dsl' do
+          it "tries all timestamp server if provided through the #timestamp_server dsl" do
             subject.signing_identity("foo", timestamp_servers: ["http://fooserver", "http://barserver"])
             expect(subject).to receive(:try_sign).with(appx, "http://fooserver").and_return(false)
             expect(subject).to receive(:try_sign).with(appx, "http://barserver").and_return(true)
             subject.sign_package(appx)
           end
 
-          it 'tries all timestamp server if provided through the #timestamp_servers dsl and stops at the first available' do
+          it "tries all timestamp server if provided through the #timestamp_servers dsl and stops at the first available" do
             subject.signing_identity("foo", timestamp_servers: ["http://fooserver", "http://barserver"])
             expect(subject).to receive(:try_sign).with(appx, "http://fooserver").and_return(true)
             expect(subject).not_to receive(:try_sign).with(appx, "http://barserver")

--- a/spec/unit/packagers/base_spec.rb
+++ b/spec/unit/packagers/base_spec.rb
@@ -71,7 +71,7 @@ module Omnibus
       end
     end
 
-    describe '#install_dir' do
+    describe "#install_dir" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:install_dir)
       end
@@ -81,13 +81,13 @@ module Omnibus
       end
     end
 
-    describe '#windows_safe_path' do
+    describe "#windows_safe_path" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:windows_safe_path)
       end
     end
 
-    describe '#run!' do
+    describe "#run!" do
       before do
         allow(subject).to receive(:remove_directory)
         allow(Metadata).to receive(:generate)
@@ -105,14 +105,14 @@ module Omnibus
       end
     end
 
-    describe '#staging_dir' do
+    describe "#staging_dir" do
       it "creates a temporary directory" do
         expect(Dir).to receive(:mktmpdir)
         subject.send(:staging_dir)
       end
     end
 
-    describe '#resource_path' do
+    describe "#resource_path" do
       let(:id) { :base }
       before { allow(subject).to receive(:id).and_return(id) }
 

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -32,13 +32,13 @@ module Omnibus
       create_directory(subject.scripts_staging_dir)
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :bff" do
         expect(subject.id).to eq(:bff)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("x86_64")
       end
@@ -48,19 +48,19 @@ module Omnibus
       end
     end
 
-    describe '#scripts_install_dir' do
+    describe "#scripts_install_dir" do
       it "is nested inside the project install_dir" do
         expect(subject.scripts_install_dir).to start_with(project.install_dir)
       end
     end
 
-    describe '#scripts_staging_dir' do
+    describe "#scripts_staging_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.scripts_staging_dir).to start_with(staging_dir)
       end
     end
 
-    describe '#write_scripts' do
+    describe "#write_scripts" do
       context "when scripts are given" do
         let(:scripts) { %w{ preinst postinst prerm postrm } }
         before do
@@ -83,7 +83,7 @@ module Omnibus
       end
     end
 
-    describe '#write_gen_template' do
+    describe "#write_gen_template" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("x86_64")
       end
@@ -224,13 +224,13 @@ module Omnibus
       end
     end
 
-    describe '#create_bff_file' do
+    describe "#create_bff_file" do
       # Need to mock out the id calls
-      let(:id_shellout) {
+      let(:id_shellout) do
         shellout_mock = double("shellout_mock")
         allow(shellout_mock).to receive(:stdout).and_return("300")
         shellout_mock
-      }
+      end
 
       before do
         allow(subject).to receive(:shellout!)
@@ -240,7 +240,7 @@ module Omnibus
         allow(subject).to receive(:shellout!)
           .with("id -g").and_return(id_shellout)
 
-        create_file(File.join(staging_dir, ".info", "#{project.name}.inventory")) {
+        create_file(File.join(staging_dir, ".info", "#{project.name}.inventory")) do
           <<-INVENTORY.gsub(/^\s{12}/, "")
             /opt/project/version-manifest.txt:
                       owner = root
@@ -251,7 +251,7 @@ module Omnibus
                       size = 1906
                       checksum = "02776    2 "
           INVENTORY
-        }
+        end
         create_file("#{staging_dir}/file") { "http://goo.gl/TbkO01" }
       end
 
@@ -307,7 +307,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_base_package_name' do
+    describe "#safe_base_package_name" do
       context 'when the project name is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_base_package_name).to eq("project")
@@ -328,20 +328,20 @@ module Omnibus
       end
     end
 
-    describe '#create_bff_file_name' do
+    describe "#create_bff_file_name" do
       it "constructs the proper package name" do
         expect(subject.create_bff_file_name).to eq("project-1.2.3-2.x86_64.bff")
       end
 
     end
 
-    describe '#bff_version' do
+    describe "#bff_version" do
       it "returns the build version up with the build iteration" do
         expect(subject.bff_version).to eq("1.2.3.2")
       end
     end
 
-    describe '#safe_architecture' do
+    describe "#safe_architecture" do
       before do
         stub_ohai(platform: "ubuntu", version: "12.04") do |data|
           data["kernel"]["machine"] = "i386"

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -30,7 +30,7 @@ module Omnibus
       create_directory("#{staging_dir}/DEBIAN")
     end
 
-    describe '#vendor' do
+    describe "#vendor" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:vendor)
       end
@@ -44,7 +44,7 @@ module Omnibus
       end
     end
 
-    describe '#license' do
+    describe "#license" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:license)
       end
@@ -66,7 +66,7 @@ module Omnibus
       end
     end
 
-    describe '#priority' do
+    describe "#priority" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:priority)
       end
@@ -80,7 +80,7 @@ module Omnibus
       end
     end
 
-    describe '#section' do
+    describe "#section" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:section)
       end
@@ -94,13 +94,13 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :deb" do
         expect(subject.id).to eq(:deb)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("amd64")
       end
@@ -110,13 +110,13 @@ module Omnibus
       end
     end
 
-    describe '#debian_dir' do
+    describe "#debian_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.debian_dir).to eq("#{staging_dir}/DEBIAN")
       end
     end
 
-    describe '#write_control_file' do
+    describe "#write_control_file" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("amd64")
       end
@@ -144,7 +144,7 @@ module Omnibus
       end
     end
 
-    describe '#write_conffiles_file' do
+    describe "#write_conffiles_file" do
       before do
         project.config_file("/opt/project/file1")
         project.config_file("/opt/project/file2")
@@ -173,7 +173,7 @@ module Omnibus
       end
     end
 
-    describe '#write_scripts' do
+    describe "#write_scripts" do
       before do
         create_file("#{project_root}/package-scripts/project/preinst") { "preinst" }
         create_file("#{project_root}/package-scripts/project/postinst") { "postinst" }
@@ -207,7 +207,7 @@ module Omnibus
       end
     end
 
-    describe '#write_md5_sums' do
+    describe "#write_md5_sums" do
       before do
         create_file("#{staging_dir}/.filea") { ".filea" }
         create_file("#{staging_dir}/file1") { "file1" }
@@ -234,7 +234,7 @@ module Omnibus
       end
     end
 
-    describe '#create_deb_file' do
+    describe "#create_deb_file" do
       before do
         allow(subject).to receive(:shellout!)
         allow(Dir).to receive(:chdir) { |_, &b| b.call }
@@ -259,7 +259,7 @@ module Omnibus
       end
     end
 
-    describe '#package_size' do
+    describe "#package_size" do
       before do
         project.install_dir(staging_dir)
 
@@ -272,7 +272,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_base_package_name' do
+    describe "#safe_base_package_name" do
       context 'when the project name is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_base_package_name).to eq("project")
@@ -293,13 +293,13 @@ module Omnibus
       end
     end
 
-    describe '#safe_build_iteration' do
+    describe "#safe_build_iteration" do
       it "returns the build iteration" do
         expect(subject.safe_build_iteration).to eq(project.build_iteration)
       end
     end
 
-    describe '#safe_version' do
+    describe "#safe_version" do
       context 'when the project build_version is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_version).to eq("1.2.3")
@@ -332,7 +332,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_architecture' do
+    describe "#safe_architecture" do
       let(:shellout) { double("Mixlib::ShellOut", :run_command => true, :error! => nil) }
 
       before do

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -39,7 +39,7 @@ module Omnibus
       end
     end
 
-    describe '#publisher_prefix' do
+    describe "#publisher_prefix" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:publisher_prefix)
       end
@@ -49,47 +49,47 @@ module Omnibus
       end
     end
 
-    it '#id is :IPS' do
+    it "#id is :IPS" do
       expect(subject.id).to eq(:ips)
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it "should create correct package name" do
         expect(subject.package_name).to eq("project-1.2.3-2.i386.p5p")
       end
     end
 
-    describe '#fmri_package_name' do
+    describe "#fmri_package_name" do
       it "should create correct fmri package name" do
         expect(subject.fmri_package_name).to eq ("project@1.2.3,5.11-2")
       end
     end
 
-    describe '#pkg_metadata_file' do
+    describe "#pkg_metadata_file" do
       it "is created inside the staging_dir" do
         expect(subject.pkg_metadata_file).to eq("#{subject.staging_dir}/gen.manifestfile")
       end
     end
 
-    describe '#pkg_manifest_file' do
+    describe "#pkg_manifest_file" do
       it "is created inside the staging_dir" do
         expect(subject.pkg_manifest_file).to eq("#{subject.staging_dir}/#{subject.safe_base_package_name}.p5m")
       end
     end
 
-    describe '#repo_dir' do
+    describe "#repo_dir" do
       it "is created inside the staging_dir" do
         expect(subject.repo_dir).to eq("#{subject.staging_dir}/publish/repo")
       end
     end
 
-    describe '#source_dir' do
+    describe "#source_dir" do
       it "is created inside the staging_dir" do
         expect(subject.source_dir).to eq("#{subject.staging_dir}/proto_install")
       end
     end
 
-    describe '#safe_base_package_name' do
+    describe "#safe_base_package_name" do
       context 'when the project name is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_base_package_name).to eq("project")
@@ -110,7 +110,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_architecture' do
+    describe "#safe_architecture" do
       context "the architecture is Intel-based" do
         let(:architecture) { "i86pc" }
 

--- a/spec/unit/packagers/makeself_spec.rb
+++ b/spec/unit/packagers/makeself_spec.rb
@@ -27,13 +27,13 @@ module Omnibus
       create_directory(staging_dir)
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :makeself" do
         expect(subject.id).to eq(:makeself)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("x86_64")
       end
@@ -43,7 +43,7 @@ module Omnibus
       end
     end
 
-    describe '#write_makeselfinst' do
+    describe "#write_makeselfinst" do
       it "generates the executable file", :not_supported_on_windows do
         subject.write_makeselfinst
         expect("#{staging_dir}/makeselfinst").to be_an_executable
@@ -57,7 +57,7 @@ module Omnibus
       end
     end
 
-    describe '#write_scripts' do
+    describe "#write_scripts" do
       let(:default_scripts) { %w{ postinst } }
       before do
         default_scripts.each do |script_name|
@@ -79,7 +79,7 @@ module Omnibus
       end
     end
 
-    describe '#create_makeself_package' do
+    describe "#create_makeself_package" do
       before do
         allow(subject).to receive(:shellout!)
         allow(Dir).to receive(:chdir) { |_, &b| b.call }

--- a/spec/unit/packagers/msi_spec.rb
+++ b/spec/unit/packagers/msi_spec.rb
@@ -38,27 +38,27 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :pkg" do
         expect(subject.id).to eq(:msi)
       end
     end
 
-    describe '#upgrade_code' do
+    describe "#upgrade_code" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:upgrade_code)
       end
 
       it "is required" do
-        expect {
+        expect do
           subject.upgrade_code
-        }.to raise_error(MissingRequiredAttribute)
+        end.to raise_error(MissingRequiredAttribute)
       end
 
       it "requires the value to be a String" do
-        expect {
+        expect do
           subject.parameters(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -68,7 +68,7 @@ module Omnibus
       end
     end
 
-    describe '#parameters' do
+    describe "#parameters" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:parameters)
       end
@@ -78,9 +78,9 @@ module Omnibus
       end
 
       it "requires the value to be a Hash" do
-        expect {
+        expect do
           subject.parameters(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -90,7 +90,7 @@ module Omnibus
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       before do
         allow(Config).to receive(:windows_arch).and_return(:foo_arch)
       end
@@ -105,13 +105,13 @@ module Omnibus
       end
     end
 
-    describe '#resources_dir' do
+    describe "#resources_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.resources_dir).to eq("#{staging_dir}/Resources")
       end
     end
 
-    describe '#write_localization_file' do
+    describe "#write_localization_file" do
       it "generates the file" do
         subject.write_localization_file
         expect("#{staging_dir}/localization-en-us.wxl").to be_a_file
@@ -127,7 +127,7 @@ module Omnibus
       end
     end
 
-    describe '#write_parameters_file' do
+    describe "#write_parameters_file" do
       before do
         subject.upgrade_code("ABCD-1234")
       end
@@ -147,7 +147,7 @@ module Omnibus
       end
     end
 
-    describe '#write_source_file' do
+    describe "#write_source_file" do
       it "generates the file" do
         subject.write_source_file
         expect("#{staging_dir}/source.wxs").to be_a_file
@@ -202,7 +202,7 @@ module Omnibus
       end
     end
 
-    describe '#write_bundle_file' do
+    describe "#write_bundle_file" do
       before do
         subject.bundle_msi(true)
         subject.upgrade_code("ABCD-1234")
@@ -223,7 +223,7 @@ module Omnibus
       end
     end
 
-    describe '#windows_package_version' do
+    describe "#windows_package_version" do
       context "when the project build_version semver" do
         it "returns the right value" do
           expect(subject.windows_package_version).to eq("1.2.3.2")
@@ -239,7 +239,7 @@ module Omnibus
       end
     end
 
-    describe '#msi_display_version' do
+    describe "#msi_display_version" do
       context 'when the project build_version is "safe"' do
         it "returns the right value" do
           expect(subject.msi_display_version).to eq("1.2.3")
@@ -255,29 +255,29 @@ module Omnibus
       end
     end
 
-    describe '#wix_candle_extensions' do
+    describe "#wix_candle_extensions" do
       it "defaults to an empty Array" do
         expect(subject.wix_candle_extensions).to be_an(Array)
         expect(subject.wix_candle_extensions).to be_empty
       end
     end
 
-    describe '#wix_light_extensions' do
+    describe "#wix_light_extensions" do
       it "defaults to an empty Array" do
         expect(subject.wix_light_extensions).to be_an(Array)
         expect(subject.wix_light_extensions).to be_empty
       end
     end
 
-    describe '#wix_candle_extension' do
+    describe "#wix_candle_extension" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:wix_candle_extension)
       end
 
       it "requires the value to be an String" do
-        expect {
+        expect do
           subject.wix_candle_extension(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -287,15 +287,15 @@ module Omnibus
       end
     end
 
-    describe '#wix_light_extension' do
+    describe "#wix_light_extension" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:wix_light_extension)
       end
 
       it "requires the value to be an String" do
-        expect {
+        expect do
           subject.wix_light_extension(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -305,7 +305,7 @@ module Omnibus
       end
     end
 
-    describe '#wix_extension_switches' do
+    describe "#wix_extension_switches" do
       it "returns an empty string for an empty array" do
         expect(subject.wix_extension_switches([])).to eq("")
       end
@@ -319,15 +319,15 @@ module Omnibus
       end
     end
 
-    describe '#bundle_msi' do
+    describe "#bundle_msi" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:bundle_msi)
       end
 
       it "requires the value to be a TrueClass or a FalseClass" do
-        expect {
+        expect do
           subject.bundle_msi(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -336,15 +336,15 @@ module Omnibus
       end
     end
 
-    describe '#fast_msi' do
+    describe "#fast_msi" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:fast_msi)
       end
 
       it "requires the value to be a TrueClass or a FalseClass" do
-        expect {
+        expect do
           subject.fast_msi(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "returns the given value" do
@@ -353,7 +353,7 @@ module Omnibus
       end
     end
 
-    describe '#zip_command' do
+    describe "#zip_command" do
       it "returns a String" do
         expect(subject.zip_command).to be_a(String)
       end
@@ -363,7 +363,7 @@ module Omnibus
       end
     end
 
-    describe '#candle_command' do
+    describe "#candle_command" do
       it "returns a String" do
         expect(subject.candle_command).to be_a(String)
       end
@@ -393,7 +393,7 @@ module Omnibus
       end
     end
 
-    describe '#heat_command' do
+    describe "#heat_command" do
       it "returns a String" do
         expect(subject.heat_command).to be_a(String)
       end
@@ -423,7 +423,7 @@ module Omnibus
       end
     end
 
-    describe '#light_command' do
+    describe "#light_command" do
       it "returns a String" do
         expect(subject.light_command("foo")).to be_a(String)
       end
@@ -453,7 +453,7 @@ module Omnibus
       end
     end
 
-    describe '#gem_path' do
+    describe "#gem_path" do
       let(:install_dir) { File.join(tmp_path, "install_dir") }
 
       before do
@@ -469,9 +469,9 @@ module Omnibus
       end
 
       it "requires the value to be a String" do
-        expect {
+        expect do
           subject.gem_path(Object.new)
-        }.to raise_error(InvalidValue)
+        end.to raise_error(InvalidValue)
       end
 
       it "globs for gems under the install directory" do
@@ -509,7 +509,7 @@ module Omnibus
           allow(subject).to receive(:shellout!)
         end
 
-        describe '#timestamp_servers' do
+        describe "#timestamp_servers" do
           it "defaults to using ['http://timestamp.digicert.com','http://timestamp.verisign.com/scripts/timestamp.dll']" do
             subject.signing_identity("foo")
             expect(subject).to receive(:try_sign).with(msi, "http://timestamp.digicert.com").and_return(false)
@@ -517,20 +517,20 @@ module Omnibus
             subject.sign_package(msi)
           end
 
-          it 'uses the timestamp server if provided through the #timestamp_server dsl' do
+          it "uses the timestamp server if provided through the #timestamp_server dsl" do
             subject.signing_identity("foo", timestamp_servers: "http://fooserver")
             expect(subject).to receive(:try_sign).with(msi, "http://fooserver").and_return(true)
             subject.sign_package(msi)
           end
 
-          it 'tries all timestamp server if provided through the #timestamp_server dsl' do
+          it "tries all timestamp server if provided through the #timestamp_server dsl" do
             subject.signing_identity("foo", timestamp_servers: ["http://fooserver", "http://barserver"])
             expect(subject).to receive(:try_sign).with(msi, "http://fooserver").and_return(false)
             expect(subject).to receive(:try_sign).with(msi, "http://barserver").and_return(true)
             subject.sign_package(msi)
           end
 
-          it 'tries all timestamp server if provided through the #timestamp_servers dsl and stops at the first available' do
+          it "tries all timestamp server if provided through the #timestamp_servers dsl and stops at the first available" do
             subject.signing_identity("foo", timestamp_servers: ["http://fooserver", "http://barserver"])
             expect(subject).to receive(:try_sign).with(msi, "http://fooserver").and_return(true)
             expect(subject).not_to receive(:try_sign).with(msi, "http://barserver")

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -40,31 +40,31 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :pkg" do
         expect(subject.id).to eq(:pkg)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it "includes the name, version, and build iteration" do
         expect(subject.package_name).to eq("project-full-name-1.2.3-2.pkg")
       end
     end
 
-    describe '#resources_dir' do
+    describe "#resources_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.resources_dir).to eq("#{staging_dir}/Resources")
       end
     end
 
-    describe '#scripts_dir' do
+    describe "#scripts_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.scripts_dir).to eq("#{staging_dir}/Scripts")
       end
     end
 
-    describe '#write_scripts' do
+    describe "#write_scripts" do
       context "when scripts are given" do
         let(:scripts) { %w{ preinstall postinstall } }
         before do
@@ -109,7 +109,7 @@ module Omnibus
       end
     end
 
-    describe '#build_component_pkg' do
+    describe "#build_component_pkg" do
       it "executes the pkgbuild command" do
         expect(subject).to receive(:shellout!).with <<-EOH.gsub(/^ {10}/, "")
           pkgbuild \\
@@ -125,7 +125,7 @@ module Omnibus
       end
     end
 
-    describe '#write_distribution_file' do
+    describe "#write_distribution_file" do
       it "generates the file" do
         subject.write_distribution_file
         expect("#{staging_dir}/Distribution").to be_a_file
@@ -141,7 +141,7 @@ module Omnibus
       end
     end
 
-    describe '#build_product_pkg' do
+    describe "#build_product_pkg" do
       context "when pkg signing is disabled" do
         it "generates the distribution and runs productbuild" do
           expect(subject).to receive(:shellout!).with <<-EOH.gsub(/^ {12}/, "")
@@ -175,7 +175,7 @@ module Omnibus
       context "when the identifier isn't specified by the project" do
         before do
           subject.identifier(nil)
-          project.name('$Project#')
+          project.name("$Project#")
         end
 
         it "uses com.example.PROJECT_NAME as the identifier" do
@@ -184,13 +184,13 @@ module Omnibus
       end
     end
 
-    describe '#component_pkg' do
+    describe "#component_pkg" do
       it "returns the project name with -core.pkg" do
         expect(subject.component_pkg).to eq("project-full-name-core.pkg")
       end
     end
 
-    describe '#safe_base_package_name' do
+    describe "#safe_base_package_name" do
       context 'when the project name is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_base_package_name).to eq("project-full-name")
@@ -211,8 +211,8 @@ module Omnibus
       end
     end
 
-    describe '#safe_identifier' do
-      context 'when Project#identifier is given' do
+    describe "#safe_identifier" do
+      context "when Project#identifier is given" do
         before { subject.identifier("com.apple.project") }
 
         it "is used" do
@@ -241,13 +241,13 @@ module Omnibus
       end
     end
 
-    describe '#safe_build_iteration' do
+    describe "#safe_build_iteration" do
       it "returns the build iternation" do
         expect(subject.safe_build_iteration).to eq(project.build_iteration)
       end
     end
 
-    describe '#safe_version' do
+    describe "#safe_version" do
       context 'when the project build_version is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_version).to eq("1.2.3")

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -40,7 +40,7 @@ module Omnibus
       end
     end
 
-    describe '#signing_passphrase' do
+    describe "#signing_passphrase" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:signing_passphrase)
       end
@@ -50,7 +50,7 @@ module Omnibus
       end
     end
 
-    describe '#vendor' do
+    describe "#vendor" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:vendor)
       end
@@ -64,7 +64,7 @@ module Omnibus
       end
     end
 
-    describe '#license' do
+    describe "#license" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:license)
       end
@@ -86,7 +86,7 @@ module Omnibus
       end
     end
 
-    describe '#priority' do
+    describe "#priority" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:priority)
       end
@@ -100,7 +100,7 @@ module Omnibus
       end
     end
 
-    describe '#category' do
+    describe "#category" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:category)
       end
@@ -114,7 +114,7 @@ module Omnibus
       end
     end
 
-    describe '#dist_tag' do
+    describe "#dist_tag" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:dist_tag)
       end
@@ -124,13 +124,13 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :rpm" do
         expect(subject.id).to eq(:rpm)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       context "when dist_tag is enabled" do
         before do
           allow(subject).to receive(:safe_architecture).and_return("x86_64")
@@ -152,13 +152,13 @@ module Omnibus
       end
     end
 
-    describe '#build_dir' do
+    describe "#build_dir" do
       it "is nested inside the staging_dir" do
         expect(subject.build_dir).to eq("#{staging_dir}/BUILD")
       end
     end
 
-    describe '#write_rpm_spec' do
+    describe "#write_rpm_spec" do
       before do
         allow(subject).to receive(:safe_architecture).and_return("x86_64")
       end
@@ -301,7 +301,7 @@ module Omnibus
       end
     end
 
-    describe '#create_rpm_file' do
+    describe "#create_rpm_file" do
       before do
         allow(subject).to receive(:shellout!)
         allow(Dir).to receive(:chdir) { |_, &b| b.call }
@@ -332,7 +332,7 @@ module Omnibus
       end
     end
 
-    describe '#spec_file' do
+    describe "#spec_file" do
       before do
         allow(subject).to receive(:package_name).and_return("package_name")
       end
@@ -342,7 +342,7 @@ module Omnibus
       end
     end
 
-    describe '#rpm_safe' do
+    describe "#rpm_safe" do
       it "adds quotes when required" do
         expect(subject.rpm_safe("file path")).to eq('"file path"')
       end
@@ -364,7 +364,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_base_package_name' do
+    describe "#safe_base_package_name" do
       context 'when the project name is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_base_package_name).to eq("project")
@@ -385,13 +385,13 @@ module Omnibus
       end
     end
 
-    describe '#safe_build_iteration' do
+    describe "#safe_build_iteration" do
       it "returns the build iternation" do
         expect(subject.safe_build_iteration).to eq(project.build_iteration)
       end
     end
 
-    describe '#safe_version' do
+    describe "#safe_version" do
       context 'when the project build_version is "safe"' do
         it "returns the value without logging a message" do
           expect(subject.safe_version).to eq("1.2.3")
@@ -454,7 +454,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_architecture' do
+    describe "#safe_architecture" do
       before do
         stub_ohai(platform: "redhat", version: "6.5") do |data|
           data["kernel"]["machine"] = "i386"

--- a/spec/unit/packagers/solaris_spec.rb
+++ b/spec/unit/packagers/solaris_spec.rb
@@ -36,37 +36,37 @@ module Omnibus
       end
     end
 
-    describe '#id' do
+    describe "#id" do
       it "is :solaris" do
         expect(subject.id).to eq(:solaris)
       end
     end
 
-    describe '#package_name' do
+    describe "#package_name" do
       it "includes the name, version, iteration and architecture" do
         expect(subject.package_name).to eq("project-1.2.3-1.i386.solaris")
       end
     end
 
-    describe '#pkgmk_version' do
+    describe "#pkgmk_version" do
       it "includes the version and iteration" do
         expect(subject.pkgmk_version).to eq("1.2.3-1")
       end
     end
 
-    describe '#install_dirname' do
+    describe "#install_dirname" do
       it "returns the parent directory" do
         expect(subject.install_dirname).to eq("/opt")
       end
     end
 
-    describe '#install_basename' do
+    describe "#install_basename" do
       it "name of the install directory" do
         expect(subject.install_basename).to eq("project")
       end
     end
 
-    describe '#write_scripts' do
+    describe "#write_scripts" do
       context "when scripts are given" do
         let(:scripts) { %w{ postinstall postremove } }
         before do
@@ -111,7 +111,7 @@ module Omnibus
       end
     end
 
-    describe '#write_prototype_file' do
+    describe "#write_prototype_file" do
       let(:prototype_file) { File.join(staging_dir, "Prototype") }
 
       before do
@@ -155,7 +155,7 @@ module Omnibus
       end
     end
 
-    describe '#create_solaris_file' do
+    describe "#create_solaris_file" do
       it "uses the correct commands" do
         expect(subject).to receive(:shellout!)
           .with("pkgmk -o -r /opt -d #{staging_dir} -f #{File.join(staging_dir, 'Prototype')}")
@@ -168,7 +168,7 @@ module Omnibus
       end
     end
 
-    describe '#write_pkginfo_file' do
+    describe "#write_pkginfo_file" do
       let(:pkginfo_file) { File.join(staging_dir, "pkginfo") }
       let(:hostname) { Socket.gethostname }
       let(:now) { Time.now }
@@ -199,7 +199,7 @@ module Omnibus
       end
     end
 
-    describe '#create_solaris_file' do
+    describe "#create_solaris_file" do
       before do
         allow(subject).to receive(:shellout!)
         allow(Dir).to receive(:chdir) { |_, &b| b.call }
@@ -217,7 +217,7 @@ module Omnibus
       end
     end
 
-    describe '#safe_architecture' do
+    describe "#safe_architecture" do
       context "the architecture is Intel-based" do
         let(:architecture) { "i86pc" }
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -87,7 +87,7 @@ module Omnibus
       end
     end
 
-    describe '#install_dir' do
+    describe "#install_dir" do
       it "removes duplicate slashes" do
         subject.install_dir("///opt//chef")
         expect(subject.install_dir).to eq("/opt/chef")
@@ -108,7 +108,7 @@ module Omnibus
       end
     end
 
-    describe '#default_root' do
+    describe "#default_root" do
       context "on Windows" do
         before { stub_ohai(platform: "windows", version: "2012") }
 
@@ -145,19 +145,19 @@ module Omnibus
       end
     end
 
-    describe '#license' do
+    describe "#license" do
       it "sets the default to Unspecified" do
         expect(subject.license).to eq ("Unspecified")
       end
     end
 
-    describe '#license_file_path' do
+    describe "#license_file_path" do
       it "sets the default to LICENSE" do
         expect(subject.license_file_path).to eq ("/sample/LICENSE")
       end
     end
 
-    describe '#dirty!' do
+    describe "#dirty!" do
       let(:software) { double(Omnibus::Software) }
 
       it "dirties the cache" do
@@ -173,7 +173,7 @@ module Omnibus
       end
     end
 
-    describe '#dirty?' do
+    describe "#dirty?" do
       it "returns true by default" do
         subject.instance_variable_set(:@culprit, nil)
         expect(subject).to_not be_dirty
@@ -190,7 +190,7 @@ module Omnibus
       end
     end
 
-    describe '#<=>' do
+    describe "#<=>" do
       let(:chefdk) { described_class.new.tap { |p| p.name("chefdk") } }
       let(:chef)   { described_class.new.tap { |p| p.name("chef") } }
       let(:ruby)   { described_class.new.tap { |p| p.name("ruby") } }
@@ -201,7 +201,7 @@ module Omnibus
       end
     end
 
-    describe '#build_iteration' do
+    describe "#build_iteration" do
       let(:fauxhai_options) { Hash.new }
 
       before { stub_ohai(fauxhai_options) }
@@ -243,20 +243,20 @@ module Omnibus
       end
     end
 
-    describe '#overrides' do
+    describe "#overrides" do
       before { subject.overrides.clear }
 
-      it 'sets all the things through #overrides' do
+      it "sets all the things through #overrides" do
         subject.override(:thing, version: "6.6.6")
         expect(subject.override(:zlib)).to be_nil
       end
 
-      it 'retrieves the things set through #overrides' do
+      it "retrieves the things set through #overrides" do
         subject.override(:thing, version: "6.6.6")
         expect(subject.override(:thing)[:version]).to eq("6.6.6")
       end
 
-      it 'symbolizes #overrides' do
+      it "symbolizes #overrides" do
         subject.override("thing", version: "6.6.6")
         [:thing, "thing"].each do |thing|
           expect(subject.override(thing)).not_to be_nil
@@ -265,7 +265,7 @@ module Omnibus
       end
     end
 
-    describe '#ohai' do
+    describe "#ohai" do
       before { stub_ohai(platform: "ubuntu", version: "12.04") }
 
       it "is a DSL method" do
@@ -277,21 +277,21 @@ module Omnibus
       end
     end
 
-    describe '#packagers_for_system' do
+    describe "#packagers_for_system" do
       it "returns array of packager objects" do
         subject.packagers_for_system.each do |packager|
           expect(packager).to be_a(Packager::Base)
         end
       end
 
-      it 'calls Packager#for_current_system' do
+      it "calls Packager#for_current_system" do
         expect(Packager).to receive(:for_current_system)
           .and_call_original
         subject.packagers_for_system
       end
     end
 
-    describe '#package' do
+    describe "#package" do
       it "raises an exception when a block is not given" do
         expect { subject.package(:foo) }.to raise_error(InvalidValue)
       end
@@ -312,7 +312,7 @@ module Omnibus
       end
     end
 
-    describe '#packagers' do
+    describe "#packagers" do
       it "returns a Hash" do
         expect(subject.packagers).to be_a(Hash)
       end
@@ -323,12 +323,12 @@ module Omnibus
       end
     end
 
-    describe '#compressor' do
+    describe "#compressor" do
       it "returns a compressor object" do
         expect(subject.compressor).to be_a(Compressor::Base)
       end
 
-      it 'calls Compressor#for_current_system' do
+      it "calls Compressor#for_current_system" do
         expect(Compressor).to receive(:for_current_system)
           .and_call_original
 
@@ -347,7 +347,7 @@ module Omnibus
       end
     end
 
-    describe '#compress' do
+    describe "#compress" do
       it "does not raises an exception when a block is not given" do
         expect { subject.compress(:foo) }.to_not raise_error
       end
@@ -373,7 +373,7 @@ module Omnibus
       end
     end
 
-    describe '#compressors' do
+    describe "#compressors" do
       it "returns a Hash" do
         expect(subject.compressors).to be_a(Hash)
       end
@@ -384,7 +384,7 @@ module Omnibus
       end
     end
 
-    describe '#shasum' do
+    describe "#shasum" do
       context "when a filepath is given" do
         let(:path) { "/project.rb" }
         let(:file) { double(File) }

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -24,7 +24,7 @@ module Omnibus
 
     subject { described_class.new(pattern, options) }
 
-    describe '#packages' do
+    describe "#packages" do
       let(:a) { "/path/to/files/a.deb" }
       let(:b) { "/path/to/files/b.deb" }
       let(:glob) { [a, b] }
@@ -185,7 +185,7 @@ module Omnibus
 
     end
 
-    describe '#publish' do
+    describe "#publish" do
       it "is an abstract method" do
         expect { subject.publish }.to raise_error(NotImplementedError)
       end

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -137,7 +137,7 @@ module Omnibus
 
     subject { described_class.new(path, options) }
 
-    describe '#publish' do
+    describe "#publish" do
       before do
         allow(subject).to receive(:packages).and_return(packages)
         Config.artifactory_base_path("com/getchef")
@@ -246,7 +246,7 @@ module Omnibus
       end
     end
 
-    describe '#metadata_properties_for' do
+    describe "#metadata_properties_for" do
       it "returns the transformed package metadata values" do
         expect(subject.send(:metadata_properties_for, package)).to include(package_properties.merge(build_values))
       end

--- a/spec/unit/publishers/s3_publisher_spec.rb
+++ b/spec/unit/publishers/s3_publisher_spec.rb
@@ -40,7 +40,7 @@ module Omnibus
 
     subject { described_class.new(path) }
 
-    describe '#publish' do
+    describe "#publish" do
       before { allow(subject).to receive(:packages).and_return(packages) }
 
       it "validates the package" do

--- a/spec/unit/s3_helpers_spec.rb
+++ b/spec/unit/s3_helpers_spec.rb
@@ -5,8 +5,8 @@ module Omnibus
   describe S3Helpers do
     include Omnibus::S3Helpers
 
-    context 'when #s3_configuration is not defined' do
-      describe '#client' do
+    context "when #s3_configuration is not defined" do
+      describe "#client" do
         it "raises an error if it is not overridden" do
           expect { s3_configuration }.to raise_error(RuntimeError,
                                                      "You must override s3_configuration")
@@ -19,7 +19,7 @@ module Omnibus
       end
     end
 
-    describe '#to_base64_digest' do
+    describe "#to_base64_digest" do
       it 'turns "c3b5247592ce694f7097873aa07d66fe" into "w7UkdZLOaU9wl4c6oH1m/g=="' do
         expect(to_base64_digest("c3b5247592ce694f7097873aa07d66fe")).to eql("w7UkdZLOaU9wl4c6oH1m/g==")
       end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -446,7 +446,7 @@ module Omnibus
       end
     end
 
-    describe '#ohai' do
+    describe "#ohai" do
       before { stub_ohai(platform: "ubuntu", version: "12.04") }
 
       it "is a DSL method" do
@@ -516,7 +516,7 @@ module Omnibus
       end
     end
 
-    describe '#<=>' do
+    describe "#<=>" do
       let(:zlib)   { described_class.new(project).tap { |s| s.name("zlib") } }
       let(:erchef) { described_class.new(project).tap { |s| s.name("erchef") } }
       let(:bacon)  { described_class.new(project).tap { |s| s.name("bacon") } }
@@ -527,7 +527,7 @@ module Omnibus
       end
     end
 
-    describe '#whitelist_file' do
+    describe "#whitelist_file" do
       it "appends to the whitelist_files array" do
         expect(subject.whitelist_files.size).to eq(0)
         subject.whitelist_file(/foo\/bar/)
@@ -636,7 +636,7 @@ module Omnibus
       end
     end
 
-    describe '#fetcher' do
+    describe "#fetcher" do
       before do
         expect(Omnibus::Fetcher).to receive(:resolve_version).with("1.2.3", source).and_return("1.2.8")
       end
@@ -760,7 +760,7 @@ module Omnibus
       end
     end
 
-    describe '#shasum' do
+    describe "#shasum" do
       context "when a filepath is given" do
         let(:path) { "/software.rb" }
         let(:file) { double(File) }

--- a/spec/unit/sugarable_spec.rb
+++ b/spec/unit/sugarable_spec.rb
@@ -47,12 +47,12 @@ module Omnibus
       end
 
       it "makes the DSL methods available in the cleanroom" do
-        expect {
+        expect do
           instance.evaluate <<-EOH.gsub(/^ {12}/, "")
             windows?
             vagrant?
           EOH
-        }.to_not raise_error
+        end.to_not raise_error
       end
     end
   end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -4,7 +4,7 @@ module Omnibus
   describe Util do
     subject { Class.new { include Util }.new }
 
-    describe '#shellout!' do
+    describe "#shellout!" do
       let(:shellout) do
         double(Mixlib::ShellOut,
           command:     "evil command",
@@ -28,9 +28,9 @@ module Omnibus
         end
 
         it "raises an CommandFailed exception" do
-          expect {
+          expect do
             subject.shellout!
-          }.to raise_error(CommandFailed) { |error|
+          end.to raise_error(CommandFailed) { |error|
             message = error.message
 
             expect(message).to include("$ I_LOVE_YOU=barney TICKLE_ME=elmo evil command")
@@ -49,9 +49,9 @@ module Omnibus
         end
 
         it "raises an CommandFailed exception" do
-          expect {
+          expect do
             subject.shellout!
-          }.to raise_error(CommandTimeout) { |error|
+          end.to raise_error(CommandTimeout) { |error|
             message = error.message
 
             expect(message).to include("shell command timed out at 7,200 seconds")
@@ -62,7 +62,7 @@ module Omnibus
       end
     end
 
-    describe '#create_directory' do
+    describe "#create_directory" do
       before { allow(FileUtils).to receive(:mkdir_p) }
 
       it "creates the directory" do
@@ -80,7 +80,7 @@ module Omnibus
       end
     end
 
-    describe '#remove_directory' do
+    describe "#remove_directory" do
       before { allow(FileUtils).to receive(:rm_rf) }
 
       it "remove the directory" do
@@ -99,7 +99,7 @@ module Omnibus
       end
     end
 
-    describe '#copy_file' do
+    describe "#copy_file" do
       before { allow(FileUtils).to receive(:cp) }
 
       it "copies the file" do
@@ -117,7 +117,7 @@ module Omnibus
       end
     end
 
-    describe '#remove_file' do
+    describe "#remove_file" do
       before { allow(FileUtils).to receive(:rm_f) }
 
       it "removes the file" do
@@ -136,7 +136,7 @@ module Omnibus
       end
     end
 
-    describe '#create_file' do
+    describe "#create_file" do
       before do
         allow(FileUtils).to receive(:mkdir_p)
         allow(FileUtils).to receive(:touch)
@@ -171,7 +171,7 @@ module Omnibus
       end
     end
 
-    describe '#create_link' do
+    describe "#create_link" do
       before { allow(FileUtils).to receive(:ln_s) }
 
       it "creates the directory" do


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

chefstyle 0.4.0 came out, with updated rules.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

@mwrock resolves the style violations in https://github.com/chef/omnibus/pull/708

please take an extra look at the 3 manual changes I made that didn't autocorrect:

```
lib/omnibus/core_extensions/open_uri.rb:69:5: C: Style/ConstantName: Use SCREAMING_SNAKE_CASE for constants.
    StringMax = 0
    ^^^^^^^^^
lib/omnibus/fetchers/git_fetcher.rb:217:5: W: Lint/UselessAccessModifier: Useless public access modifier.
    public
    ^^^^^^
lib/omnibus/manifest.rb:131:5: W: Lint/UselessAccessModifier: Useless private access modifier.
    private
    ^^^^^^^
```

@chef/engineering-services 