### PR TITLE
berkshelf 4.x

### DIFF
--- a/lib/omnibus/generator_files/Gemfile.erb
+++ b/lib/omnibus/generator_files/Gemfile.erb
@@ -13,7 +13,7 @@ gem 'omnibus', '~> <%= Omnibus::VERSION.split('.')[0...-1].join('.') %>'
 # by running `bundle install --without development` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
-  gem 'berkshelf', '~> 3.3'
+  gem 'berkshelf', '~> 4.3'
 
   # Use Test Kitchen with Vagrant for converging the build environment
   gem 'test-kitchen',    '~> 1.4'


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

Berkshelf 3.x fails with a newer Faraday for the kitchen builds
Basically this means that unless I change the berkshelf to 4.x, the bin/kitchen converge will fail with the message described here:

https://github.com/berkshelf/berkshelf/issues/1466

which is:
  :gzip is not registered on Faraday::Response

---

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
#### Maintainers

Please ensure that you check for:
- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
