### PR TITLE
Add msys2 support behind feature flag

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -281,6 +281,14 @@ module Omnibus
     expose :windows_safe_path
 
     #
+    # (see Util#to_msys2_path)
+    #
+    def to_msys2_path(*pieces)
+      super
+    end
+    expose :to_msys2_path
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -81,10 +81,6 @@ module Omnibus
       warn_for_shell_commands(command)
 
       build_commands << BuildCommand.new("Execute: `#{command}'") do
-        # If we expect the command to run cleanly in windows within a limited
-        # msys shell, we also expect it to run cleanly on other platforms
-        # without the assistance of our chef or ruby binaries.
-        options[:clean_ruby_path] = true if options[:in_msys_bash]
         shellout!(command, options)
       end
     end
@@ -249,7 +245,6 @@ module Omnibus
 
       patches << patch_path
       options[:in_msys_bash] = true
-      options[:clean_ruby_path] = true
       build_commands << BuildCommand.new("Apply patch `#{source}'") do
         shellout!(patch_cmd, options)
       end
@@ -311,7 +306,6 @@ module Omnibus
     def ruby(command, options = {})
       build_commands << BuildCommand.new("ruby `#{command}'") do
         bin = embedded_bin("ruby")
-        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -329,7 +323,6 @@ module Omnibus
     def gem(command, options = {})
       build_commands << BuildCommand.new("gem `#{command}'") do
         bin = embedded_bin("gem")
-        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -350,7 +343,6 @@ module Omnibus
     def bundle(command, options = {})
       build_commands << BuildCommand.new("bundle `#{command}'") do
         bin = embedded_bin("bundle")
-        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end
@@ -384,7 +376,6 @@ module Omnibus
         # Ensure the main bin dir exists
         FileUtils.mkdir_p(bin_dir)
 
-        options[:clean_ruby_path] = true
         shellout!("#{appbundler_bin} '#{app_software.project_dir}' '#{bin_dir}'", options)
       end
     end
@@ -403,7 +394,6 @@ module Omnibus
     def rake(command, options = {})
       build_commands << BuildCommand.new("rake `#{command}'") do
         bin = embedded_bin("rake")
-        options[:clean_ruby_path] = true
         shellout!("#{bin} #{command}", options)
       end
     end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -737,7 +737,7 @@ module Omnibus
       # On windows, make this an msys style path because autotools don't grok
       # windows paths and use : as a path separator. See the mingw cookbook for
       # how the flag gets passed into the msys2 shell.
-      if windows?
+      if windows? && ENV["MSYS_TOOLCHAIN"]
         pkg_config_flags["PREMSYS2_PKG_CONFIG_PATH"] = to_msys2_path(pkg_config_flags["PKG_CONFIG_PATH"])
       end
 
@@ -765,7 +765,7 @@ module Omnibus
       new_env = env.merge(path_key => path_value)
 
       # Extra path elements for msys2.
-      if windows?
+      if windows? && ENV["MSYS_TOOLCHAIN"]
         msys2_paths = paths.map { |x| to_msys2_path(x) }
         new_env["PREMSYS2_PATH"] = msys2_paths.join(":")
       end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -674,7 +674,7 @@ module Omnibus
           arch_flag = windows_arch_i386? ? "-m32" : "-m64"
           opt_flag = windows_arch_i386? ? "-march=i686" : "-march=x86-64"
           {
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -fno-lto",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib #{arch_flag} -Wl,-rpath,#{install_dir}/embedded/lib",
             # We do not wish to enable SSE even though we target i686 because
             # of a stack alignment issue with some libraries. We have not
             # exactly ascertained the cause but some compiled library/binary
@@ -688,9 +688,7 @@ module Omnibus
             # TODO: This was true of our old TDM gcc 4.7 compilers. Is it still
             # true with mingw-w64?
             #
-            # XXX: Temporarily turning -O3 into -O2 -fno-lto to work around some
-            # weird linker issues.
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O2 -fno-lto #{opt_flag}",
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 #{opt_flag}",
           }
         else
           {
@@ -729,12 +727,23 @@ module Omnibus
         extra_linker_flags["LD_OPTIONS"] = ld_options
       end
 
+      # Always want to favor pkg-config from embedded location to not hose
+      # configure scripts which try to be too clever and ignore our explicit
+      # CFLAGS and LDFLAGS in favor of pkg-config info.
+      pkg_config_flags = {
+        "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig",
+      }
+
+      # On windows, make this an msys style path because autotools don't grok
+      # windows paths and use : as a path separator. See the mingw cookbook for
+      # how the flag gets passed into the msys2 shell.
+      if windows?
+        pkg_config_flags["PREMSYS2_PKG_CONFIG_PATH"] = to_msys2_path(pkg_config_flags["PKG_CONFIG_PATH"])
+      end
+
       env.merge(compiler_flags).
         merge(extra_linker_flags).
-        # always want to favor pkg-config from embedded location to not hose
-        # configure scripts which try to be too clever and ignore our explicit
-        # CFLAGS and LDFLAGS in favor of pkg-config info
-        merge({ "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig" }).
+        merge(pkg_config_flags).
         # Set default values for CXXFLAGS and CPPFLAGS.
         merge("CXXFLAGS" => compiler_flags["CFLAGS"]).
         merge("CPPFLAGS" => compiler_flags["CFLAGS"])
@@ -753,7 +762,14 @@ module Omnibus
     def with_embedded_path(env = {})
       paths = ["#{install_dir}/bin", "#{install_dir}/embedded/bin"]
       path_value = prepend_path(paths)
-      env.merge(path_key => path_value)
+      new_env = env.merge(path_key => path_value)
+
+      # Extra path elements for msys2.
+      if windows?
+        msys2_paths = paths.map { |x| to_msys2_path(x) }
+        new_env["PREMSYS2_PATH"] = msys2_paths.join(":")
+      end
+      new_env
     end
     expose :with_embedded_path
 
@@ -1115,6 +1131,10 @@ module Omnibus
 
     private
 
+    def to_msys2_path(path)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
     #
     # The git caching implementation for this software.
     #
@@ -1122,28 +1142,6 @@ module Omnibus
     #
     def git_cache
       @git_cache ||= GitCache.new(self)
-    end
-
-    #
-    # The proper platform-specific "$PATH" key.
-    #
-    # @return [String]
-    #
-    def path_key
-      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
-      # $WINDOWSRAGE, and if you don't set that your native gem compiles
-      # will fail because the magic fixup it does to add the mingw compiler
-      # stuff won't work.
-      #
-      # Turns out there is other build environments that only set ENV['PATH'] and if we
-      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
-      # one that we find.
-      #
-      if Ohai["platform"] == "windows"
-        ENV.keys.grep(/\Apath\Z/i).first
-      else
-        "PATH"
-      end
     end
 
     #

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1131,10 +1131,6 @@ module Omnibus
 
     private
 
-    def to_msys2_path(path)
-      path.sub(/^([A-Za-z]):\//, "/\\1/")
-    end
-
     #
     # The git caching implementation for this software.
     #

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -114,7 +114,7 @@ module Omnibus
         path_dirs = path_dirs.map { |p| windows_safe_path(p) }
         safe_install_dir = windows_safe_path(install_dir)
         path_dirs = path_dirs.reject do |p|
-          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| safe_p.start_with?(f) }
+          !p.start_with?(safe_install_dir) && filter_paths.any? { |f| p.start_with?(f) }
         end
         options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
       end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -21,6 +21,7 @@ module Omnibus
     def self.included(base)
       # This module requires logging is also available
       base.send(:include, Logging)
+      base.send(:include, Sugarable)
     end
 
     #
@@ -33,6 +34,31 @@ module Omnibus
       timeout: 7200, # 2 hours
       environment: {},
     }.freeze
+
+    #
+    # The proper platform-specific "$PATH" key.
+    #
+    # @return [String]
+    #
+    def path_key
+      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
+      # $WINDOWSRAGE, and if you don't set that your native gem compiles
+      # will fail because the magic fixup it does to add the mingw compiler
+      # stuff won't work.
+      #
+      # Turns out there is other build environments that only set ENV['PATH'] and if we
+      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
+      # one that we find.
+      #
+      if windows?
+        result = ENV.keys.grep(/\Apath\Z/i)
+        raise "The current omnibus environment has no PATH" if result.length == 0
+        raise "The current omnibus environment has duplicate PATHs" if result.length > 1
+        result.first
+      else
+        "PATH"
+      end
+    end
 
     #
     # Shells out and runs +command+.
@@ -53,6 +79,14 @@ module Omnibus
       options = args.last.kind_of?(Hash) ? args.pop : {}
       options = SHELLOUT_OPTIONS.merge(options)
 
+      command_string = args.join(" ")
+      in_msys = options.delete(:in_msys_bash) && windows?
+      # Mixlib will handle escaping characters for cmd but our command might
+      # contain '. For now, assume that won't happen because I don't know
+      # whether this command is going to be played via cmd or through
+      # ProcessCreate.
+      command_string = "bash -c \'#{command_string}\'" if in_msys
+
       # Grab the log_level
       log_level = options.delete(:log_level)
 
@@ -65,18 +99,54 @@ module Omnibus
         options[:environment] = options.fetch(:environment, {}).merge(options[:env])
       end
 
+      # Double check that we don't have conflicting PATH definitions.
+      path_keys = options[:environment].keys.grep(/\Apath\Z/i)
+      if path_keys.length > 1
+        raise InvalidValue.new("shellout", "receive environment without duplicate PATH values")
+      elsif path_keys.length == 1 && path_keys.first != path_key
+        options[:environment][path_key] = options[:environment].delete(path_keys.first)
+      end
+
+      # Try our best to get rid of the "outer" omnibus ruby and any current
+      # chef-client/chef-dk installations from the path.
+      if options.delete(:clean_ruby_path)
+        path_dirs = options[:environment].fetch(path_key, "").split(File::PATH_SEPARATOR || ":")
+        path_dirs = path_dirs.reject do |p|
+          filter_paths.any? { |f| windows_safe_path(p).start_with?(f) }
+        end
+        options[:environment][path_key] = path_dirs.join(File::PATH_SEPARATOR || ":")
+      end
+
       # Log any environment options given
       unless options[:environment].empty?
         log.public_send(log_level, log_key) { "Environment:" }
-        options[:environment].sort.each do |key, value|
-          log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+        if in_msys
+          # Run a command to log the actual environment variables inside the
+          # msys shell. Live stream at the same level we would have otherwise
+          # logged the environment at.
+          env_options = options.dup
+          env_options[:live_stream] = log.live_stream(log_level || :info)
+          env_cmds = options[:environment].keys.sort.map do |key|
+            # Special case "PATH" because it's capitalized and handled differently.
+            key = "PATH" if key == path_key
+            "echo #{key}=$#{key}"
+          end
+          env_cmds << "echo PWD=$PWD"
+
+          cmd = Mixlib::ShellOut.new("bash -c \'#{env_cmds.join(';')}\'", env_options)
+          cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
+          cmd.run_command
+        else
+          options[:environment].sort.each do |key, value|
+            log.public_send(log_level, log_key) { "  #{key}=#{value.inspect}" }
+          end
         end
       end
 
       # Log the actual command
-      log.public_send(log_level, log_key) { "$ #{args.join(' ')}" }
+      log.public_send(log_level, log_key) { "$ #{command_string}" }
 
-      cmd = Mixlib::ShellOut.new(*args, options)
+      cmd = Mixlib::ShellOut.new(command_string, options)
       cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
       cmd.run_command
       cmd
@@ -219,6 +289,25 @@ module Omnibus
     def create_link(a, b)
       log.debug(log_key) { "Linking `#{a}' to `#{b}'" }
       FileUtils.ln_s(a, b)
+    end
+
+    private
+
+    def filter_paths
+      @filter_paths ||=
+        begin
+          # Any alternate binaries or gems from the users environment.
+          filters = Gem.paths.path.dup
+          # Any possible embedded ruby in chef products.
+          if windows?
+            filters << "C:/opscode"
+          else
+            filters << "/opt/chef" << "/opt/chefdk" << "/opt/delivery-cli"
+          end
+          # Current ruby - this is the ruby that omnibus itself uses.
+          filters << File.expand_path(File.join(RbConfig.ruby, "../.."))
+          filters.map { |p| windows_safe_path(p) }
+        end
     end
   end
 end

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -192,6 +192,18 @@ module Omnibus
     end
 
     #
+    # Takes a ruby style path (e.g. C:/foo/bar) and coverts it to an msys path (/C/foo/bar).
+    #
+    # @param [String, Array<String>] pieces
+    #   the pieces of the path to join and fix
+    # @return [String]
+    #
+    def to_msys2_path(*pieces)
+      path = File.join(*pieces)
+      path.sub(/^([A-Za-z]):\//, "/\\1/")
+    end
+
+    #
     # Create a directory at the given +path+.
     #
     # @param [String, Array<String>] paths

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -109,7 +109,7 @@ module Omnibus
 
       # Try our best to get rid of the "outer" omnibus ruby and any current
       # chef-client/chef-dk installations from the path.
-      if options.delete(:clean_ruby_path)
+      if ENV["MSYS_TOOLCHAIN"]
         path_dirs = options[:environment].fetch(path_key, "").split(File::PATH_SEPARATOR || ":")
         path_dirs = path_dirs.map { |p| windows_safe_path(p) }
         safe_install_dir = windows_safe_path(install_dir)

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -303,28 +303,28 @@ module Omnibus
       it "invokes patch with patch level 1 unless specified" do
         expect { subject.patch(source: "good_patch") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch with patch level provided" do
         expect { subject.patch(source: "good_patch", plevel: 0) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
+          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "invokes patch differently if target is provided" do
         expect { subject.patch(source: "good_patch", target: "target/path") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true)
+          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
 
       it "persists other options" do
         expect { subject.patch(source: "good_patch", timeout: 3600) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true, clean_ruby_path: true)
         run_build_command
       end
     end

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -303,28 +303,28 @@ module Omnibus
       it "invokes patch with patch level 1 unless specified" do
         expect { subject.patch(source: "good_patch") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
         run_build_command
       end
 
       it "invokes patch with patch level provided" do
         expect { subject.patch(source: "good_patch", plevel: 0) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true, clean_ruby_path: true)
+          .with("patch -p0 -i #{project_dir}/patch_location2/good_patch", in_msys_bash: true)
         run_build_command
       end
 
       it "invokes patch differently if target is provided" do
         expect { subject.patch(source: "good_patch", target: "target/path") }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true, clean_ruby_path: true)
+          .with("cat #{project_dir}/patch_location2/good_patch | patch -p1 target/path", in_msys_bash: true)
         run_build_command
       end
 
       it "persists other options" do
         expect { subject.patch(source: "good_patch", timeout: 3600) }.to_not raise_error
         expect(subject).to receive(:shellout!)
-          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true, clean_ruby_path: true)
+          .with("patch -p1 -i #{project_dir}/patch_location2/good_patch", timeout: 3600, in_msys_bash: true)
         run_build_command
       end
     end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -340,9 +340,25 @@ module Omnibus
               "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
               "LDFLAGS"         => "-L/opt/project/embedded/lib -m32 -Wl,-rpath,/opt/project/embedded/lib",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
-              "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
             )
+          end
+
+          context "with MSYS_TOOLCHAIN enabled" do
+            before { ENV["MSYS_TOOLCHAIN"] = "true" }
+            after { ENV.delete("MSYS_TOOLCHAIN") }
+
+            it "sets a modified default" do
+              expect(subject.with_standard_compiler_flags).to eq(
+                "CFLAGS"          => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+                "CXXFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+                "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+                "LDFLAGS"         => "-L/opt/project/embedded/lib -m32 -Wl,-rpath,/opt/project/embedded/lib",
+                "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+                "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+                "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              )
+            end
           end
         end
 
@@ -356,9 +372,25 @@ module Omnibus
               "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
               "LDFLAGS"         => "-L/opt/project/embedded/lib -m64 -Wl,-rpath,/opt/project/embedded/lib",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
-              "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
             )
+          end
+
+          context "with MSYS_TOOLCHAIN enabeld" do
+            before { ENV["MSYS_TOOLCHAIN"] = "true" }
+            after { ENV.delete("MSYS_TOOLCHAIN") }
+
+            it "sets a modified default" do
+              expect(subject.with_standard_compiler_flags).to eq(
+                "CFLAGS"          => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+                "CXXFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+                "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+                "LDFLAGS"         => "-L/opt/project/embedded/lib -m64 -Wl,-rpath,/opt/project/embedded/lib",
+                "LD_RUN_PATH"     => "/opt/project/embedded/lib",
+                "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+                "PREMSYS2_PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              )
+            end
           end
         end
       end


### PR DESCRIPTION
### Description

This takes the important bits from the existing msys2 branch and hides certain portion of the code behind a feature flag controlled by the `MSYS_TOOLCHAIN` environment flag. When the omnibus-toolchain modifications are complete, we should be able to come back through and remove these components. 

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
