### PR TITLE
Switch from single to double quotes in git config

### DIFF
--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -76,8 +76,9 @@ refs}.freeze
       else
         create_directory(File.dirname(cache_path))
         git_cmd("init -q")
-        git_cmd("config --local user.name 'Omnibus Git Cache'")
-        git_cmd("config --local user.email 'omnibus@localhost'")
+        # On windows, git is very picky about single vs double quotes
+        git_cmd("config --local user.name \"Omnibus Git Cache\"")
+        git_cmd("config --local user.email \"omnibus@localhost\"")
         true
       end
     end

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -87,9 +87,9 @@ module Omnibus
         expect(ipc).to receive(:shellout!)
           .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} init -q")
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.name 'Omnibus Git Cache'")
+          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.name \"Omnibus Git Cache\"")
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.email 'omnibus@localhost'")
+          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.email \"omnibus@localhost\"")
         ipc.create_cache_path
       end
 


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

git on some versions of windows gets very cranky regarding single quotes vs double quotes.

@chef/engineering-services 
--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
