### PR TITLE
IPS package fixes

### DIFF
--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -2,3 +2,4 @@
 <transform file depend -> edit pkg.debug.depend.file ruby env>
 <transform file depend -> edit pkg.debug.depend.file make env>
 <transform file depend -> edit pkg.debug.depend.file perl env>
+<transform pkg depend -> default facet.version-lock.*> false>

--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -1,2 +1,4 @@
 <transform dir path=<%= pathdir %>$ -> edit group bin sys>
 <transform file depend -> edit pkg.debug.depend.file ruby env>
+<transform file depend -> edit pkg.debug.depend.file make env>
+<transform file depend -> edit pkg.debug.depend.file perl env>

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -144,6 +144,8 @@ module Omnibus
         transform_file_contents = File.read(transform_file)
         expect(transform_file_contents).to include("<transform dir path=opt$ -> edit group bin sys>")
         expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file ruby env>")
+        expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file make env>")
+        expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file perl env>")
       end
     end
 


### PR DESCRIPTION
### Description

Remove IPS version dependencies
The IPS package generates version dependencies on base packages in its manifest.
These constraints can be relaxed by setting the version-lock facet to false. This should allow chef-client IPS package to be installed on Solaris11.1 and Solaris11.2

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

/cc @chef/engineering-services 

