### PR TITLE
Do not autoload fetcher to avoid eace conditions

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -19,7 +19,11 @@ require "omnibus/core_extensions"
 require "cleanroom"
 require "pathname"
 
+require "omnibus/digestable"
 require "omnibus/exceptions"
+require "omnibus/sugarable"
+require "omnibus/util"
+require "omnibus/fetcher"
 require "omnibus/version"
 
 module Omnibus
@@ -36,9 +40,7 @@ module Omnibus
   autoload :Cleaner,          "omnibus/cleaner"
   autoload :Compressor,       "omnibus/compressor"
   autoload :Config,           "omnibus/config"
-  autoload :Digestable,       "omnibus/digestable"
   autoload :Error,            "omnibus/exceptions"
-  autoload :Fetcher,          "omnibus/fetcher"
   autoload :FileSyncer,       "omnibus/file_syncer"
   autoload :Generator,        "omnibus/generator"
   autoload :GitCache,         "omnibus/git_cache"
@@ -57,10 +59,8 @@ module Omnibus
   autoload :Reports,          "omnibus/reports"
   autoload :S3Cache,          "omnibus/s3_cache"
   autoload :Software,         "omnibus/software"
-  autoload :Sugarable,        "omnibus/sugarable"
   autoload :Templating,       "omnibus/templating"
   autoload :ThreadPool,       "omnibus/thread_pool"
-  autoload :Util,             "omnibus/util"
   autoload :Licensing,        "omnibus/licensing"
 
   autoload :GitFetcher,  "omnibus/fetchers/git_fetcher"


### PR DESCRIPTION
We have now seen on several occations the following errors on jenkins servers:

```
bundler: failed to load command: omnibus (/usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bin/omnibus)
NameError: uninitialized constant Omnibus::Fetcher
Did you mean?  Omnibus::Fetcher
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/fetchers/net_fetcher.rb:21:in `<module:Omnibus>'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/fetchers/net_fetcher.rb:20:in `<top (required)>'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/software.rb:1014:in `require'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/software.rb:1014:in `fetcher'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/software.rb:873:in `fetch'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/project.rb:1066:in `block (3 levels) in download'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/thread_pool.rb:64:in `block (4 levels) in initialize'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/thread_pool.rb:62:in `loop'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/thread_pool.rb:62:in `block (3 levels) in initialize'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/thread_pool.rb:61:in `catch'
  /usr/home/jenkins/workspace/chef-build/architecture/x86_64/platform/freebsd-9/project/chef/role/builder/omnibus/vendor/bundle/ruby/2.3.0/bundler/gems/omnibus-98c9af20a0f7/lib/omnibus/thread_pool.rb:61:in `block (2 levels) in initialize'
 ```

This is intermittent and the build often succeeds on the next try. I'm not super familiar with `autoload` but I do know that it has thread safety issues and as can be seen at the bottom of this stack, we are clearly in a multi threaded scenario.

This PR attempts to avoid these errors by loading `Fetcher` via `requires` instead of autoloading it.