### PR TITLE
git_cache: core.ignorecase=false

### DIFF
--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -196,11 +196,14 @@ refs}.freeze
     # @return [Mixlib::Shellout] the underlying command object.
     #
     def git_cmd(command)
-      shellout!("git -c core.autocrlf=false \
-                     -c core.ignorecase=false \
-                     --git-dir=#{cache_path} \
-                     --work-tree=#{install_dir} \
-                     #{command}".gsub(/\s+/, " "))
+      shellout!([
+        "git",
+        "-c core.autocrlf=false",
+        "-c core.ignorecase=false",
+        "--git-dir=\"#{cache_path}\"",
+        "--work-tree=\"#{install_dir}\"",
+        command,
+      ].join(" "))
     end
 
     #

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -196,7 +196,11 @@ refs}.freeze
     # @return [Mixlib::Shellout] the underlying command object.
     #
     def git_cmd(command)
-      shellout!("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} #{command}")
+      shellout!("git -c core.autocrlf=false \
+                     -c core.ignorecase=false \
+                     --git-dir=#{cache_path} \
+                     --work-tree=#{install_dir} \
+                     #{command}".gsub(/\s+/, " "))
     end
 
     #

--- a/spec/unit/git_cache_spec.rb
+++ b/spec/unit/git_cache_spec.rb
@@ -52,6 +52,8 @@ module Omnibus
       described_class.new(zlib)
     end
 
+    let(:git_flags) { "-c core.autocrlf=false -c core.ignorecase=false --git-dir=#{cache_path} --work-tree=#{install_dir}" }
+
     describe "#cache_path" do
       it "returns the install path appended to the install_cache path" do
         expect(ipc.cache_path).to eq(cache_path)
@@ -85,11 +87,11 @@ module Omnibus
         expect(FileUtils).to receive(:mkdir_p)
           .with(File.dirname(ipc.cache_path))
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} init -q")
+          .with("git #{git_flags} init -q")
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.name \"Omnibus Git Cache\"")
+          .with("git #{git_flags} config --local user.name \"Omnibus Git Cache\"")
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} config --local user.email \"omnibus@localhost\"")
+          .with("git #{git_flags} config --local user.email \"omnibus@localhost\"")
         ipc.create_cache_path
       end
 
@@ -119,19 +121,19 @@ module Omnibus
       it "adds all the changes to git removing git directories" do
         expect(ipc).to receive(:remove_git_dirs)
         expect(ipc).to receive(:shellout!)
-          .with("git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} add -A -f")
+          .with("git #{git_flags} add -A -f")
         ipc.incremental
       end
 
       it "commits the backup for the software" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} commit -q -m "Backup of #{ipc.tag}"})
+          .with(%Q{git #{git_flags} commit -q -m "Backup of #{ipc.tag}"})
         ipc.incremental
       end
 
       it "tags the software backup" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f "#{ipc.tag}"})
+          .with(%Q{git #{git_flags} tag -f "#{ipc.tag}"})
         ipc.incremental
       end
     end
@@ -171,10 +173,10 @@ module Omnibus
 
       before(:each) do
         allow(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+          .with(%Q{git #{git_flags} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         allow(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f restore_here "#{ipc.tag}"})
+          .with(%Q{git #{git_flags} tag -f restore_here "#{ipc.tag}"})
         allow(ipc).to receive(:create_cache_path)
       end
 
@@ -185,10 +187,10 @@ module Omnibus
 
       it "checks for a tag with the software and version, and if it finds it, marks it as restoration point" do
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+          .with(%Q{git #{git_flags} tag -l "#{ipc.tag}"})
           .and_return(tag_cmd)
         expect(ipc).to receive(:shellout!)
-          .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -f restore_here "#{ipc.tag}"})
+          .with(%Q{git #{git_flags} tag -f restore_here "#{ipc.tag}"})
         ipc.restore
       end
 
@@ -206,15 +208,15 @@ module Omnibus
 
           it "checks out the last save restoration point and deletes the marker tag" do
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "restore_here"})
+              .with(%Q{git #{git_flags} tag -l "restore_here"})
               .and_return(restore_tag_cmd)
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+              .with(%Q{git #{git_flags} tag -l "#{ipc.tag}"})
               .and_return(tag_cmd)
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} checkout -f restore_here})
+              .with(%Q{git #{git_flags} checkout -f restore_here})
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -d restore_here})
+              .with(%Q{git #{git_flags} tag -d restore_here})
             ipc.restore
           end
         end
@@ -224,10 +226,10 @@ module Omnibus
 
           it "does nothing" do
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "restore_here"})
+              .with(%Q{git #{git_flags} tag -l "restore_here"})
               .and_return(restore_tag_cmd)
             expect(ipc).to receive(:shellout!)
-              .with(%Q{git -c core.autocrlf=false --git-dir=#{cache_path} --work-tree=#{install_dir} tag -l "#{ipc.tag}"})
+              .with(%Q{git #{git_flags} tag -l "#{ipc.tag}"})
               .and_return(tag_cmd)
             ipc.restore
           end


### PR DESCRIPTION
Signed-off-by: Isa <ifarnik@llnw.com>

### Description

PR for https://github.com/chef/omnibus/issues/765

Previously (when building `ncurses` on bento's trusty image via omnibus's `.kitchen.yml`):
```
       [Builder: ncurses] I | 2017-03-23T01:36:59+00:00 | Build ncurses: 105.578s

▽
       [Builder: ncurses] I | 2017-03-23T01:36:59+00:00 | Finished build
The following shell command exited with status 128:

    $ git -c core.autocrlf=false --git-dir=/var/cache/omnibus/cache/git_cache/opt/salt --work-tree=/opt/salt add -A -f

▽

Output:

    (nothing)

Error:

    fatal: Will not add file alias 'embedded/share/terminfo/32/2621a' ('embedded/share/terminfo/32/2621A' already exists in index)


/home/vagrant/omnibus/lib/omnibus/util.rb:139:in `rescue in shellout!'
  /home/vagrant/omnibus/lib/omnibus/util.rb:135:in `shellout!'
  /home/vagrant/omnibus/lib/omnibus/git_cache.rb:198:in `git_cmd'
  /home/vagrant/omnibus/lib/omnibus/git_cache.rb:129:in `incremental'
  /home/vagrant/omnibus/lib/omnibus/software.rb:1212:in `execute_build'
  /home/vagrant/omnibus/lib/omnibus/software.rb:1086:in `build_me'
  /home/vagrant/omnibus/lib/omnibus/project.rb:1077:in `block (2 levels) in build'
  /home/vagrant/omnibus/lib/omnibus/project.rb:1076:in `each'
  /home/vagrant/omnibus/lib/omnibus/project.rb:1076:in `block in build'
  /home/vagrant/omnibus/lib/omnibus/licensing.rb:62:in `block in create_incrementally'
  /home/vagrant/omnibus/lib/omnibus/licensing.rb:57:in `tap'
  /home/vagrant/omnibus/lib/omnibus/licensing.rb:57:in `create_incrementally'
  /home/vagrant/omnibus/lib/omnibus/project.rb:1075:in `build'
  /home/vagrant/omnibus/lib/omnibus/cli.rb:84:in `build'
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
  /home/vagrant/omnibus/lib/omnibus/cli/base.rb:33:in `dispatch'
  /opt/omnibus-toolchain/embedded/lib/ruby/gems/2.3.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
  /home/vagrant/omnibus/lib/omnibus/cli.rb:42:in `execute!'
  /home/vagrant/omnibus/bin/omnibus:16:in `<top (required)>'
  bin/omnibus:17:in `load'
  bin/omnibus:17:in `<main>'
```

--------------------------------------------------
/cc @chef/omnibus-maintainers