### PR TITLE
Ignore paths with braces in the BFF packager

### DIFF
--- a/lib/omnibus/packagers/bff.rb
+++ b/lib/omnibus/packagers/bff.rb
@@ -131,9 +131,9 @@ module Omnibus
     def write_gen_template
       # Get a list of all files
       files = FileSyncer.glob("#{staging_dir}/**/*").reject do |path|
-        # remove any files with spaces.
-        if path =~ /[[:space:]]/
-          log.warn(log_key) { "Skipping packaging '#{path}' file due to whitespace in filename" }
+        # remove any files with spaces or braces.
+        if path =~ /[[:space:]{}]/
+          log.warn(log_key) { "Skipping packaging '#{path}' file due to whitespace or braces in filename" }
           true
         end
       end

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -191,6 +191,36 @@ module Omnibus
         end
       end
 
+      context "when paths with invalid characters are present", if: !windows? do
+        let(:contents) do
+          subject.write_gen_template
+          File.read(gen_file)
+        end
+
+        before do
+          create_file("#{staging_dir}/file with_a_space")
+          create_file("#{staging_dir}/file_with_{left_brace")
+          create_file("#{staging_dir}/file_with_}right_brace")
+          create_file("#{staging_dir}/file_that_meets_expectations")
+        end
+
+        it "includes a file that does not include invalid characters" do
+          expect(contents).to include("/file_that_meets_expectations")
+        end
+
+        it "does not include a file with spaces in the path" do
+          expect(contents).to_not include("/file with_a_space")
+        end
+
+        it "does not include a file with left braces in the path" do
+          expect(contents).to_not include("/file_with_{left_brace")
+        end
+
+        it "does not include a file with right braces in the path" do
+          expect(contents).to_not include("/file_with_}right_brace")
+        end
+      end
+
       context "when script files are present" do
         before do
           create_file("#{subject.scripts_staging_dir}/preinst")


### PR DESCRIPTION
### Description

Do not include files whose pathnames contain braces (`{` and `}`) as they are not valid on AIX and will cause a package install failure

### Additional Details

Gems like thor include files that have braces in the pathname:

```
/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/thor-0.19.1/spec/fixtures/app{1}/README
```

... which fail to install on AIX:

```
sysck: 3001-008 The attribute name is not valid for the file
	/opt/chef/embedded/lib/ruby/gems/2.4.0/gems/thor-0.19.1/spec/fixtures/app{1}/README.
```

This change skips filenames with braces in the pathname much like we already
do for paths with spaces in them.


--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
