### PR TITLE
Remove IPS version dependencies

### DIFF
--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -2,3 +2,4 @@
 <transform file depend -> edit pkg.debug.depend.file ruby env>
 <transform file depend -> edit pkg.debug.depend.file make env>
 <transform file depend -> edit pkg.debug.depend.file perl env>
+<transform pkg depend -> default facet.version-lock.*> false>


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

The IPS package generates version dependencies on base packages in its manifest.
These constraints can be relaxed by setting the version-lock facet to false. This should allow chef-client IPS package to be installed on Solaris11.1 and Solaris11.2

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

@chef/engineering-services 