### PR TITLE
BEN-121- Fix P5P package naming

### DIFF
--- a/lib/omnibus/packagers/ips.rb
+++ b/lib/omnibus/packagers/ips.rb
@@ -81,8 +81,7 @@ module Omnibus
     # @see Base#package_name
     #
     def package_name
-      version = project.build_version.split(/[^\d]/)[0..2].join(".")
-      "#{safe_base_package_name}-#{version}-#{project.build_iteration}.#{safe_architecture}.p5p"
+      "#{safe_base_package_name}-#{project.build_version}-#{project.build_iteration}.#{safe_architecture}.p5p"
     end
 
     #

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -8,7 +8,7 @@ module Omnibus
         project.name("project")
         project.homepage("https://example.com")
         project.install_dir("/opt/project")
-        project.build_version("1.2.3")
+        project.build_version("1.2.3+20161003185500.git.37.089ab3f")
         project.build_iteration("2")
         project.maintainer("Chef Software")
       end
@@ -55,7 +55,7 @@ module Omnibus
 
     describe "#package_name" do
       it "should create correct package name" do
-        expect(subject.package_name).to eq("project-1.2.3-2.i386.p5p")
+        expect(subject.package_name).to eq("project-1.2.3+20161003185500.git.37.089ab3f-2.i386.p5p")
       end
     end
 
@@ -211,7 +211,7 @@ module Omnibus
     describe "#export_pkg_archive_file" do
       it "uses the correct commands" do
         expect(subject).to receive(:shellout!)
-          .with("pkgrecv -s #{staging_dir}/publish/repo -a -d #{package_dir}/project-1.2.3-2.i386.p5p project")
+          .with("pkgrecv -s #{staging_dir}/publish/repo -a -d #{package_dir}/project-1.2.3+20161003185500.git.37.089ab3f-2.i386.p5p project")
 
         expect(shellout).to receive(:stdout)
         subject.export_pkg_archive_file


### PR DESCRIPTION
### Description

Update the IPS package_name to append the git timestamp build version.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
@chef/engineering-services 
#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

… data

Use fixed package_name while creating p5p archive