### PR TITLE
expose overrides to software defns

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012 Chef Software, Inc.
+# Copyright 2012-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -959,6 +959,7 @@ module Omnibus
 
       @overrides
     end
+    expose :overrides
 
     #
     # Determine if this software version overridden externally, relative to the

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -142,6 +142,12 @@ module Omnibus
       end
     end
 
+    describe "#overrides" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:overrides)
+      end
+    end
+
     describe "#make" do
       before do
         allow(subject).to receive(:command)


### PR DESCRIPTION
allows software defns to pull other arbitrary overrides out of the software's override hash other than `:source` or `:version`