### PR TITLE
[BEN-122] - IPS install fails on perl dependancy

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -670,6 +670,17 @@ module Omnibus
             freebsd_flags["CXX"] = "clang++"
           end
           freebsd_flags
+        when "suse"
+          suse_flags = {
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+          }
+          # Enable gcc version 4.8 if it is available
+          if which("gcc-4.8")
+            suse_flags["CC"] = "gcc-4.8"
+            suse_flags["CXX"] = "g++-4.8"
+          end
+          suse_flags
         when "windows"
           arch_flag = windows_arch_i386? ? "-m32" : "-m64"
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"

--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -1,2 +1,4 @@
 <transform dir path=<%= pathdir %>$ -> edit group bin sys>
 <transform file depend -> edit pkg.debug.depend.file ruby env>
+<transform file depend -> edit pkg.debug.depend.file perl env>
+<transform file depend -> edit pkg.debug.depend.file make env>

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -324,6 +324,61 @@ module Omnibus
         end
       end
 
+      context "on sles 11" do
+        before do
+          # sles identifies as suse
+          stub_ohai(platform: "suse", version: "11.4")
+        end
+        it "sets the defaults" do
+          expect(subject.with_standard_compiler_flags).to eq(
+          "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+          "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+          "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+          "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+          "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+          "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+          )
+        end
+
+        context "with gcc 4.8 installed" do
+
+          before do
+            allow(subject).to receive(:which).and_return("/usr/bin/gcc-4.8")
+          end
+
+          it "sets the compiler args" do
+            expect(subject.with_standard_compiler_flags).to eq(
+              "CC"              => "gcc-4.8",
+              "CXX"             => "g++-4.8",
+              "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+              "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              )
+          end
+        end
+      end
+
+      context "on sles 12" do
+        before do
+          # sles identifies as suse
+          stub_ohai(platform: "suse", version: "12.1")
+        end
+
+        it "sets the defaults" do
+          expect(subject.with_standard_compiler_flags).to eq(
+            "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+          )
+        end
+      end
+
       context "on Windows" do
         let(:win_arch_i386) { true }
 


### PR DESCRIPTION
### Description

Solaris 11 IPS package install fails on package dependancy on perl.

Fix is to transform perl and make dependancies as environmental
Tested built IPS package successfully on Solaris SPARC client node.

@chef/engineering-services 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
