### PR TITLE
Enable gcc 4.8 on suse/sles if available

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -703,6 +703,17 @@ module Omnibus
             freebsd_flags["CXX"] = "clang++"
           end
           freebsd_flags
+        when "suse"
+          suse_flags = {
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+          }
+          # Enable gcc version 4.8 if it is available
+          if which("gcc-4.8")
+            suse_flags["CC"] = "gcc-4.8"
+            suse_flags["CXX"] = "g++-4.8"
+          end
+          suse_flags
         when "windows"
           arch_flag = windows_arch_i386? ? "-m32" : "-m64"
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -325,6 +325,61 @@ module Omnibus
         end
       end
 
+      context "on sles 11" do
+        before do
+          # sles identifies as suse
+          stub_ohai(platform: "suse", version: "11.4")
+        end
+        it "sets the defaults" do
+          expect(subject.with_standard_compiler_flags).to eq(
+          "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+          "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+          "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+          "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+          "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+          "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+          )
+        end
+
+        context "with gcc 4.8 installed" do
+
+          before do
+            allow(subject).to receive(:which).and_return("/usr/bin/gcc-4.8")
+          end
+
+          it "sets the compiler args" do
+            expect(subject.with_standard_compiler_flags).to eq(
+              "CC"              => "gcc-4.8",
+              "CXX"             => "g++-4.8",
+              "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+              "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              )
+          end
+        end
+      end
+
+      context "on sles 12" do
+        before do
+          # sles identifies as suse
+          stub_ohai(platform: "suse", version: "12.1")
+        end
+
+        it "sets the defaults" do
+          expect(subject.with_standard_compiler_flags).to eq(
+            "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+          )
+        end
+      end
+
       context "on Windows" do
         let(:win_arch_i386) { true }
 


### PR DESCRIPTION
### Description

In order to build chef, we need at least gcc 4.7. With https://github.com/chef-cookbooks/build-essential/pull/124 merged, we can now use gcc 4.8 on SLES 11.4 (which comes with gcc 4.4).

If gcc 4.8 isn't present, it's a no-op.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

Signed-off-by: Scott Hain <shain@chef.io>