### PR TITLE
Only checkout from git_cache once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "pedump", git: "https://github.com/ksubrama/pedump", branch: "patch-1"
 
 # Always use license_scout from master
-gem "license_scout", github: "chef/license_scout"
+gem "license_scout", git: "https://github.com/chef/license_scout"
 
 # net-ssh 4.x does not work with Ruby 2.2 on Windows. Chef and ChefDK
 # are pinned to 3.2 so pinning that here. Only used by fauxhai in this project

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -148,11 +148,13 @@ refs}.freeze
       end
 
       if restore_me
-        log.internal(log_key) { "Detected tag `#{tag}' can be restored, restoring" }
-        git_cmd(%Q{checkout -f "#{tag}"})
+        log.internal(log_key) { "Detected tag `#{tag}' can be restored, marking it for restoration" }
+        git_cmd(%Q{tag -f restore_here "#{tag}"})
         true
       else
-        log.internal(log_key) { "Could not find tag `#{tag}', skipping restore" }
+        log.internal(log_key) { "Could not find tag `#{tag}', restoring previous tag" }
+        git_cmd(%Q{checkout -f restore_here})
+        git_cmd(%Q{tag -d restore_here})
         false
       end
     end

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -146,13 +146,18 @@ refs}.freeze
         true
       elsif has_tag("restore_here")
         log.internal(log_key) { "Could not find tag `#{tag}', restoring previous tag" }
-        git_cmd(%Q{checkout -f restore_here})
-        git_cmd(%Q{tag -d restore_here})
+        restore_from_cache
         false
       else
         log.internal(log_key) { "Could not find marker tag `restore_here', nothing to restore" }
         false
       end
+    end
+
+    def restore_from_cache
+      git_cmd("checkout -f restore_here")
+    ensure
+      git_cmd("tag -d restore_here")
     end
 
     #

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1076,6 +1076,12 @@ module Omnibus
         softwares.each do |software|
           software.build_me([license_collector])
         end
+
+        # If nothing has dirtied the cache, checkout the last cache dir
+        unless dirty?
+          log.info(log_key) { "Cache not dirtied, restoring last marker" }
+          GitCache.new(softwares.last).restore_from_cache
+        end
       end
 
       write_json_manifest

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -170,7 +170,7 @@ module Omnibus
           .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         allow(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f restore_here "#{ipc.tag}"})
         allow(ipc).to receive(:create_cache_path)
       end
 
@@ -179,24 +179,26 @@ module Omnibus
         ipc.restore
       end
 
-      it "checks for a tag with the software and version, and if it finds it, checks it out" do
+      it "checks for a tag with the software and version, and if it finds it, marks it as restoration point" do
         expect(ipc).to receive(:shellout!)
           .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f restore_here "#{ipc.tag}"})
         ipc.restore
       end
 
       describe "if the tag does not exist" do
         let(:git_tag_output) { "\n" }
 
-        it "does nothing" do
+        it "checks out the last save restoration point and deletes the marker tag" do
           expect(ipc).to receive(:shellout!)
             .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
             .and_return(tag_cmd)
-          expect(ipc).to_not receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f "#{ipc.tag}"})
+          expect(ipc).to receive(:shellout!)
+            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f restore_here})
+          expect(ipc).to receive(:shellout!)
+            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -d restore_here})
           ipc.restore
         end
       end

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -190,16 +190,43 @@ module Omnibus
 
       describe "if the tag does not exist" do
         let(:git_tag_output) { "\n" }
+        let(:restore_tag_cmd) do
+          cmd_double = double(Mixlib::ShellOut)
+          allow(cmd_double).to receive(:stdout).and_return(git_restore_tag_output)
+          allow(cmd_double).to receive(:error!).and_return(cmd_double)
+          cmd_double
+        end
 
-        it "checks out the last save restoration point and deletes the marker tag" do
-          expect(ipc).to receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
-            .and_return(tag_cmd)
-          expect(ipc).to receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f restore_here})
-          expect(ipc).to receive(:shellout!)
-            .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -d restore_here})
-          ipc.restore
+        describe "if the restore marker tag exists" do
+          let(:git_restore_tag_output) { "restore_here\n" }
+
+          it "checks out the last save restoration point and deletes the marker tag" do
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "restore_here"})
+              .and_return(restore_tag_cmd)
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+              .and_return(tag_cmd)
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f restore_here})
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -d restore_here})
+            ipc.restore
+          end
+        end
+
+        describe "if the restore marker tag does not exist" do
+          let(:git_restore_tag_output) { "\n" }
+
+          it "does nothing" do
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "restore_here"})
+              .and_return(restore_tag_cmd)
+            expect(ipc).to receive(:shellout!)
+              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+              .and_return(tag_cmd)
+            ipc.restore
+          end
         end
       end
     end


### PR DESCRIPTION
### Description

This changes the checkout logic from 

- "check out everything that can be checked out"

to

- "keep a marker git tag pointing to what is the last thing you can restore and restore it if encountering something that dirties the cache"
- if there's no marker tag (because preparation dirtied the cache) -- don't panic
- if the project isn't dirty at all (because nothing dirtied the cache) -- checkout the marker tag, which then points to the last software definition that was processed

This doesn't invalidate caches or anything, as besides _when checkout is happening_, nothing changes.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
