### PR TITLE
Add 'Project.provide()' for virtual packages

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -324,6 +324,7 @@ module Omnibus
           category:        category,
           conflicts:       project.conflicts,
           replaces:        project.replaces,
+          provides:        project.provides,
           dependencies:    project.runtime_dependencies,
           user:            project.package_user,
           group:           project.package_group,

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -286,6 +286,23 @@ module Omnibus
     expose :description
 
     #
+    # Add to the list of packages this one provides.
+    #
+    # @example
+    #   provide 'the-virtual-package'
+    #
+    # @param [String] val
+    #   the name of the package to provide
+    #
+    # @return [String]
+    #
+    def provide(val = NULL)
+      provides << val
+      provides.dup
+    end
+    expose :provide
+
+    #
     # Add to the list of packages this one replaces.
     #
     # This should only be used when renaming a package and obsoleting the old
@@ -895,6 +912,15 @@ module Omnibus
     #
     def replaces
       @replaces ||= []
+    end
+
+    #
+    # The list of things this project provides.
+    #
+    # @return [Array<String>]
+    #
+    def provides
+      @provides ||= []
     end
 
     #

--- a/resources/deb/control.erb
+++ b/resources/deb/control.erb
@@ -14,6 +14,9 @@ Conflicts: <%= conflicts.join(', ') %>
 <% unless replaces.empty? -%>
 Replaces: <%= replaces.join(', ') %>
 <% end -%>
+<% unless provides.empty? -%>
+Provides: <%= provides.join(', ') %>
+<% end -%>
 Section: <%= section %>
 Priority: <%= priority %>
 Homepage: <%= homepage %>


### PR DESCRIPTION
### Description

This PR adds package support for the 'provides' directive for .deb and .rpm
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

