### PR TITLE
Defining fips_enabled? in omnibus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gem "pedump", git: "https://github.com/ksubrama/pedump", branch: "patch-1"
 # Always use license_scout from master
 gem "license_scout", github: "chef/license_scout"
 
+# net-ssh 4.x does not work with Ruby 2.2 on Windows. Chef and ChefDK
+# are pinned to 3.2 so pinning that here. Only used by fauxhai in this project
+gem "net-ssh", "3.2.0"
+
 group :docs do
   gem "yard",          "~> 0.8"
   gem "redcarpet",     "~> 2.2.2"

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -471,6 +471,12 @@ module Omnibus
       :x86
     end
 
+    # Flag specifying whether the project should be built with FIPS
+    # compatability or not.
+    #
+    # @return [true, false]
+    default(:fips_mode, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/sugarable.rb
+++ b/lib/omnibus/sugarable.rb
@@ -67,5 +67,9 @@ module Omnibus
     def windows_arch_i386?
       Config.windows_arch.to_sym == :x86
     end
+
+    def fips_mode?
+      !!Config.fips_mode
+    end
   end
 end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -45,6 +45,7 @@ module Omnibus
     include_examples "a configurable", :fetcher_read_timeout, 60
     include_examples "a configurable", :fetcher_retries, 5
     include_examples "a configurable", :fatal_licensing_warnings, false
+    include_examples "a configurable", :fips_mode, false
 
     describe "#workers" do
       context "when the Ohai data is not present" do

--- a/spec/unit/sugarable_spec.rb
+++ b/spec/unit/sugarable_spec.rb
@@ -12,7 +12,7 @@ module Omnibus
       expect(described_class.singleton_class.included_modules).to include(Sugarable)
     end
 
-    it "includes Sugarable" do
+    it "is a sugarable" do
       expect(described_class.ancestors).to include(Sugarable)
     end
   end
@@ -54,6 +54,26 @@ module Omnibus
           EOH
         end.to_not raise_error
       end
+    end
+  end
+
+  describe Sugar do
+    let(:klass) do
+      Class.new do
+        include Sugar
+      end
+    end
+
+    let(:instance) { klass.new }
+
+    it "returns the windows architecture being built" do
+      expect(Omnibus::Config).to receive(:windows_arch).and_return(:x86_64)
+      expect(instance.windows_arch_i386?).to eq(false)
+    end
+
+    it "returns whether fips_mode is enabled" do
+      expect(Omnibus::Config).to receive(:fips_mode).and_return(false)
+      expect(instance.fips_mode?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
### Description

Add a `fips_mode?` DSL method that we can leveraged in the project and software definitions. This replaces the need to copy around [this](https://github.com/chef/omnibus-software/blob/master/config/software/openssl.rb#L23) override checking line everywhere.

We will instead set `fips_mode = true` on a per-project basis and toggle it per builder.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache serial number
- [x] If this change impacts compatibility with omnibus-software, the corresponding change is reviewed and there is a release plan
- [x] If this change impacts compatibility with the omnibus cookbook, the corresponding change is reviewed and there is a release plan
