### PR TITLE
Support appbundler 0.11.0

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2012-2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -372,19 +372,31 @@ module Omnibus
     # @param (see #command)
     # @return (see #command)
     #
-    def appbundle(software_name, options = {})
+    def appbundle(software_name, lockdir: nil, gem: nil, without: nil, **options)
       build_commands << BuildCommand.new("appbundle `#{software_name}'") do
-        app_software = project.softwares.find do |p|
-          p.name == software_name
-        end
-
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin("appbundler")
+        gem              ||= software_name
+
+        lockdir ||=
+          begin
+            app_software = project.softwares.find do |p|
+              p.name == software_name
+            end
+            if app_software.nil?
+              raise "could not find software definition for #{software_name}, add a dependency to it, or pass a lockdir argument to appbundle command."
+            end
+            app_software.project_dir
+          end
+
+        command = [ appbundler_bin, "'#{lockdir}'", "'#{bin_dir}'", "'#{gem}'" ]
+
+        command << [ "--without", without.join(",") ] unless without.nil?
 
         # Ensure the main bin dir exists
         FileUtils.mkdir_p(bin_dir)
 
-        shellout!("#{appbundler_bin} '#{app_software.project_dir}' '#{bin_dir}'", options)
+        shellout!(command.join(" "), options)
       end
     end
     expose :appbundle

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -376,7 +376,6 @@ module Omnibus
       build_commands << BuildCommand.new("appbundle `#{software_name}'") do
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin("appbundler")
-        gem              ||= software_name
 
         lockdir ||=
           begin
@@ -389,7 +388,8 @@ module Omnibus
             app_software.project_dir
           end
 
-        command = [ appbundler_bin, "'#{lockdir}'", "'#{bin_dir}'", "'#{gem}'" ]
+        command = [ appbundler_bin, "'#{lockdir}'", "'#{bin_dir}'" ]
+        command << [ "'#{gem}'" ] if gem
 
         command << [ "--without", without.join(",") ] unless without.nil?
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -389,8 +389,15 @@ module Omnibus
           end
 
         command = [ appbundler_bin, "'#{lockdir}'", "'#{bin_dir}'" ]
+
+        # This option is almost entirely for support of ChefDK and enables transitive gemfile lock construction in order
+        # to be able to decouple the dev gems for all the different components of ChefDK.  AKA:  don't use it outside of
+        # ChefDK.  You should also explicitly specify the lockdir when going down this road.
         command << [ "'#{gem}'" ] if gem
 
+        # FIXME: appbundler lacks support for this argument when not also specifying the gem (3-arg appbundling lacks support)
+        # (if you really need this bug fixed, though, fix it in appbundler, don't try using the 4-arg version to try to
+        # get `--without` support, you will likely wind up going down a sad path).
         command << [ "--without", without.join(",") ] unless without.nil?
 
         # Ensure the main bin dir exists

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -395,8 +395,8 @@ module Omnibus
         # ChefDK.  You should also explicitly specify the lockdir when going down this road.
         command << [ "'#{gem}'" ] if gem
 
-        # FIXME: appbundler lacks support for this argument when not also specifying the gem (3-arg appbundling lacks support)
-        # (if you really need this bug fixed, though, fix it in appbundler, don't try using the 4-arg version to try to
+        # FIXME: appbundler lacks support for this argument when not also specifying the gem (2-arg appbundling lacks support)
+        # (if you really need this bug fixed, though, fix it in appbundler, don't try using the 3-arg version to try to
         # get `--without` support, you will likely wind up going down a sad path).
         command << [ "--without", without.join(",") ] unless without.nil?
 


### PR DESCRIPTION
The changes here:

- The `lockdir` argument used to be entirely auto-populated.  It is now settable via the `lockdir` option.  The default auto-population algorithm has not changed, but it now gives a much more informative error message if that fails (I think it NoMethod on NilClass'd before).

- Support has been added for the `gem` and `without` options which are used by ChefDK and use the 3-argument version of appbundler to do transitive Gemfile.lock minimum-viable-horribleness in ChefDK.

- The API for all other non-ChefDK projects should still use the 2-argument form of appbundler and the API should be unchanged (certainly it is *intended* that it will be unchanged).

There's a bug in appbundler around trying to use the without argument with the 2-arg form, which I believe is broken in appbundler -- it'll get passed to appbundler and silently fail.  It isn't in principle nonsense that should cause a raise here, but if someone wants that fixed, it should just get fixed in appbundler.