### PR TITLE
[BEN-127] Add version-lock facet at end of manifest

### DIFF
--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -2,4 +2,3 @@
 <transform file depend -> edit pkg.debug.depend.file ruby env>
 <transform file depend -> edit pkg.debug.depend.file make env>
 <transform file depend -> edit pkg.debug.depend.file perl env>
-<transform pkg depend -> default facet.version-lock.*> false>

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -136,6 +136,16 @@ module Omnibus
       end
     end
 
+    describe "#write_versionlock_file" do
+      let(:versionlock_file) { File.join(staging_dir, "version-lock") }
+
+      it "creates the version-lock file" do
+        subject.write_versionlock_file
+        versionlock_file_contents = File.read(versionlock_file)
+        expect(versionlock_file_contents).to include("<transform pkg depend -> default facet.version-lock.*> false>")
+      end
+    end
+
     describe "#write_transform_file" do
       let(:transform_file) { File.join(staging_dir, "doc-transform") }
 
@@ -208,6 +218,8 @@ module Omnibus
           .with("pkgmogrify -DARCH=`uname -p` #{staging_dir}/project.p5m.3 #{staging_dir}/doc-transform | pkgfmt > #{staging_dir}/project.p5m.4")
         expect(subject).to receive(:shellout!)
           .with("pkgdepend resolve -m #{staging_dir}/project.p5m.4")
+        expect(subject).to receive(:shellout!)
+          .with("pkgmogrify #{staging_dir}/project.p5m.4.res #{staging_dir}/version-lock > #{staging_dir}/project.p5m.5.res")
         subject.generate_pkg_deps
       end
     end
@@ -215,7 +227,7 @@ module Omnibus
     describe "#validate_pkg_manifest" do
       it "uses the correct commands" do
         expect(subject).to receive(:shellout!)
-          .with("pkglint -c /tmp/lint-cache -r http://pkg.oracle.com/solaris/release #{staging_dir}/project.p5m.4.res")
+          .with("pkglint -c /tmp/lint-cache -r http://pkg.oracle.com/solaris/release #{staging_dir}/project.p5m.5.res")
         subject.validate_pkg_manifest
       end
     end
@@ -233,7 +245,7 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with("pkgrepo -s #{staging_dir}/publish/repo set publisher/prefix=Omnibus")
         expect(subject).to receive(:shellout!)
-          .with("pkgsend publish -s #{staging_dir}/publish/repo -d #{staging_dir}/proto_install #{staging_dir}/project.p5m.4.res")
+          .with("pkgsend publish -s #{staging_dir}/publish/repo -d #{staging_dir}/proto_install #{staging_dir}/project.p5m.5.res")
 
         expect(shellout).to receive(:stdout)
         subject.publish_ips_pkg


### PR DESCRIPTION
When version-lock facet to remove package version
dependencies is added to the doc-transform file it gets overwritten
while resolving dependencies.  So adding it right before publishing
the manifest

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

The package created from this fix was tested on Solaris11.2.  I was able to install the generated package after setting the version-lock to false at the command line with
# pkg change-facet facet.version-lock.*=false

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
