### PR TITLE
Add support for building against omnibus-toolchain on Windows

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -276,6 +276,21 @@ module Omnibus
     expose :windows_safe_path
 
     #
+    # (see Util#compiler_safe_path)
+    #
+    # Some compilers require paths to be formatted in certain ways. This helper
+    # takes in the standard Omnibus-style path and ensures that it is passed
+    # correctly.
+    #
+    # @example
+    #   configure ["--prefix=#{compiler_safe_path(install_dir, "embedded")}"]
+    #
+    def compiler_safe_path(*pieces)
+      super
+    end
+    expose :compiler_safe_path
+
+    #
     # @!endgroup
     # --------------------------------------------------
 
@@ -795,14 +810,6 @@ module Omnibus
       # Make sure the PWD is set to the correct directory
       # Also make a clone of options so that we can mangle it safely below.
       options = { cwd: software.project_dir }.merge(options)
-
-      if options.delete(:in_msys_bash) && windows?
-        # Mixlib will handle escaping characters for cmd but our command might
-        # contain '. For now, assume that won't happen because I don't know
-        # whether this command is going to be played via cmd or through
-        # ProcessCreate.
-        command_string = "bash -c \'#{command_string}\'"
-      end
 
       # Set the log level to :info so users will see build commands
       options[:log_level] ||= :info

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -32,7 +32,7 @@ module Omnibus
     # will not have the generated content, so these snapshots would be
     # incompatible with the current omnibus codebase. Incrementing the serial
     # number ensures these old shapshots will not be used in subsequent builds.
-    SERIAL_NUMBER = 2
+    SERIAL_NUMBER = 3
 
     REQUIRED_GIT_FILES = %w{
 HEAD

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -728,13 +728,7 @@ module Omnibus
             # soon as gcc emits aligned SSE xmm register spills which generate
             # GPEs and terminate the application very rudely with very little
             # to debug with.
-            #
-            # TODO: This was true of our old TDM gcc 4.7 compilers. Is it still
-            # true with mingw-w64?
-            #
-            # XXX: Temporarily turning -O3 into -O2 -fno-lto to work around some
-            # weird linker issues.
-            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O2 -fno-lto #{opt_flag}",
+            "CFLAGS" => "-I#{install_dir}/embedded/include #{arch_flag} -O3 #{opt_flag}",
           }
         else
           {
@@ -781,7 +775,8 @@ module Omnibus
         merge({ "PKG_CONFIG_PATH" => "#{install_dir}/embedded/lib/pkgconfig" }).
         # Set default values for CXXFLAGS and CPPFLAGS.
         merge("CXXFLAGS" => compiler_flags["CFLAGS"]).
-        merge("CPPFLAGS" => compiler_flags["CFLAGS"])
+        merge("CPPFLAGS" => compiler_flags["CFLAGS"]).
+        merge("OMNIBUS_INSTALL_DIR" => install_dir)
     end
     expose :with_standard_compiler_flags
 
@@ -1166,28 +1161,6 @@ module Omnibus
     #
     def git_cache
       @git_cache ||= GitCache.new(self)
-    end
-
-    #
-    # The proper platform-specific "$PATH" key.
-    #
-    # @return [String]
-    #
-    def path_key
-      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
-      # $WINDOWSRAGE, and if you don't set that your native gem compiles
-      # will fail because the magic fixup it does to add the mingw compiler
-      # stuff won't work.
-      #
-      # Turns out there is other build environments that only set ENV['PATH'] and if we
-      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
-      # one that we find.
-      #
-      if Ohai["platform"] == "windows"
-        ENV.keys.grep(/\Apath\Z/i).first
-      else
-        "PATH"
-      end
     end
 
     #

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -35,6 +35,36 @@ module Omnibus
     }.freeze
 
     #
+    # The proper platform-specific "$PATH" key.
+    #
+    # @return [String]
+    #
+    def path_key
+      # The ruby devkit needs ENV['Path'] set instead of ENV['PATH'] because
+      # $WINDOWSRAGE, and if you don't set that your native gem compiles
+      # will fail because the magic fixup it does to add the mingw compiler
+      # stuff won't work.
+      #
+      # Turns out there is other build environments that only set ENV['PATH'] and if we
+      # modify ENV['Path'] then it ignores that.  So, we scan ENV and returns the first
+      # one that we find.
+      #
+      if windows?
+        result = ENV.keys.grep(/\Apath\Z/i)
+        case result.length
+        when 0
+          raise "The current omnibus environment has no PATH"
+        when 1
+          result.first
+        else
+          raise "The current omnibus environment has multiple PATH/Path variables."
+        end
+      else
+        "PATH"
+      end
+    end
+
+    #
     # Shells out and runs +command+.
     #
     # @overload shellout(command, options = {})
@@ -52,6 +82,14 @@ module Omnibus
     def shellout(*args)
       options = args.last.kind_of?(Hash) ? args.pop : {}
       options = SHELLOUT_OPTIONS.merge(options)
+
+      command_string = args.join(" ")
+      in_msys = options.delete(:in_msys_bash) && ENV["MSYSTEM"]
+      # Mixlib will handle escaping characters for cmd but our command might
+      # contain '. For now, assume that won't happen because I don't know
+      # whether this command is going to be played via cmd or through
+      # ProcessCreate.
+      command_string = "bash -c \'#{command_string}\'" if in_msys
 
       # Grab the log_level
       log_level = options.delete(:log_level)
@@ -74,9 +112,9 @@ module Omnibus
       end
 
       # Log the actual command
-      log.public_send(log_level, log_key) { "$ #{args.join(' ')}" }
+      log.public_send(log_level, log_key) { "$ #{command_string}" }
 
-      cmd = Mixlib::ShellOut.new(*args, options)
+      cmd = Mixlib::ShellOut.new(command_string, options)
       cmd.environment["HOME"] = "/tmp" unless ENV["HOME"]
       cmd.run_command
       cmd
@@ -148,6 +186,20 @@ module Omnibus
       else
         path
       end
+    end
+
+    #
+    # Convert the given path to be appropriate for usage with the given compiler
+    #
+    # @param [String, Array<String>] pieces
+    #   the pieces of the path to join and fix
+    # @return [String]
+    #   the path with applied changes
+    #
+    def compiler_safe_path(*pieces)
+      path = File.join(*pieces)
+      path = path.sub(/^([A-Za-z]):\//, "/\\1/") if ENV["MSYSTEM"]
+      path
     end
 
     #

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -77,7 +77,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
         it "overrides LDFLAGS" do
@@ -87,7 +88,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
         it "overrides CFLAGS" do
@@ -97,7 +99,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
         it "overrides CXXFLAGS" do
@@ -107,7 +110,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
         it "overrides CPPFLAGS" do
@@ -117,7 +121,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
         it "preserves anything else" do
@@ -128,7 +133,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
       end
@@ -150,7 +156,8 @@ module Omnibus
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib -static-libgcc",
             "LD_OPTIONS"      => "-R/opt/project/embedded/lib",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
 
@@ -176,7 +183,8 @@ module Omnibus
               "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib -static-libgcc",
               "LD_OPTIONS"      => "-R/opt/project/embedded/lib",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
             )
           end
         end
@@ -199,7 +207,8 @@ module Omnibus
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "LD_OPTIONS"      => "-R/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
 
@@ -225,7 +234,8 @@ module Omnibus
               "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
               "LD_OPTIONS"      => "-R/opt/project/embedded/lib -M #{project_root}/files/mapfile/solaris",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
             )
           end
         end
@@ -241,7 +251,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
       end
@@ -266,7 +277,8 @@ module Omnibus
             "OBJECT_MODE"     => "64",
             "ARFLAGS"         => "-X64 cru",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
       end
@@ -283,7 +295,8 @@ module Omnibus
             "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",
             "LDFLAGS" => "-L/opt/project/embedded/lib",
             "LD_RUN_PATH" => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
 
@@ -301,7 +314,9 @@ module Omnibus
               "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",
               "LDFLAGS" => "-L/opt/project/embedded/lib",
               "LD_RUN_PATH" => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig" )
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
+            )
           end
         end
       end
@@ -320,7 +335,8 @@ module Omnibus
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LDFLAGS"         => "-L/opt/project/embedded/lib",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
       end
@@ -337,7 +353,8 @@ module Omnibus
           "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
           "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
           "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-          "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+          "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+          "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
 
@@ -356,7 +373,8 @@ module Omnibus
               "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
               "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
               )
           end
         end
@@ -375,7 +393,8 @@ module Omnibus
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+            "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+            "OMNIBUS_INSTALL_DIR" => "/opt/project"
           )
         end
       end
@@ -391,12 +410,13 @@ module Omnibus
         context "in 32-bit mode" do
           it "sets the default" do
             expect(subject.with_standard_compiler_flags).to eq(
-              "CFLAGS"          => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O2 -fno-lto -march=i686",
+              "CFLAGS"          => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -m32 -O3 -march=i686",
               "LDFLAGS"         => "-L/opt/project/embedded/lib -m32 -fno-lto",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
             )
           end
         end
@@ -406,12 +426,13 @@ module Omnibus
 
           it "sets the default" do
             expect(subject.with_standard_compiler_flags).to eq(
-              "CFLAGS"          => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O2 -fno-lto -march=x86-64",
+              "CFLAGS"          => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -m64 -O3 -march=x86-64",
               "LDFLAGS"         => "-L/opt/project/embedded/lib -m64 -fno-lto",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig"
+              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
+              "OMNIBUS_INSTALL_DIR" => "/opt/project"
             )
           end
         end
@@ -481,9 +502,10 @@ module Omnibus
             allow(ENV).to receive(:keys).and_return(%w{ Path PATH })
           end
 
-          it "returns a path key of `Path`" do
-            expect(subject.with_embedded_path).to eq(
-              "Path" => prepended_path
+          it "and raises an error when PATH is also set" do
+            expect { subject.with_embedded_path }.to raise_error(
+              RuntimeError,
+              "The current omnibus environment has multiple PATH/Path variables."
             )
           end
         end


### PR DESCRIPTION
### Description

This cleans up the build process for Windows by adding supporting code to use `omnibus-toolchain` on Windows and adds compiler optimizations. Moreover, this removes a large chunk of code which is no longer needed to build Windows projects.

*Important Note:* _Chef, ChefDK, Inspec, and omnibus-toolchain are still pinned to the existing crazy long-standing branches, and will need to remain pinned until we have replaced the internal CI build and test systems for each corresponding project._

--------------------------------------------------
/cc @chef/omnibus-maintainers 
/cc @chef/engineering-services 
/cc @tduffield @ksubrama

#### Maintainers

Please ensure that you check for:

- [x] This change impacts git cache validity
  - [x]  The git cache serial number has been correctly bumped
- [x] This change impacts compatibility with omnibus-software
  - [x] The corresponding change is reviewed
  - [x] There is a release plan
- [x] If this change impacts compatibility with the omnibus cookbook
  - [x] The corresponding change is reviewed 
  - [x] There is a release plan
