### PR TITLE
Add support for S3 transfer acceleration for S3 Cache

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -297,6 +297,16 @@ module Omnibus
       "us-east-1"
     end
 
+    # The HTTP or HTTPS endpoint to send requests to, when using non-standard endpoint
+    #
+    # @return [String, nil]
+    default(:s3_endpoint, nil)
+
+    # Enable or disable S3 Accelerate support
+    #
+    # @return [true, false]
+    default(:s3_accelerate, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -144,7 +144,7 @@ module Omnibus
     #
     def download_url
       if Config.use_s3_caching
-        "http://#{Config.s3_bucket}.s3.amazonaws.com/#{S3Cache.key_for(self)}"
+        S3Cache.url_for(self)
       else
         source[:url]
       end

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -132,14 +132,20 @@ module Omnibus
         "#{software.name}-#{software.version}-#{software.fetcher.checksum}"
       end
 
+      def url_for(software)
+        client.bucket(Config.s3_bucket).object(S3Cache.key_for(software)).public_url
+      end
+
       private
 
       def s3_configuration
         {
-          region:               Config.s3_region,
-          access_key_id:        Config.s3_access_key,
-          secret_access_key:    Config.s3_secret_key,
-          bucket_name:          Config.s3_bucket,
+          region:                  Config.s3_region,
+          access_key_id:           Config.s3_access_key,
+          secret_access_key:       Config.s3_secret_key,
+          bucket_name:             Config.s3_bucket,
+          endpoint:                Config.s3_endpoint,
+          use_accelerate_endpoint: Config.s3_accelerate
         }
       end
 

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -145,7 +145,7 @@ module Omnibus
           secret_access_key:       Config.s3_secret_key,
           bucket_name:             Config.s3_bucket,
           endpoint:                Config.s3_endpoint,
-          use_accelerate_endpoint: Config.s3_accelerate
+          use_accelerate_endpoint: Config.s3_accelerate,
         }
       end
 

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -60,10 +60,17 @@ module Omnibus
           region:                   s3_configuration[:region],
           access_key_id:            s3_configuration[:access_key_id],
           secret_access_key:        s3_configuration[:secret_access_key],
-          use_accelerate_endpoint:  s3_configuration[:use_accelerate_endpoint]
+          use_accelerate_endpoint:  s3_configuration[:use_accelerate_endpoint],
         }
 
-        params.merge(endpoint:      s3_configuration[:endpoint]) if s3_configuration[:endpoint]
+        if s3_configuration[:use_accelerate_endpoint]
+          params[:endpoint] = "https://s3-accelerate.amazonaws.com"
+        end
+
+        if s3_configuration[:endpoint]
+          params[:endpoint] = s3_configuration[:endpoint]
+        end
+
         params
       end
 

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -32,10 +32,12 @@ module Omnibus
       #
       # @example
       #   {
-      #     region:               'us-east-1',
-      #     access_key_id:        Config.s3_access_key,
-      #     secret_access_key:    Config.s3_secret_key,
-      #     bucket_name:          Config.s3_bucket
+      #     region:                   'us-east-1',
+      #     access_key_id:            Config.s3_access_key,
+      #     secret_access_key:        Config.s3_secret_key,
+      #     bucket_name:              Config.s3_bucket,
+      #     endpoint:                 Config.s3_endpoint,
+      #     use_accelerate_endpoint:  Config.s3_accelerate
       #   }
       #
       # @return [Hash<String, String>]
@@ -50,11 +52,19 @@ module Omnibus
       # @return [Aws::S3::Resource]
       #
       def client
-        @s3_client ||= Aws::S3::Resource.new(
-          region:            s3_configuration[:region],
-          access_key_id:     s3_configuration[:access_key_id],
-          secret_access_key: s3_configuration[:secret_access_key]
-        )
+        @s3_client ||= Aws::S3::Resource.new(client_params)
+      end
+
+      def client_params
+        params = {
+          region:                   s3_configuration[:region],
+          access_key_id:            s3_configuration[:access_key_id],
+          secret_access_key:        s3_configuration[:secret_access_key],
+          use_accelerate_endpoint:  s3_configuration[:use_accelerate_endpoint]
+        }
+
+        params.merge(endpoint:      s3_configuration[:endpoint]) if s3_configuration[:endpoint]
+        params
       end
 
       #

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -176,6 +176,27 @@ module Omnibus
       end
     end
 
+    describe '#download_url' do
+      context 's3 cache enabled' do
+        before do
+          Config.use_s3_caching(true)
+          Config.s3_access_key('ABCD1234')
+          Config.s3_secret_key('EFGH5678')
+          Config.s3_bucket('mybucket')
+        end
+
+        it 'returns the source url' do
+          expect(subject.send(:download_url)).to eq('https://mybucket.s3.amazonaws.com/file-1.2.3-abcd1234')
+        end
+      end
+
+      context 's3 cache disabled' do
+        it 'returns the source url' do
+          expect(subject.send(:download_url)).to eq('https://get.example.com/file.tar.gz')
+        end
+      end
+    end
+
     describe "downloading the file" do
 
       let(:expected_open_opts) do

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -176,23 +176,42 @@ module Omnibus
       end
     end
 
-    describe '#download_url' do
-      context 's3 cache enabled' do
+    describe "#download_url" do
+      context "s3 cache enabled" do
         before do
           Config.use_s3_caching(true)
-          Config.s3_access_key('ABCD1234')
-          Config.s3_secret_key('EFGH5678')
-          Config.s3_bucket('mybucket')
+          Config.s3_access_key("ABCD1234")
+          Config.s3_secret_key("EFGH5678")
+          Config.s3_bucket("mybucket")
+
+          # clear cache
+          S3Cache.remove_instance_variable(:@s3_client) if S3Cache.instance_variable_defined?(:@s3_client)
         end
 
-        it 'returns the source url' do
-          expect(subject.send(:download_url)).to eq('https://mybucket.s3.amazonaws.com/file-1.2.3-abcd1234')
+        it "returns the source s3 generated url" do
+          expect(subject.send(:download_url)).to eq("https://mybucket.s3.amazonaws.com/file-1.2.3-abcd1234")
+        end
+
+        context "custom endpoint" do
+          before { Config.s3_endpoint("http://example.com") }
+
+          it "returns the url using custom s3 endpoint" do
+            expect(subject.send(:download_url)).to eq("http://mybucket.example.com/file-1.2.3-abcd1234")
+          end
+        end
+
+        context "s3 transfer acceleration" do
+          before { Config.s3_accelerate(true) }
+
+          it "returns the url using s3 accelerate endpoint" do
+            expect(subject.send(:download_url)).to eq("https://mybucket.s3-accelerate.amazonaws.com/file-1.2.3-abcd1234")
+          end
         end
       end
 
-      context 's3 cache disabled' do
-        it 'returns the source url' do
-          expect(subject.send(:download_url)).to eq('https://get.example.com/file.tar.gz')
+      context "s3 cache disabled" do
+        it "returns the source url" do
+          expect(subject.send(:download_url)).to eq("https://get.example.com/file.tar.gz")
         end
       end
     end


### PR DESCRIPTION
### Description

Omnibus can use S3 to cache software assets used during the build to speedup the process.

If we have a slow connection to S3, it will slow down the whole build process. To fight that we can either enable S3 Transfer Acceleration, or host something like "MinIO" closer to where the build runs.

Unfortunately, there is no way to either change the endpoint or enable the S3 transfer acceleration flag to the `aws-sdk` in omnibus.

From the `NetFetcher`, the endpoint is hardcoded (you can only customize the bucket name):
> https://github.com/chef/omnibus/blob/3eefb1cd8de69b1d97de2962f779512892e9296d/lib/omnibus/fetchers/net_fetcher.rb#L145-L151

And From the `S3Cache` you can't set the `:endpoint` [configuration param](https://github.com/aws/aws-sdk-ruby#configuration) nor can you define the `:use_accelerate_endpoint` [flag](https://github.com/aws/aws-sdk-ruby/blob/9e05bc17ad7a20379820301c5d21692fff9f99dd/aws-sdk-core/lib/aws-sdk-core/plugins/s3_accelerate.rb#L10):
> https://github.com/chef/omnibus/blob/3eefb1cd8de69b1d97de2962f779512892e9296d/lib/omnibus/s3_cache.rb#L137-L144

## Proposal

Make `:endpoint` configurable in S3Cache, and use it to generate the URL in `NetFetcher`.
the new configuration in `omnibus.rb` configuration file will be called: `s3_endpoint`

Add a configuration flag to optionally use the S3 Transfer Acceleration within the AWS-SDK bundled support.

Both solutions are required to enable either custom S3 endpoints, or to use the AWS officially supported S3 Transfer Acceleration.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
