### PR TITLE
Update ruby versions we test and OS we test on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ $RECYCLE.BIN/
 /test/version_tmp/
 /tmp/
 /spec/tmp
+gem_graph.png
 
 ## Specific to RubyMotion:
 .dat*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.2.7
+  - 2.3.4
   - 2.4.1
 bundler_args: "--jobs 7 --without docs local"
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 version: "{build}"
 
-os: Windows Server 2012
+os: Windows Server 2012 R2
 platform:
   - x64
 
 environment:
   matrix:
+    - RUBY_VERSION: 24
     - RUBY_VERSION: 23
     - RUBY_VERSION: 22
 


### PR DESCRIPTION
Test on the latest distros in appveyor / travis and use the latest ruby releases. Same thing we do elsewhere

Signed-off-by: Tim Smith <tsmith@chef.io>