### PR TITLE
Ability to manually specify transitive dependency license information

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -145,7 +145,6 @@ module Omnibus
     #
     def execute_post_build(software)
       collect_licenses_for(software)
-
       unless software.skip_transitive_dependency_licensing
         collect_transitive_dependency_licenses_for(software)
       end
@@ -521,11 +520,14 @@ EOH
         license_output_dir,
         LicenseScout::Options.new(
           environment: software.with_embedded_path,
-          ruby_bin: software.embedded_bin("ruby")
+          ruby_bin: software.embedded_bin("ruby"),
+          manual_licenses: software.dependency_licenses
         )
       )
 
       begin
+        # We do not automatically collect dependency licensing information when
+        # skip_transitive_dependency_licensing is set on the software.
         collector.run
       rescue LicenseScout::Exceptions::UnsupportedProjectType => e
         # Looks like this project is not supported by LicenseScout. Either the

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -400,6 +400,39 @@ module Omnibus
     expose :skip_transitive_dependency_licensing
 
     #
+    # Set or retrieve licensing information of the dependencies.
+    # The information set is not validated or inspected. It is directly
+    #   passed to LicenseScout.
+    #
+    # @example
+    # dependency_licenses [
+    #   {
+    #     dependency_name: "logstash-output-websocket",
+    #     dependency_manager: "logstash_plugin",
+    #     license: "Apache-2.0",
+    #     license_file: [
+    #       "relative/path/to/license/file",
+    #       "https://download.elastic.co/logstash/LICENSE"
+    #     ]
+    #   },
+    #   ...
+    # ]
+    #
+    # @param [Hash] val
+    # @param [Array<Hash>] val
+    #   dependency license information.
+    # @return [Array<Hash>]
+    #
+    def dependency_licenses(val = NULL)
+      if null?(val)
+        @dependency_licenses || nil
+      else
+        @dependency_licenses = Array(val)
+      end
+    end
+    expose :dependency_licenses
+
+    #
     # Evaluate a block only if the version matches.
     #
     # @example

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -42,6 +42,7 @@ module Omnibus
     it_behaves_like "a cleanroom setter", :license, %{license 'Apache 2.0'}
     it_behaves_like "a cleanroom setter", :license_file, %{license_file 'LICENSES/artistic.txt'}
     it_behaves_like "a cleanroom setter", :skip_transitive_dependency_licensing, %{skip_transitive_dependency_licensing true}
+    it_behaves_like "a cleanroom setter", :dependency_licenses, %{dependency_licenses [{license: "MIT"}]}
     it_behaves_like "a cleanroom setter", :whitelist_file, %{whitelist_file '/opt/whatever'}
     it_behaves_like "a cleanroom setter", :relative_path, %{relative_path '/path/to/extracted'}
     it_behaves_like "a cleanroom setter", :build, %|build {}|


### PR DESCRIPTION
### Description

This PR adds the ability to manually specify license information for transitive dependencies for software definitions that omnibus can not automatically detect the license information for. 

A great example for this is the logstash plugins we are using in one of our products which are very hard to detect automatically and I am sure there are hundred other cases like that. 

Here is how this feature is used:

```
plugin_licenses = logstash_plugins.each do |l|
  plugin_licenses << {
    dependency_manager: "logstash_plugin",
    name: l,
    version: "latest",
    license: "Apache-2.0",
    license_file: [
      "https://raw.githubusercontent.com/logstash-plugins/#{l}/master/LICENSE",
      "https://raw.githubusercontent.com/logstash-plugins/#{l}/master/NOTICE.txt"
    ]
  }
end

# Add license information for the logstash plugins we are installing manually.
dependency_licenses(plugin_licenses)
```

- [ ] Since this DSL requires a newer version of license_scout, we need to have a release it before merging this in.

--------------------------------------------------
/cc @chef/omnibus-maintainers, @danielsdeleo, @ryancragun 