### PR TITLE
Add new build option to populate S3 cache and add AWS shared credentials support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 rvm:
   - 2.2.5
   - 2.3.1
+  - 2.4.1
 bundler_args: "--jobs 7 --without docs local"
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ use_git_caching false
 use_s3_caching true
 s3_access_key  ENV['S3_ACCESS_KEY']
 s3_secret_key  ENV['S3_SECRET_KEY']
+# You can use the Shared Credentials files in place of the s3_access_key and s3_secret_key.
+#s3_profile    ENV['S3_PROFILE']
 s3_bucket      ENV['S3_BUCKET']
 ```
 

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -70,6 +70,10 @@ module Omnibus
       desc: "Use the given manifest when downloading software sources.",
       type: :string,
       default: nil
+    method_option :populate_s3_cache,
+      desc: "Populate the S3 cache.",
+      type: :boolean,
+      default: false
     desc "build PROJECT", "Build the given Omnibus project"
     def build(name)
       manifest = if @options[:use_manifest]
@@ -80,6 +84,7 @@ module Omnibus
 
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
+      Omnibus::S3Cache.populate if @options[:populate_s3_cache] && !Omnibus::S3Cache.fetch_missing.empty?
       project.download
       project.build
 

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -279,15 +279,28 @@ module Omnibus
     #
     # @return [String]
     default(:s3_access_key) do
-      raise MissingRequiredAttribute.new(self, :s3_access_key, "'ABCD1234'")
+      if self.s3_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :s3_access_key, "'ABCD1234'")
+      end
     end
 
     # The S3 secret key to use with S3 caching.
     #
-    # @return [String]
+    # @return [String, nil]
     default(:s3_secret_key) do
-      raise MissingRequiredAttribute.new(self, :s3_secret_key, "'EFGH5678'")
+      if self.s3_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :s3_secret_key, "'EFGH5678'")
+      end
     end
+
+    # The AWS credentials profile to use with S3 caching.
+    #
+    # @return [String]
+    default(:s3_profile, nil)
 
     # The region of the S3 bucket you want to cache software artifacts in.
     # Defaults to 'us-east-1'
@@ -400,14 +413,22 @@ module Omnibus
     #
     # @return [String]
     default(:publish_s3_access_key) do
-      raise MissingRequiredAttribute.new(self, :publish_s3_access_key, "'ABCD1234'")
+      if self.s3_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :publish_s3_access_key, "'ABCD1234'")
+      end
     end
 
     # The S3 secret key to use for S3 artifact release
     #
     # @return [String]
     default(:publish_s3_secret_key) do
-      raise MissingRequiredAttribute.new(self, :publish_s3_secret_key, "'EFGH5678'")
+      if self.s3_profile
+        nil
+      else
+        raise MissingRequiredAttribute.new(self, :publish_s3_secret_key, "'EFGH5678'")
+      end
     end
 
     # --------------------------------------------------

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -33,6 +33,7 @@
 # use_s3_caching true
 # s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 # s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
+# s3_profile     ENV['AWS_S3_PROFILE']
 # s3_bucket      ENV['AWS_S3_BUCKET']
 
 # Customize compiler bits

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -46,12 +46,17 @@ module Omnibus
     private
 
     def s3_configuration
-      {
+      config = {
         region:            @options[:region],
-        access_key_id:     Config.publish_s3_access_key,
-        secret_access_key: Config.publish_s3_secret_key,
         bucket_name:       @options[:bucket],
       }
+
+      if Config.publish_s3_profile
+        config[:profile]            = Config.publish_s3_profile
+      else
+        config[:access_key_id]      = Config.publish_s3_access_key
+        config[:secret_access_key]  = Config.publish_s3_secret_key
+      end
     end
 
     #

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -139,14 +139,21 @@ module Omnibus
       private
 
       def s3_configuration
-        {
-          region:                  Config.s3_region,
-          access_key_id:           Config.s3_access_key,
-          secret_access_key:       Config.s3_secret_key,
-          bucket_name:             Config.s3_bucket,
-          endpoint:                Config.s3_endpoint,
-          use_accelerate_endpoint: Config.s3_accelerate,
+        config = {
+          region:                   Config.s3_region,
+          bucket_name:              Config.s3_bucket,
+          endpoint:                 Config.s3_endpoint,
+          use_accelerate_endpoint:  Config.s3_accelerate,
         }
+
+        if Config.s3_profile
+          config[:profile] = Config.s3_profile
+        else
+          config[:access_key_id] = Config.s3_access_key,
+          config[:secret_access_key] = Config.s3_secret_key
+        end
+
+        config
       end
 
       #


### PR DESCRIPTION
### Description

This PR adds two new features.

1. New argument `--populate-omnibus-cache` to `build` subcommand to automatically upload source artifacts to S3. This ensures source and binary build dependencies are populated across our entire platform matrix and reduces the potential for human error.
2. AWS shared credentials support via the standard `.aws/credentials` profiles.

--------------------------------------------------
/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [ ] This change DOES NOT impact git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
