### PR TITLE
[BEN-123] Fix IPS package must create symlinks to package commands

### DIFF
--- a/lib/omnibus/packagers/ips.rb
+++ b/lib/omnibus/packagers/ips.rb
@@ -193,6 +193,24 @@ module Omnibus
     end
 
     #
+    # A set of symbolic links to installed commands that
+    #`pkgmogrify' will apply to the package manifest. Is called only when
+    # symlinks.erb template exists
+    # The resource exists locally. For example for project omnibus-toolchain
+    # resource_path("symlinks.erb") #=>
+    # {"/path/to/omnibus-toolchain/resources/omnibus-toolchain/ips/symlinks.erb"}
+    #
+    # @return [String]
+    #
+    def render_symlinks
+      render_template_content(resource_path("symlinks.erb"),
+        {
+          projectdir: project.install_dir,
+        }
+      )
+    end
+
+    #
     # Generate package metadata
     #
     # Create the gen template for `pkgmogrify`
@@ -210,6 +228,13 @@ module Omnibus
           arch:              safe_architecture,
         }
       )
+
+      # Append the contents of symlinks.erb if it exists
+      if File.exists?(resource_path("symlinks.erb"))
+        File.open(pkg_metadata_file, "a") do |symlink|
+          symlink.write(render_symlinks)
+        end
+      end
 
       # Print the full contents of the rendered template file to generate package contents
       log.debug(log_key) { "Rendered Template:\n" + File.read(pkg_metadata_file) }

--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 require "erb"
 
 module Omnibus
@@ -21,6 +20,32 @@ module Omnibus
     def self.included(base)
       # This module also requires logging
       base.send(:include, Logging)
+    end
+
+    #
+    # Render an erb template to a String variable.
+    #
+    # @return [String]
+    #
+    # @param [String] source
+    #   the path on disk where the ERB template lives
+    #
+    # @option options [Fixnum] :mode (default: +0644+)
+    #   the mode of the rendered file
+    # @option options [Hash] :variables (default: +{}+)
+    #   the list of variables to pass to the template
+    #
+    def render_template_content(source, variables = {})
+      template = ERB.new(File.read(source), nil, "-")
+
+      struct =
+        if variables.empty?
+          Struct.new("Empty")
+        else
+          Struct.new(*variables.keys).new(*variables.values)
+        end
+
+      template.result(struct.instance_eval { binding })
     end
 
     #
@@ -41,8 +66,7 @@ module Omnibus
     #
     def render_template(source, options = {})
       destination = options.delete(:destination) || source.chomp(".erb")
-
-      mode      = options.delete(:mode) || 0644
+      mode = options.delete(:mode) || 0644
       variables = options.delete(:variables) || {}
 
       log.info(log_key) { "Rendering `#{source}' to `#{destination}'" }
@@ -52,16 +76,8 @@ module Omnibus
           "Unknown option(s): #{options.keys.map(&:inspect).join(', ')}"
       end
 
-      template = ERB.new(File.read(source), nil, "-")
-
-      struct =
-        if variables.empty?
-          Struct.new("Empty")
-        else
-          Struct.new(*variables.keys).new(*variables.values)
-        end
-
-      result = template.result(struct.instance_eval { binding })
+      # String value returned from #render_template_content
+      result = render_template_content(source, variables)
 
       File.open(destination, "w", mode) do |file|
         file.write(result)

--- a/spec/functional/templating_spec.rb
+++ b/spec/functional/templating_spec.rb
@@ -8,33 +8,33 @@ module Omnibus
   describe Templating do
     subject { RandomClass.new }
 
-    describe "#render_template" do
-      let(:source)      { File.join(tmp_path, "source.erb") }
-      let(:destination) { File.join(tmp_path, "final") }
-      let(:mode)        { 0644 }
-      let(:variables)   { { name: "Name" } }
-      let(:contents) do
-        <<-EOH.gsub(/^ {10}/, "")
+    let(:source)      { File.join(tmp_path, "source.erb") }
+    let(:destination) { File.join(tmp_path, "final") }
+    let(:mode)        { 0644 }
+    let(:variables)   { { name: "Name" } }
+    let(:contents) do
+      <<-EOH.gsub(/^ {10}/, "")
           <%= name %>
 
           <% if false -%>
             This is magic!
           <% end -%>
         EOH
-      end
+    end
 
-      let(:options) do
-        {
-          destination: destination,
-          variables:   variables,
-          mode:        mode,
-        }
-      end
+    let(:options) do
+      {
+        destination: destination,
+        variables:   variables,
+        mode:        mode,
+      }
+    end
 
-      before do
-        File.open(source, "w") { |f| f.write(contents) }
-      end
+    before do
+      File.open(source, "w") { |f| f.write(contents) }
+    end
 
+    describe "#render_template" do
       context "when no destination is given" do
         let(:destination) { nil }
 
@@ -59,24 +59,25 @@ module Omnibus
           expect(destination).to be_an_executable
         end
       end
+    end
 
+    describe "#render_template_content" do
       context "when an undefined variable is used" do
         let(:contents) { "<%= not_a_real_variable %>" }
 
         it "raise an exception" do
           expect do
-            subject.render_template(source, options)
+            subject.render_template_content(source, variables)
           end.to raise_error(NameError)
         end
       end
 
       context "when no variables are present" do
-        let(:content)   { "static content" }
+        let(:contents) { "static content" }
         let(:variables) { {} }
 
         it "renders the template" do
-          subject.render_template(source, options)
-          expect(destination).to be_a_file
+          expect(subject.render_template_content(source, variables)).to eq("static content")
         end
       end
     end

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -148,13 +148,43 @@ module Omnibus
     end
 
     describe "#write_pkg_metadata" do
+      let(:resources_path) { File.join(tmp_path, "resources/path") }
+      let(:manifest_file) { File.join(staging_dir, "gen.manifestfile") }
+
       it "should create metadata correctly" do
         subject.write_pkg_metadata
-        manifest_file = File.join(staging_dir, "gen.manifestfile")
-        manifest_file_contents = File.read(manifest_file)
         expect(File.exist?(manifest_file)).to be(true)
+        manifest_file_contents = File.read(manifest_file)
         expect(manifest_file_contents).to include("set name=pkg.fmri value=developer/versioning/project@1.2.3,5.11-2")
         expect(manifest_file_contents).to include("set name=variant.arch value=i386")
+      end
+
+      context "when symlinks.erb exists" do
+        before do
+          FileUtils.mkdir_p(resources_path)
+          allow(subject).to receive(:resources_path).and_return(resources_path)
+          File.open(File.join(resources_path, "symlinks.erb"), "w+") do |f|
+            f.puts("link path=usr/bin/ohai target=<%= projectdir %>/bin/ohai")
+            f.puts("link path=<%= projectdir %>/bin/gmake target=<%= projectdir %>/embedded/bin/make")
+          end
+        end
+
+        it "should append symlinks to metadata contents" do
+          subject.write_pkg_metadata
+          expect(File.exist?(manifest_file)).to be(true)
+          manifest_file_contents = File.read(manifest_file)
+          expect(manifest_file_contents).to include("link path=usr/bin/ohai target=/opt/project/bin/ohai")
+          expect(manifest_file_contents).to include("link path=/opt/project/bin/gmake target=/opt/project/embedded/bin/make")
+        end
+      end
+
+      context "when symlinks.erb does not exist" do
+        it "#write_pkg_metadata does not include symlinks" do
+          subject.write_pkg_metadata
+          manifest_file = File.join(staging_dir, "gen.manifestfile")
+          manifest_file_contents = File.read(manifest_file)
+          expect(manifest_file_contents).not_to include("link path=usr/bin/ohai target=/opt/project/bin/ohai")
+        end
       end
     end
 


### PR DESCRIPTION
### Description

IPS package creation script looks for symlinks.erb in local project resources and adds them to
manifest file so the IPS package will install symlinks from the template. These are the links added by post install scripts for other package types. But since IPS does not use post install scripts they need to be added here.

Fixes issue: https://github.com/chef/chef/issues/5458
---

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
@chef/engineering-services 
#### Maintainers

Please ensure that you check for:
- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
  - Looks for symlinks.erb in project directories and adds them to
    manifest file
  - Add unit tests for symlinks file creation
  - Update unit tests for manifest file creation

Signed-off-by: Jaymala Sinha jsinha@chef.io
