### PR TITLE
Retry git network operations by default

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -856,7 +856,7 @@ module Omnibus
         if tries <= 0
           raise e
         else
-          delay = delay * 2
+          delay *= 2
 
           log.warn(log_key) do
             label = "#{(Config.build_retries - tries) + 1}/#{Config.build_retries}"

--- a/lib/omnibus/cli/base.rb
+++ b/lib/omnibus/cli/base.rb
@@ -26,7 +26,7 @@ module Omnibus
         # Handle the case where Thor thinks a trailing --help is actually an
         # argument and blows up...
         if args.length > 1 && !(args & Thor::HELP_MAPPINGS).empty?
-          args = args - Thor::HELP_MAPPINGS
+          args -= Thor::HELP_MAPPINGS
           args.insert(-2, "help")
         end
 

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -76,9 +76,11 @@ module Omnibus
       default: {}
     desc "artifactory REPOSITORY PATTERN", "Publish to an Artifactory instance"
     def artifactory(repository, pattern)
-      Omnibus.logger.deprecated("ArtifactoryPublisher") do
-        "The `--version-manifest' option has been deprecated. Version manifest data is now part of the `*.metadata.json' file"
-      end if options[:version_manifest]
+      if options[:version_manifest]
+        Omnibus.logger.deprecated("ArtifactoryPublisher") do
+          "The `--version-manifest' option has been deprecated. Version manifest data is now part of the `*.metadata.json' file"
+        end
+      end
 
       options[:repository] = repository
       publish(ArtifactoryPublisher, pattern, options)

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -18,9 +18,9 @@ require "ffi_yajl"
 
 module Omnibus
   class Manifest
-    class InvalidManifestFormat < Exception; end
-    class NotAManifestEntry < Exception; end
-    class MissingManifestEntry < Exception; end
+    class InvalidManifestFormat < RuntimeError; end
+    class NotAManifestEntry < RuntimeError; end
+    class MissingManifestEntry < RuntimeError; end
 
     include Logging
 

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -167,6 +167,7 @@ module Omnibus
       #   the platform shortname. this might be an Ohai-returned platform or
       #   platform family but it also might be a shortname like `el`
       #
+      # rubocop:disable Lint/DuplicateCaseCondition
       def truncate_platform_version(platform_version, platform)
         case platform
         when "centos", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos", "nexus", "ios_xr"

--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -75,7 +75,7 @@ module Omnibus
         if package_types.include?(APPX) &&
             !Chef::Sugar::Constraints::Version.new(version).satisfies?(">= 6.2")
           log.warn(log_key) { "APPX generation is only supported on Windows versions 2012 and above" }
-          package_types = package_types - [APPX]
+          package_types -= [APPX]
         end
 
         package_types

--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -226,9 +226,7 @@ module Omnibus
       # from within the staging_dir's .info folder (where control files for the
       # packaging process are kept.)
       log.debug(log_key) do
-        "With .inventory file of:\n" + File.read("#{
-          File.join( staging_dir, '.info', "#{safe_base_package_name}.inventory" )
-        }")
+        "With .inventory file of:\n" + File.read("#{File.join( staging_dir, '.info', "#{safe_base_package_name}.inventory" )}")
       end
 
       # Copy the resulting package up to the package_dir

--- a/lib/omnibus/reports.rb
+++ b/lib/omnibus/reports.rb
@@ -25,7 +25,7 @@ module Omnibus
     # will be stored in the column, the width is 0 (i.e., nothing
     # should be printed, not even the column header)
     def column_width(items, column_name)
-      widest_item = items.max { |a, b| a.size <=> b.size }
+      widest_item = items.max_by(&:size)
       if widest_item
         widest = (widest_item.size >= column_name.size) ? widest_item : column_name
         widest.size + PADDING

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -104,6 +104,35 @@ module Omnibus
     end
 
     #
+    # Retry the given block if a retriable exception is
+    # raised. Returns the value of the block call if successful.
+    #
+    # @param [String] logstr
+    #   Description of the action being retried. Used in log output.
+    #
+    # @param [Array<Exception>] retried_exceptions
+    #   List of exceptions to retry.  Any other exceptions are raisesd.
+    #
+    # @param [Integer] retries
+    #   Number of times to retry the given block.
+    #
+    def retry_block(logstr, retried_exceptions = [], retries = Omnibus::Config.fetcher_retries, &block)
+      begin
+        yield
+      rescue Exception => e
+        raise e unless retried_exceptions.any? { |eclass| e.is_a?(eclass) }
+        if retries != 0
+          log.info(log_key) { "Retrying failed #{logstr} due to #{e} (#{retries} retries left)..." }
+          retries -= 1
+          retry
+        else
+          log.error(log_key) { "#{logstr} failed - #{e.class}!" }
+          raise
+        end
+      end
+    end
+
+    #
     # Convert the given path to be appropiate for shelling out on Windows.
     #
     # @param [String, Array<String>] pieces

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -47,7 +47,7 @@ module Omnibus
       options
     end
 
-    def make_gemspec()
+    def make_gemspec
       gemspec = File.join(project_dir, "#{project_name}.gemspec")
       File.open(gemspec, "w") do |f|
         f.write <<-EOH.gsub(/^ {12}/, "")
@@ -64,7 +64,7 @@ module Omnibus
       gemspec
     end
 
-    def make_gemfile()
+    def make_gemfile
       gemfile = File.join(project_dir, "Gemfile")
       File.open(gemfile, "w") do |f|
         f.write <<-EOH.gsub(/^ {12}/, "")
@@ -74,7 +74,7 @@ module Omnibus
       gemfile
     end
 
-    def make_gemfile_lock()
+    def make_gemfile_lock
       gemfile_lock = File.join(project_dir, "Gemfile.lock")
       File.open(gemfile_lock, "w") do |f|
         f.write <<-EOH.gsub(/^ {12}/, "")

--- a/spec/support/git_helpers.rb
+++ b/spec/support/git_helpers.rb
@@ -21,30 +21,36 @@ module Omnibus
           git %{remote add origin "#{options[:remote]}"} if options[:remote]
           git %{push origin master}
 
-          options[:annotated_tags].each do |tag|
-            File.open("tag", "w") { |f| f.write(tag) }
-            git %{add tag}
-            git %{commit -am "Create tag #{tag}"}
-            git %{tag "#{tag}" -m "#{tag}"}
-            git %{push origin "#{tag}"} if options[:remote]
-          end if options[:annotated_tags]
+          if options[:annotated_tags]
+            options[:annotated_tags].each do |tag|
+              File.open("tag", "w") { |f| f.write(tag) }
+              git %{add tag}
+              git %{commit -am "Create tag #{tag}"}
+              git %{tag "#{tag}" -m "#{tag}"}
+              git %{push origin "#{tag}"} if options[:remote]
+            end
+          end
 
-          options[:tags].each do |tag|
-            File.open("tag", "w") { |f| f.write(tag) }
-            git %{add tag}
-            git %{commit -am "Create tag #{tag}"}
-            git %{tag "#{tag}"}
-            git %{push origin "#{tag}"} if options[:remote]
-          end if options[:tags]
+          if options[:tags]
+            options[:tags].each do |tag|
+              File.open("tag", "w") { |f| f.write(tag) }
+              git %{add tag}
+              git %{commit -am "Create tag #{tag}"}
+              git %{tag "#{tag}"}
+              git %{push origin "#{tag}"} if options[:remote]
+            end
+          end
 
-          options[:branches].each do |branch|
-            git %{checkout -b #{branch} master}
-            File.open("branch", "w") { |f| f.write(branch) }
-            git %{add branch}
-            git %{commit -am "Create branch #{branch}"}
-            git %{push origin "#{branch}"} if options[:remote]
-            git %{checkout master}
-          end if options[:branches]
+          if options[:branches]
+            options[:branches].each do |branch|
+              git %{checkout -b #{branch} master}
+              File.open("branch", "w") { |f| f.write(branch) }
+              git %{add branch}
+              git %{commit -am "Create branch #{branch}"}
+              git %{push origin "#{branch}"} if options[:remote]
+              git %{checkout master}
+            end
+          end
         end
         path
       end

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -195,7 +195,7 @@ module Omnibus
           # raise an exception a set number of times.
           @times = 0
           allow(artifact).to receive(:upload) do
-            @times += 1;
+            @times += 1
             raise Artifactory::Error::HTTPError.new("status" => "409", "message" => "CONFLICT") unless @times > 1
           end
         end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -4,6 +4,37 @@ module Omnibus
   describe Util do
     subject { Class.new { include Util }.new }
 
+    describe "#retry_block" do
+      class OurTestException < StandardError; end
+      let(:expected_retries) { 3 }
+      let(:expected_calls) { expected_retries + 1 }
+      let(:sentinel) { double }
+
+      it "retries the block if the passed exception is raised" do
+        expect(sentinel).to receive(:call_me).and_raise(OurTestException)
+        expect(sentinel).to receive(:call_me).and_return(:test_return)
+        block_return = nil
+        expect do
+          block_return = subject.retry_block("test", [OurTestException], expected_retries) { sentinel.call_me }
+        end.to_not raise_error
+        expect(block_return).to eq(:test_return)
+      end
+
+      it "raises the last exception if the number of retries is exceeded" do
+        expect(sentinel).to receive(:call_me).exactly(expected_calls).times.and_raise(OurTestException)
+        expect do
+          subject.retry_block("test", [OurTestException], expected_retries) { sentinel.call_me }
+        end.to raise_error(OurTestException)
+      end
+
+      it "doesn't retry exceptions not listed by the user" do
+        expect(sentinel).to receive(:call_me).exactly(1).times.and_raise(StandardError)
+        expect do
+          subject.retry_block("test", [OurTestException], expected_retries) { sentinel.call_me }
+        end.to raise_error(StandardError)
+      end
+    end
+
     describe "#shellout!" do
       let(:shellout) do
         double(Mixlib::ShellOut,


### PR DESCRIPTION
We see occasional build failures because of transient network issues
between the build environment and upstream git providers. To reduce
the number of failures caused by transient outages, this provides a
simple retry helper that we then use to wrap the network operations in
the git fetcher.

Signed-off-by: Steven Danna <steve@chef.io>

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
