### PR TITLE
[BEN-147] Add omnibus-gcc libraries to LD_RUN_PATH for s390x and RHEL6

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -754,6 +754,13 @@ module Omnibus
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
       }
 
+      if s390x? && platform_version.satisfies?("< 7.0")
+        extra_linker_flags = {
+          "LD_RUN_PATH" => "/opt/omnibus-gcc/embedded/lib64,#{install_dir}/embedded/lib",
+        }
+      end
+
+
       if solaris2?
         ld_options = "-R#{install_dir}/embedded/lib"
 


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

@chef/engineering-services 
#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
