### PR TITLE
Update pedump to latest released (ksubrama's patch was merged!)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-# Fork to allow for a recent version of multipart-post.
-gem "pedump", git: "https://github.com/ksubrama/pedump", branch: "patch-1"
-
 # Always use license_scout from master
 gem "license_scout", git: "https://github.com/chef/license_scout"
 

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,18 +21,19 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ["lib"]
 
-  # https://github.com/ksubrama/pedump, branch 'patch-1'
-  # is declared in the Gemfile because of its outdated
-  # dependency on multipart-post (~> 1.1.4)
+  gem.add_dependency "aws-sdk",          "~> 2"
   gem.add_dependency "chef-sugar",       "~> 3.3"
   gem.add_dependency "cleanroom",        "~> 1.0"
+  gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  "~> 2.0"
-  gem.add_dependency "mixlib-versioning"
   gem.add_dependency "ohai",             "~> 8.0"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
-  gem.add_dependency "aws-sdk",          "~> 2"
   gem.add_dependency "thor",             "~> 0.18"
-  gem.add_dependency "ffi-yajl",         "~> 2.2"
+
+  gem.add_dependency "mixlib-versioning"
+  gem.add_dependency "pedump"
+
+  # from Gemfile
   gem.add_dependency "license_scout"
 
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
### Description

Now that ksubrama's patch to pedump has been merged to master and released, we no longer need to refer to his patch branch. This removes it and refers directly to pedump.

---

/cc @chef/omnibus-maintainers
#### Maintainers

Please ensure that you check for:
- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
