### PR TITLE
Only support Solaris 10u11 and newer

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -644,7 +644,7 @@ module Omnibus
               # http://lists.gnu.org/archive/html/bug-libtool/2005-10/msg00004.html
               "CC" => "gcc -static-libgcc",
               "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
-              "CFLAGS" => "-I#{install_dir}/embedded/include",
+              "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
             }
           elsif platform_version.satisfies?(">= 5.11")
             solaris_flags = {

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -193,9 +193,9 @@ module Omnibus
           expect(subject.with_standard_compiler_flags).to eq(
             "CC"              => "gcc -static-libgcc",
             "LDFLAGS"         => "-R/opt/project/embedded/lib -L/opt/project/embedded/lib -static-libgcc",
-            "CFLAGS"          => "-I/opt/project/embedded/include",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "LD_OPTIONS"      => "-R/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
@@ -219,9 +219,9 @@ module Omnibus
             expect(subject.with_standard_compiler_flags).to eq(
               "CC"              => "gcc -static-libgcc",
               "LDFLAGS"         => "-R/opt/project/embedded/lib -L/opt/project/embedded/lib -static-libgcc",
-              "CFLAGS"          => "-I/opt/project/embedded/include",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include",
+              "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
               "LD_OPTIONS"      => "-R/opt/project/embedded/lib -M #{project_root}/files/mapfile/solaris",
               "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"


### PR DESCRIPTION
### Description
Only support Solaris 10u11 and newer. This is mostly a cleanup of the prior work done for this by @scotthain 

--------------------------------------------------
/cc @chef/omnibus-maintainers 
#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [x] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

