### PR TITLE
Add some verification and defensive coding 

### DIFF
--- a/resources/dmg/create_dmg.osascript.erb
+++ b/resources/dmg/create_dmg.osascript.erb
@@ -1,17 +1,37 @@
+# find disks that start with <%= volume_name %>
+set found_disk to do shell script "ls /Volumes/ | grep <%= volume_name %>*"
+
+if found_disk is {} then
+	set errormsg to "Disk " & found_disk & " not found"
+	error errormsg
+end if
+
 tell application "Finder"
-  tell disk "<%= volume_name %>"
-    open
-    set current view of container window to icon view
-    set toolbar visible of container window to false
-    set statusbar visible of container window to false
-    set the bounds of container window to {<%= window_bounds %>}
-    set theViewOptions to the icon view options of container window
-    set arrangement of theViewOptions to not arranged
-    set icon size of theViewOptions to 72
+	# In case finder has been closed somehow
+	reopen
+	# Reactivate it in case it is "out of focus"
+	activate
+	# Deactivate any current selections
+	set selection to {}
+	# Set it to the location of the proper volume
+	set target of Finder window 1 to found_disk
+	# We like icons
+	set current view of Finder window 1 to icon view
+	# No toolbar or statusbar
+	set toolbar visible of Finder window 1 to false
+	set statusbar visible of Finder window 1 to false
+	# How big and where does it live on the desktop
+	set the bounds of Finder window 1 to {<%= window_bounds %>}
+  # We now talk to the disk object that is a subset of the "Finder"
+  tell disk found_disk
+  	# Pull the view options from the Icon View object
+    # The container window is how we grab hold of the "Finder" window in the
+    # context of the disk object (the disk object is a sub-thing of the app)
+  	set theViewOptions to the icon view options of container window
     set background picture of theViewOptions to file ".support:background.png"
-    delay 5
-    set position of item "<%= pkg_name %>" of container window to {<%= pkg_position %>}
-    update without registering applications
-    delay 5
+  	set arrangement of theViewOptions to not arranged
+  	set icon size of theViewOptions to 72
+  	set position of item "<%= pkg_name %>" of container window to {<%= pkg_position %>}
+  	update without registering applications
   end tell
 end tell

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -181,23 +181,9 @@ module Omnibus
         subject.prettify_dmg
         contents = File.read("#{staging_dir}/create_dmg.osascript")
 
-        expect(contents).to include('tell application "Finder"')
-        expect(contents).to include('  tell disk "Project One"')
-        expect(contents).to include("    open")
-        expect(contents).to include("    set current view of container window to icon view")
-        expect(contents).to include("    set toolbar visible of container window to false")
-        expect(contents).to include("    set statusbar visible of container window to false")
-        expect(contents).to include("    set the bounds of container window to {100, 100, 750, 600}")
-        expect(contents).to include("    set theViewOptions to the icon view options of container window")
-        expect(contents).to include("    set arrangement of theViewOptions to not arranged")
-        expect(contents).to include("    set icon size of theViewOptions to 72")
-        expect(contents).to include('    set background picture of theViewOptions to file ".support:background.png"')
-        expect(contents).to include("    delay 5")
-        expect(contents).to include('    set position of item "project-1.2.3-2.pkg" of container window to {535, 50}')
-        expect(contents).to include("    update without registering applications")
-        expect(contents).to include("    delay 5")
-        expect(contents).to include("  end tell")
-        expect(contents).to include("end tell")
+        expect(contents).to include('set found_disk to do shell script "ls /Volumes/ | grep Project One*"')
+        expect(contents).to include("	set the bounds of Finder window 1 to {100, 100, 750, 600}")
+        expect(contents).to include('  	set position of item "project-1.2.3-2.pkg" of container window to {535, 50}')
       end
 
       it "runs the apple script" do


### PR DESCRIPTION
This is to add some resilience to the applescript that makes the dmg pretty

Signed-off-by: Scott Hain <shain@chef.io>

### Description

Mac builds fail relatively frequently because a finder window is/isn't open and is/isn't in the correct place, or because the Volumes are mounted in weird ways. This makes these issue a little less likely to happen and a little easier to troubleshoot.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
@chef/engineering-services 

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
