### PR TITLE
Fix appx packager

### DIFF
--- a/lib/omnibus/packagers/appx.rb
+++ b/lib/omnibus/packagers/appx.rb
@@ -68,7 +68,7 @@ module Omnibus
           friendly_name:   project.friendly_name,
           version:         windows_package_version,
           maintainer:      project.maintainer,
-          certificate_subject: certificate_subject,
+          certificate_subject: certificate_subject.gsub('"', "&quot;"),
         }
       )
     end

--- a/lib/omnibus/packagers/windows_base.rb
+++ b/lib/omnibus/packagers/windows_base.rb
@@ -76,7 +76,7 @@ module Omnibus
         end
 
         @signing_identity[:store] = params[:store] || "My"
-        @signing_identity[:algorithm] = params[:algorithm] || "SHA1"
+        @signing_identity[:algorithm] = params[:algorithm] || "SHA256"
         servers = params[:timestamp_servers] || DEFAULT_TIMESTAMP_SERVERS
         @signing_identity[:timestamp_servers] = [servers].flatten
         @signing_identity[:machine_store] = params[:machine_store] || false

--- a/spec/unit/packagers/appx_spec.rb
+++ b/spec/unit/packagers/appx_spec.rb
@@ -48,7 +48,7 @@ module Omnibus
 
     describe "#write_manifest_file" do
       before do
-        allow(subject).to receive(:shellout!).and_return(double("output", stdout: "CN=Chef "))
+        allow(subject).to receive(:shellout!).and_return(double("output", stdout: 'CN="Chef", O="Chef"'))
         allow(subject).to receive(:signing_identity).and_return({})
       end
 
@@ -63,7 +63,7 @@ module Omnibus
 
         expect(contents).to include('Name="project"')
         expect(contents).to include('Version="1.2.3.2"')
-        expect(contents).to include('Publisher="CN=Chef"')
+        expect(contents).to include('Publisher="CN=&quot;Chef&quot;, O=&quot;Chef&quot;"')
         expect(contents).to include("<DisplayName>Project</DisplayName>")
         expect(contents).to include(
           '<PublisherDisplayName>"Chef Software &lt;maintainers@chef.io&gt;"</PublisherDisplayName>'


### PR DESCRIPTION
### Description

This fixes two issues with building appx packages.

- Translate string quotes `"` from return value of `certificate_subject` method to XML `&quot;` for insertion in ERB XML template.
- Upgrades default signing algorithm from SHA1 to SHA256 for both MSI and APPX. SHA256 is the minimum allowed signing algorithm for appx packages, and SHA1 is no longer a recommended algorithm.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache serial number
- [ ] If this change impacts compatibility with omnibus-software, the corresponding change is reviewed and there is a release plan.
- [ ] If this change impacts compatibility with the omnibus cookbook, the corresponding change is reviewed and there is a release plan.
