### PR TITLE
Strip extraneous quotes from Publisher value.

### DIFF
--- a/lib/omnibus/packagers/appx.rb
+++ b/lib/omnibus/packagers/appx.rb
@@ -68,7 +68,7 @@ module Omnibus
           friendly_name:   project.friendly_name,
           version:         windows_package_version,
           maintainer:      project.maintainer,
-          certificate_subject: certificate_subject,
+          certificate_subject: certificate_subject.delete('"'),
         }
       )
     end

--- a/spec/unit/packagers/appx_spec.rb
+++ b/spec/unit/packagers/appx_spec.rb
@@ -48,7 +48,7 @@ module Omnibus
 
     describe "#write_manifest_file" do
       before do
-        allow(subject).to receive(:shellout!).and_return(double("output", stdout: "CN=Chef "))
+        allow(subject).to receive(:shellout!).and_return(double("output", stdout: 'CN="Chef", O="Chef"'))
         allow(subject).to receive(:signing_identity).and_return({})
       end
 
@@ -63,7 +63,7 @@ module Omnibus
 
         expect(contents).to include('Name="project"')
         expect(contents).to include('Version="1.2.3.2"')
-        expect(contents).to include('Publisher="CN=Chef"')
+        expect(contents).to include('Publisher="CN=Chef, O=Chef"')
         expect(contents).to include("<DisplayName>Project</DisplayName>")
         expect(contents).to include(
           '<PublisherDisplayName>"Chef Software &lt;maintainers@chef.io&gt;"</PublisherDisplayName>'


### PR DESCRIPTION
### Description
This fixes a bug in which the `Publisher` value would contain unnecessary quotes within the value.

Eg:
`Publisher="CN="Chef Software, Inc", O="Chef Software, Inc", L=Seattle, S=Washington, C=US"`

Which would result in the following error:
```
MakeAppx : error: Error info: error 80080204: App manifest validation error: The app manifest XML must be valid: Line 5, Column 28, Reason: Whitespace expected.
```
--------------------------------------------------
/cc @chef/omnibus-maintainers 

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache serial number
- [ ] If this change impacts compatibility with omnibus-software, the corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the corresponding change is reviewed and there is a release plan
