### PR TITLE
[BEN-122] - IPS install fails on perl dependency

### DIFF
--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -1,2 +1,4 @@
 <transform dir path=<%= pathdir %>$ -> edit group bin sys>
 <transform file depend -> edit pkg.debug.depend.file ruby env>
+<transform file depend -> edit pkg.debug.depend.file make env>
+<transform file depend -> edit pkg.debug.depend.file perl env>

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -144,6 +144,8 @@ module Omnibus
         transform_file_contents = File.read(transform_file)
         expect(transform_file_contents).to include("<transform dir path=opt$ -> edit group bin sys>")
         expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file ruby env>")
+        expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file make env>")
+        expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file perl env>")
       end
     end
 


### PR DESCRIPTION
### Description

Solaris 11 IPS package install fails on package dependency on perl.

Fix is to transform perl and make dependancies as environmental
Tested built IPS package successfully on Solaris SPARC client node.

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

@chef/engineering-services

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

