### PR TITLE
Ensure that Windows Paths are correctly frontwhacked

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -34,7 +34,7 @@ module Omnibus
     #   the list of all files
     #
     def glob(pattern)
-      pattern = Pathname.new(pattern).cleanpath
+      pattern = Pathname.new(pattern).cleanpath.to_s
       Dir.glob(pattern, File::FNM_DOTMATCH).sort.reject do |file|
         basename = File.basename(file)
         IGNORED_FILES.include?(basename)

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -34,6 +34,7 @@ module Omnibus
     #   the list of all files
     #
     def glob(pattern)
+      pattern = Pathname.new(pattern).cleanpath
       Dir.glob(pattern, File::FNM_DOTMATCH).sort.reject do |file|
         basename = File.basename(file)
         IGNORED_FILES.include?(basename)

--- a/spec/unit/file_syncer_spec.rb
+++ b/spec/unit/file_syncer_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+require "omnibus/file_syncer"
+
+module Omnibus
+  describe FileSyncer do
+    let(:fixture_dir) { "C:\\test" }
+
+    describe "#glob", :windows_only do
+
+      [ "/", "\\", "\\\\" ].each do |sep|
+        it "should correctly clean the path with #{sep}" do
+          pattern = fixture_dir + sep + "postinstall"
+          expect(Dir).to receive(:glob).with("C:/test/postinstall", File::FNM_DOTMATCH).and_return(["C:/test/postinstall"])
+          FileSyncer.glob(pattern)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dir.glob only handles forward slashes in paths, so mixed or backwhacked
paths return nothing.

cc @chef/omnibus-maintainers