### PR TITLE
Don't require build user to have a configured Git identity

### DIFF
--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -76,6 +76,8 @@ refs}.freeze
       else
         create_directory(File.dirname(cache_path))
         git_cmd("init -q")
+        git_cmd("config --local user.name 'Omnibus Git Cache'")
+        git_cmd("config --local user.email 'omnibus@localhost'")
         true
       end
     end

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -86,6 +86,10 @@ module Omnibus
           .with(File.dirname(ipc.cache_path))
         expect(ipc).to receive(:shellout!)
           .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} init -q")
+        expect(ipc).to receive(:shellout!)
+          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.name 'Omnibus Git Cache'")
+        expect(ipc).to receive(:shellout!)
+          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.email 'omnibus@localhost'")
         ipc.create_cache_path
       end
 


### PR DESCRIPTION
I got this failure running `omnibus build`:

    The following shell command exited with status 128:

        $ git -c core.autocrlf=false --git-dir=./local/cache/git_cache/opt/codethink-toolchain --work-tree=/opt/codethink-toolchain commit -q -m "Backup of gcc-648708f4a353b91baa1e5cb62cccc3140495d09efa783d22e44e88ef0104f670-1"

    Output:

        (nothing)

    Error:

        *** Please tell me who you are.

    Run

      git config --global user.email "you@example.com"
      git config --global user.name "Your Name"

    to set your account's default identity.
    Omit --global to set the identity only in this repository.

    fatal: unable to auto-detect email address (got 'builduser@oracle-1.(none)')

Running a package builder shouldn't require me to configure a Git identity
for the account that's being used.

This failure comes from the git_cache module. This uses Git purely as
versioned local storage, none of the commits made there are ever pushed
or shared. So the logical fix is to set up a dummy local identity in
the repo it creates.

This should also fix https://github.com/chef/omnibus/issues/512