### PR TITLE
Fix bug where volume name was not quoted in DMG compression

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -118,7 +118,7 @@ module Omnibus
     def clean_disks
       log.info(log_key) { "Cleaning previously mounted disks" }
 
-      existing_disks = shellout!("mount | grep /Volumes/#{volume_name} | awk '{print $1}'")
+      existing_disks = shellout!("mount | grep \"/Volumes/#{volume_name}\" | awk '{print $1}'")
       existing_disks.stdout.lines.each do |existing_disk|
         existing_disk.chomp!
 
@@ -240,7 +240,7 @@ module Omnibus
 
       Dir.chdir(staging_dir) do
         shellout! <<-EOH.gsub(/^ {10}/, "")
-          chmod -Rf go-w /Volumes/#{volume_name}
+          chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
           hdiutil detach "#{@device}"
           hdiutil convert \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -5,6 +5,7 @@ module Omnibus
     let(:project) do
       Project.new.tap do |project|
         project.name("project")
+        project.friendly_name("Project One")
         project.homepage("https://example.com")
         project.install_dir("/opt/project")
         project.build_version("1.2.3")
@@ -86,7 +87,7 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil create \\
               -srcfolder "#{staging_dir}/Resources" \\
-              -volname "Project" \\
+              -volname "Project One" \\
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
               -format UDRW \\
@@ -155,10 +156,10 @@ module Omnibus
             iconutil -c icns tmp.iconset
 
             # Copy it over
-            cp tmp.icns "/Volumes/Project/.VolumeIcon.icns"
+            cp tmp.icns "/Volumes/Project One/.VolumeIcon.icns"
 
             # Source the icon
-            SetFile -a C "/Volumes/Project"
+            SetFile -a C "/Volumes/Project One"
           EOH
 
         subject.set_volume_icon
@@ -181,7 +182,7 @@ module Omnibus
         contents = File.read("#{staging_dir}/create_dmg.osascript")
 
         expect(contents).to include('tell application "Finder"')
-        expect(contents).to include('  tell disk "Project"')
+        expect(contents).to include('  tell disk "Project One"')
         expect(contents).to include("    open")
         expect(contents).to include("    set current view of container window to icon view")
         expect(contents).to include("    set toolbar visible of container window to false")
@@ -221,7 +222,7 @@ module Omnibus
 
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
-            chmod -Rf go-w /Volumes/Project
+            chmod -Rf go-w "/Volumes/Project One"
             sync
             hdiutil detach "#{device}"
             hdiutil convert \\
@@ -291,8 +292,7 @@ module Omnibus
 
     describe "#volume_name" do
       it "is the project friendly_name" do
-        project.friendly_name("Friendly Bacon Bits")
-        expect(subject.volume_name).to eq("Friendly Bacon Bits")
+        expect(subject.volume_name).to eq("Project One")
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

Noticed this during dmg compression:
```
                          I | 2017-02-03T10:40:48-08:00 | chmod: /Volumes/Angry: No such file or directory
                          I | 2017-02-03T10:40:48-08:00 | chmod: Chef: No such file or directory
                          I | 2017-02-03T10:40:48-08:00 | chmod: Client: No such file or directory
```

This also updates the test to be a little more robust since having a space in the friendly name of a package is not unheard of!

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.
@chef/engineering-services 

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
