### PR TITLE
Add some more file endings and path patterns to exclude

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -159,29 +159,38 @@ module Omnibus
     ].freeze
 
     IGNORED_ENDINGS = %w{
+      .TXT
       .[ch]
+      .bat
+      .beam
+      .cmake
       .e*rb
       .gemspec
       .gitignore
       .h*h
       .java
       .js
+      .jsm
       .json
       .lock
       .log
       .lua
       .md
       .mkd
+      .npmignore
       .out
       .pl
       .pm
       .png
+      .pod
       .py[oc]*
       .r*html
       .rdoc
       .ri
+      .rst
       .sh
       .sql
+      .svg
       .toml
       .ttf
       .txt
@@ -189,12 +198,16 @@ module Omnibus
       .yml
       Gemfile
       LICENSE
+      Makefile
       README
       Rakefile
       VERSION
+      license
     }.freeze
 
     IGNORED_PATTERNS = %w{
+      /LICENSES/
+      /man/
       /share/doc/
       /share/postgresql/
       /share/terminfo/

--- a/spec/unit/health_check_spec.rb
+++ b/spec/unit/health_check_spec.rb
@@ -139,7 +139,7 @@ module Omnibus
         )
       end
 
-      let(:regexp) { ".*(\\.[ch]|\\.e*rb|\\.gemspec|\\.gitignore|\\.h*h|\\.java|\\.js|\\.json|\\.lock|\\.log|\\.lua|\\.md|\\.mkd|\\.out|\\.pl|\\.pm|\\.png|\\.py[oc]*|\\.r*html|\\.rdoc|\\.ri|\\.sh|\\.sql|\\.toml|\\.ttf|\\.txt|\\.xml|\\.yml|Gemfile|LICENSE|README|Rakefile|VERSION)$|.*\\/share\\/doc\\/.*|.*\\/share\\/postgresql\\/.*|.*\\/share\\/terminfo\\/.*|.*\\/terminfo\\/.*" }
+      let(:regexp) { ".*(\\.TXT|\\.[ch]|\\.bat|\\.beam|\\.cmake|\\.e*rb|\\.gemspec|\\.gitignore|\\.h*h|\\.java|\\.js|\\.jsm|\\.json|\\.lock|\\.log|\\.lua|\\.md|\\.mkd|\\.npmignore|\\.out|\\.pl|\\.pm|\\.png|\\.pod|\\.py[oc]*|\\.r*html|\\.rdoc|\\.ri|\\.rst|\\.sh|\\.sql|\\.svg|\\.toml|\\.ttf|\\.txt|\\.xml|\\.yml|Gemfile|LICENSE|Makefile|README|Rakefile|VERSION|license)$|.*\\/LICENSES\\/.*|.*\\/man\\/.*|.*\\/share\\/doc\\/.*|.*\\/share\\/postgresql\\/.*|.*\\/share\\/terminfo\\/.*|.*\\/terminfo\\/.*" }
 
       it "raises an exception when there are external dependencies" do
         allow(subject).to receive(:shellout)


### PR DESCRIPTION
### Description

This gets the health check time of chef-server from 44s to 27s. (Haven't had a chance to test it with Automate yet, but this is where I draw inspiration from for further stuff to exclude...)

For future reference: changing the `find` call to 
```
read_shared_libs("find #{project.install_dir}/ -type f -regextype posix-extended ! -regex '#{regexp}' -exec sh -c \"readelf -d {} >/dev/null 2>&1\" \\; -print0 | xargs -0 ldd") do |line|
```

to exclude further files -- _by paying with a shellout of `sh` and `readelf` to figure out if that's save_ --saves another 4s only. Since this also requires readelf (package binutils) to be present, I refrain from proposing that change (for now...)

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [X] If this change impacts git cache validity, it bumps the git cache
  serial number
- [X] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [X] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan