### PR TITLE
Check for the transitive dependency licensing errors during post_build.

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -147,6 +147,7 @@ module Omnibus
       collect_licenses_for(software)
       unless software.skip_transitive_dependency_licensing
         collect_transitive_dependency_licenses_for(software)
+        check_transitive_dependency_licensing_errors_for(software)
       end
     end
 
@@ -452,18 +453,6 @@ module Omnibus
     # 3. Add these licenses to the main manifest, to be merged with the main
     # licensing information from software definitions.
     def process_transitive_dependency_licensing_info
-      Dir.glob("#{cache_dir}/*").each do |license_output_dir|
-        reporter = LicenseScout::Reporter.new(license_output_dir)
-        begin
-          reporter.report.each { |i| transitive_dependency_licensing_warning(i) }
-        rescue LicenseScout::Exceptions::InvalidOutputReport => e
-          transitive_dependency_licensing_warning(<<-EOH)
-Licensing output report at '#{license_output_dir}' has errors:
-#{e}
-EOH
-        end
-      end
-
       Dir.glob("#{cache_dir}/*/*-dependency-licenses.json").each do |license_manifest_path|
         license_manifest_data = FFI_Yajl::Parser.parse(File.read(license_manifest_path))
         project_name = license_manifest_data["project_name"]
@@ -512,12 +501,11 @@ EOH
       # the build completes we will process these license files but we need to
       # perform this step after build, before git_cache to be able to operate
       # correctly with the git_cache.
-      license_output_dir = File.join(cache_dir, software.name)
 
       collector = LicenseScout::Collector.new(
         software.name,
         software.project_dir,
-        license_output_dir,
+        license_output_dir(software),
         LicenseScout::Options.new(
           environment: software.with_embedded_path,
           ruby_bin: software.embedded_bin("ruby"),
@@ -569,6 +557,25 @@ EOH
         # from cache without fixing the license issue.
         raise_if_warnings_fatal!
       end
+    end
+
+    # Checks transitive dependency licensing errors for the given software
+    def check_transitive_dependency_licensing_errors_for(software)
+      reporter = LicenseScout::Reporter.new(license_output_dir(software))
+      begin
+        reporter.report.each { |i| transitive_dependency_licensing_warning(i) }
+      rescue LicenseScout::Exceptions::InvalidOutputReport => e
+        transitive_dependency_licensing_warning(<<-EOH)
+Licensing output report at '#{license_output_dir(software)}' has errors:
+#{e}
+EOH
+      end
+      raise_if_warnings_fatal!
+    end
+
+    # The directory to store the licensing information for the given software
+    def license_output_dir(software)
+      File.join(cache_dir, software.name)
     end
 
     # Collect the license files for the software.

--- a/spec/functional/licensing_spec.rb
+++ b/spec/functional/licensing_spec.rb
@@ -155,6 +155,8 @@ module Omnibus
       softwares.each { |s| project.library.component_added(s) }
 
       Licensing.create_incrementally(project) do |licensing|
+        yield licensing if block_given?
+
         project.softwares.each do |software|
           licensing.execute_post_build(software)
         end
@@ -313,13 +315,8 @@ module Omnibus
 
       it "does not collect transitive licensing info for any software" do
         softwares.each { |s| project.library.component_added(s) }
-
-        Licensing.create_incrementally(project) do |licensing|
+        create_licenses do |licensing|
           expect(licensing).not_to receive(:collect_transitive_dependency_licenses_for)
-
-          project.softwares.each do |software|
-            licensing.execute_post_build(software)
-          end
         end
       end
     end
@@ -416,6 +413,20 @@ module Omnibus
         it "logs the warnings" do
           output = capture_logging { create_licenses }
           expect(output).to include("This is a licensing warning!!!")
+        end
+
+        describe "when :fatal_transitive_dependency_licensing_warnings is set" do
+          before do
+            Omnibus::Config.fatal_transitive_dependency_licensing_warnings(true)
+          end
+
+          it "raises an error after post_build step" do
+            expect do
+              create_licenses do |licensing|
+                expect(licensing).not_to receive(:process_transitive_dependency_licensing_info)
+              end
+            end.to raise_error(Omnibus::LicensingError)
+          end
         end
       end
 


### PR DESCRIPTION
### Description

With this change we do not need to clean the omnibus cache anymore after an error in transitive dependency licensing because we will not cache the build in `git_cache` if there is a transitive dependency error. 

Also tested with https://github.com/chef/omnibus-harmony project.

--------------------------------------------------
/cc @chef/omnibus-maintainers