### PR TITLE
Fix guard for non-caching projects

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1078,10 +1078,7 @@ module Omnibus
         end
 
         # If nothing has dirtied the cache, checkout the last cache dir
-        unless dirty?
-          log.info(log_key) { "Cache not dirtied, restoring last marker" }
-          GitCache.new(softwares.last).restore_from_cache
-        end
+        restore_complete_build unless dirty?
       end
 
       write_json_manifest
@@ -1089,6 +1086,13 @@ module Omnibus
       HealthCheck.run!(self)
       package_me
       compress_me
+    end
+
+    def restore_complete_build
+      if Config.use_git_caching
+        log.info(log_key) { "Cache not dirtied, restoring last marker" }
+        GitCache.new(softwares.last).restore_from_cache
+      end
     end
 
     def write_json_manifest

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -413,5 +413,36 @@ module Omnibus
         end
       end
     end
+
+    describe "#restore_complete_build" do
+      let(:cached_build) { double(GitCache) }
+      let(:first_software) { double(Omnibus::Software) }
+      let(:last_software) { double(Omnibus::Software) }
+
+      before do
+        allow(Config).to receive(:use_git_caching).and_return(git_caching)
+      end
+
+      context "when git caching is enabled" do
+        let(:git_caching) { true }
+
+        it "restores the last software built" do
+          expect(subject).to receive(:softwares).and_return([first_software, last_software])
+          expect(GitCache).to receive(:new).with(last_software).and_return(cached_build)
+          expect(cached_build).to receive(:restore_from_cache)
+          subject.restore_complete_build
+        end
+      end
+
+      context "when git caching is disabled" do
+        let(:git_caching) { false }
+
+        it "does nothing" do
+          expect(subject).not_to receive(:softwares)
+          expect(GitCache).not_to receive(:new)
+          subject.restore_complete_build
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
If you don't have git caching enabled, omnibus should not try to checkout anything.

Forgot about that in #747.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
