### PR TITLE
Make RPM and DEB package compression configurable

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -228,6 +228,56 @@ module Omnibus
     expose :dist_tag
 
     #
+    # Set or return the compression type (:gzip, :bzip2, :xz) for this package
+    #
+    # @example
+    #   compression_type :xz
+    #
+    # @param [Symbol] val
+    #   the compression type
+    #
+    # @return [String]
+    #   the compression type for this package
+    #
+    def compression_type(val = NULL)
+      if null?(val)
+        @compression_type || :gzip
+      else
+        unless val.is_a?(Symbol) && [:gzip, :bzip2, :xz].member?(val)
+          raise InvalidValue.new(:compression_type, "be a Symbol (:gzip, :bzip2, or :xz)")
+        end
+
+        @compression_type = val
+      end
+    end
+    expose :compression_type
+
+    #
+    # Set or return the compression level (1-9) for this package
+    #
+    # @example
+    #   compression_level 6
+    #
+    # @param [Integer] val
+    #   the compression level
+    #
+    # @return [Integer]
+    #   the compression level for this package
+    #
+    def compression_level(val = NULL)
+      if null?(val)
+        @compression_level || 9
+      else
+        unless val.is_a?(Integer) && 1 <= val && 9 >= val
+          raise InvalidValue.new(:compression_level, "be an Integer (between 1 and 9)")
+        end
+
+        @compression_level = val
+      end
+    end
+    expose :compression_level
+
+    #
     # @!endgroup
     # --------------------------------------------------
 
@@ -332,8 +382,27 @@ module Omnibus
           files:           files,
           build_dir:       build_dir,
           platform_family: Ohai["platform_family"],
+          compression:     compression,
         }
       )
+    end
+
+    #
+    # Returns the RPM spec "_binary_payload" line corresponding to the
+    # compression configuration.
+    #
+    # @return [String]
+    #
+    def compression
+      compression_name = case compression_type
+                         when :bzip2
+                           "bzdio"
+                         when :xz
+                           "xzdio"
+                         else # default to gzip
+                           "gzdio"
+                         end
+      "w#{compression_level}.#{compression_name}"
     end
 
     #

--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -11,8 +11,7 @@
 # Use md5
 %define _binary_filedigest_algorithm 1
 
-# Use gzip payload compression
-%define _binary_payload w9.gzdio
+%define _binary_payload <%= compression %>
 
 # Metadata
 Name: <%= name %>

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -94,6 +94,48 @@ module Omnibus
       end
     end
 
+    describe "#compression_type" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:compression_type)
+      end
+
+      it "has a default value" do
+        expect(subject.compression_type).to eq(:gzip)
+      end
+
+      it "must be a symbol" do
+        expect { subject.compression_type(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
+    describe "#compression_level" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:compression_level)
+      end
+
+      it "has a default value" do
+        expect(subject.compression_level).to eq(9)
+      end
+
+      it "must be a symbol" do
+        expect { subject.compression_level(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
+    describe "#compression_strategy" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:compression_strategy)
+      end
+
+      it "has a default value" do
+        expect(subject.compression_strategy).to eq(nil)
+      end
+
+      it "must be a symbol" do
+        expect { subject.compression_strategy(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
     describe "#id" do
       it "is :deb" do
         expect(subject.id).to eq(:deb)
@@ -256,6 +298,42 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with(/dpkg-deb -z9 -Zgzip -D --build/)
         subject.create_deb_file
+      end
+
+      describe "when deb compression type xz is configured" do
+        before do
+          subject.compression_type(:xz)
+        end
+
+        it "uses the correct command for xz" do
+          expect(subject).to receive(:shellout!)
+            .with(/dpkg-deb -z9 -Zxz -D --build/)
+          subject.create_deb_file
+        end
+
+        context "when deb compression level is configured" do
+          before do
+            subject.compression_level(6)
+          end
+
+          it "uses the correct command for xz" do
+            expect(subject).to receive(:shellout!)
+              .with(/dpkg-deb -z6 -Zxz -D --build/)
+            subject.create_deb_file
+          end
+        end
+
+        context "when deb compression strategy is configured" do
+          before do
+            subject.compression_strategy(:extreme)
+          end
+
+          it "uses the correct command for xz" do
+            expect(subject).to receive(:shellout!)
+              .with(/dpkg-deb -z9 -Zxz -Sextreme -D --build/)
+            subject.create_deb_file
+          end
+        end
       end
     end
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -124,6 +124,34 @@ module Omnibus
       end
     end
 
+    describe "#compression_type" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:compression_type)
+      end
+
+      it "has a default value" do
+        expect(subject.compression_type).to eq(:gzip)
+      end
+
+      it "must be a symbol" do
+        expect { subject.compression_type(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
+    describe "#compression_level" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:compression_level)
+      end
+
+      it "has a default value" do
+        expect(subject.compression_level).to eq(9)
+      end
+
+      it "must be an integer" do
+        expect { subject.compression_level(Object.new) }.to raise_error(InvalidValue)
+      end
+    end
+
     describe "#id" do
       it "is :rpm" do
         expect(subject.id).to eq(:rpm)
@@ -187,6 +215,55 @@ module Omnibus
         expect(contents).to include("URL: https://example.com")
         expect(contents).to include("Packager: Chef Software")
         expect(contents).to include("Obsoletes: old-project")
+        expect(contents).to include("_binary_payload w9.gzdio")
+      end
+
+      context "when RPM compression type xz is configured" do
+        before do
+          subject.compression_type(:xz)
+        end
+
+        it "has the correct binary_payload line" do
+          subject.write_rpm_spec
+          contents = File.read(spec_file)
+          expect(contents).to include("_binary_payload w9.xzdio")
+        end
+
+        context "when RPM compression level is also configured" do
+          before do
+            subject.compression_level(6)
+          end
+
+          it "has the correct binary_payload line" do
+            subject.write_rpm_spec
+            contents = File.read(spec_file)
+            expect(contents).to include("_binary_payload w6.xzdio")
+          end
+        end
+      end
+
+      context "when RPM compression type bzip2 is configured" do
+        before do
+          subject.compression_type(:bzip2)
+        end
+
+        it "has the correct binary_payload line" do
+          subject.write_rpm_spec
+          contents = File.read(spec_file)
+          expect(contents).to include("_binary_payload w9.bzdio")
+        end
+
+        context "when RPM compression level is also configured" do
+          before do
+            subject.compression_level(6)
+          end
+
+          it "has the correct binary_payload line" do
+            subject.write_rpm_spec
+            contents = File.read(spec_file)
+            expect(contents).to include("_binary_payload w6.bzdio")
+          end
+        end
       end
 
       context "when scripts are given" do


### PR DESCRIPTION
### Description

This allows for configuring the type and level of compression to use for DEB and RPM packages.

It adds new configurables for `config/projects/xyz.rb`, defaulting to what was hardcoded before. For example, choosing xz:

```ruby
package :deb do
  compression_level 6
  compression_type :xz
  compression_strategy :extreme # /!\ dpkg-deb 1.16.1.2 doesn't seem to know this
end
package :rpm do
  compression_level 6
  compression_type :xz
end
```

Fixes #422.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
