### PR TITLE
S3 cache: fix bug using access_key_id/secret_access_key

### DIFF
--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -149,7 +149,7 @@ module Omnibus
         if Config.s3_profile
           config[:profile] = Config.s3_profile
         else
-          config[:access_key_id] = Config.s3_access_key,
+          config[:access_key_id] = Config.s3_access_key
           config[:secret_access_key] = Config.s3_secret_key
         end
 

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -448,6 +448,10 @@ module Omnibus
           Config.cache_dir("/")
           stub_ohai(platform: "ubuntu", version: "12.04")
           stub_const("File::ALT_SEPARATOR", nil)
+
+          allow(Omnibus).to receive(:which)
+            .with("gtar")
+            .and_return(false)
         end
 
         context "when gtar is not present" do
@@ -479,8 +483,8 @@ module Omnibus
             stub_const("File::ALT_SEPARATOR", nil)
 
             allow(Omnibus).to receive(:which)
-            .with("gtar")
-            .and_return("/path/to/gtar")
+              .with("gtar")
+              .and_return("/path/to/gtar")
           end
 
           it_behaves_like "an extractor", "7z", {},

--- a/spec/unit/s3_cacher_spec.rb
+++ b/spec/unit/s3_cacher_spec.rb
@@ -106,5 +106,52 @@ module Omnibus
         expect(S3Cache.key_for(ruby_19)).to eq("ruby-1.9.3-abcd1234")
       end
     end
+
+    describe ".s3_configuration" do
+      let (:s3_bucket) { "omnibus-cache" }
+      let (:s3_region) { "eu-west-1" }
+      let (:s3_access_key) { nil }
+      let (:s3_secret_key) { nil }
+      let (:s3_profile) { nil }
+
+      before do
+        Config.s3_bucket s3_bucket
+        Config.s3_region s3_region
+        Config.s3_profile s3_profile
+        Config.s3_access_key s3_access_key
+        Config.s3_secret_key s3_secret_key
+      end
+
+      it "sets region and bucket" do
+        config = S3Cache.send(:s3_configuration)
+        expect(config[:region]).to eq(s3_region)
+        expect(config[:bucket_name]).to eq(s3_bucket)
+      end
+
+      context "s3_profile is not configured" do
+        let(:s3_access_key) { "ACCESS_KEY_ID" }
+        let(:s3_secret_key) { "SECRET_ACCESS_KEY" }
+
+        it "sets access_key_id and secret_access_key" do
+          config = S3Cache.send(:s3_configuration)
+          expect(config[:profile]).to eq(nil)
+          expect(config[:access_key_id]).to eq(s3_access_key)
+          expect(config[:secret_access_key]).to eq(s3_secret_key)
+        end
+      end
+
+      context "s3_profile is configured" do
+        let(:s3_profile) { "SHAREDPROFILE" }
+        let(:s3_access_key) { "ACCESS_KEY_ID" }
+        let(:s3_secret_key) { "SECRET_ACCESS_KEY" }
+
+        it "sets s3_profile only" do
+          config = S3Cache.send(:s3_configuration)
+          expect(config[:profile]).to eq(s3_profile)
+          expect(config[:access_key_id]).to eq(nil)
+          expect(config[:secret_access_key]).to eq(nil)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The comma causes `config[:access_key_id]` to end up having _both_ the
value of `Config.s3_access_key` AND the following line, i.e.,
`Config.s3_secret_key`.

/cc @chef/omnibus-maintainers <- This ensures the Omnibus Maintainers team are notified to review this PR.

#### Maintainers

Please ensure that you check for:

- [X] If this change impacts git cache validity, it bumps the git cache
  serial number
- [X] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [X] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
