### PR TITLE
Require a modern Fauxhai

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |gem|
   gem.version        = Omnibus::VERSION
   gem.license        = "Apache 2.0"
   gem.author         = "Chef Software, Inc."
-  gem.email          = "releng@getchef.com"
+  gem.email          = "releng@chef.io"
   gem.summary        = "Omnibus is a framework for building self-installing, full-stack software builds."
   gem.description    = gem.summary
-  gem.homepage       = "https://github.com/opscode/omnibus"
+  gem.homepage       = "https://github.com/chef/omnibus"
 
   gem.required_ruby_version = ">= 2.2"
 
@@ -40,7 +40,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "artifactory", "~> 2.0"
   gem.add_development_dependency "aruba",       "~> 0.5"
   gem.add_development_dependency "chefstyle"
-  gem.add_development_dependency "fauxhai",     "~> 3.2"
+  gem.add_development_dependency "fauxhai",     "~> 5.2"
   gem.add_development_dependency "rspec",       "~> 3.0"
   gem.add_development_dependency "rspec-json_expectations"
   gem.add_development_dependency "rspec-its"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
     FileUtils.mkdir_p(tmp_path)
 
     # Don't run Ohai - tests can still override this
-    stub_ohai(platform: "ubuntu", version: "12.04")
+    stub_ohai(platform: "ubuntu", version: "16.04")
 
     # Default to real HTTP requests
     WebMock.allow_net_connect!

--- a/spec/unit/compressor_spec.rb
+++ b/spec/unit/compressor_spec.rb
@@ -4,7 +4,7 @@ module Omnibus
   describe Compressor do
     describe ".for_current_system" do
       context "on Mac OS X" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.9.2") }
+        before { stub_ohai(platform: "mac_os_x", version: "10.12") }
 
         context "when :dmg is activated" do
           it "prefers dmg" do
@@ -26,7 +26,7 @@ module Omnibus
       end
 
       context "on Ubuntu" do
-        before { stub_ohai(platform: "ubuntu", version: "14.04") }
+        before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
         context "when :tgz activated" do
           it "prefers tgz" do

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -50,7 +50,7 @@ module Omnibus
     describe "#workers" do
       context "when the Ohai data is not present" do
         before do
-          stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+          stub_ohai(platform: "ubuntu", version: "16.04") do |data|
             data["cpu"] = nil
           end
         end
@@ -62,7 +62,7 @@ module Omnibus
 
       context "when the Ohai data is present" do
         before do
-          stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+          stub_ohai(platform: "ubuntu", version: "16.04") do |data|
             data["cpu"] = { "total" => "5" }
           end
         end
@@ -74,7 +74,7 @@ module Omnibus
     end
 
     context "on Windows" do
-      before { stub_ohai(platform: "windows", version: "2012") }
+      before { stub_ohai(platform: "windows", version: "2012R2") }
 
       include_examples "a configurable", :base_dir, "C:/omnibus-ruby"
       include_examples "a configurable", :cache_dir, "C:/omnibus-ruby/cache"

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -369,7 +369,7 @@ module Omnibus
 
         before do
           Config.cache_dir("C:/")
-          stub_ohai(platform: "windows", version: "2012")
+          stub_ohai(platform: "windows", version: "2012R2")
           allow(Dir).to receive(:mktmpdir).and_yield("C:/tmp_dir")
         end
 
@@ -446,7 +446,7 @@ module Omnibus
       context "on Linux" do
         before do
           Config.cache_dir("/")
-          stub_ohai(platform: "ubuntu", version: "12.04")
+          stub_ohai(platform: "ubuntu", version: "16.04")
           stub_const("File::ALT_SEPARATOR", nil)
 
           allow(Omnibus).to receive(:which)
@@ -479,7 +479,7 @@ module Omnibus
           before do
             Config.cache_dir("/")
 
-            stub_ohai(platform: "ubuntu", version: "12.04")
+            stub_ohai(platform: "ubuntu", version: "16.04")
             stub_const("File::ALT_SEPARATOR", nil)
 
             allow(Omnibus).to receive(:which)

--- a/spec/unit/health_check_spec.rb
+++ b/spec/unit/health_check_spec.rb
@@ -30,11 +30,11 @@ module Omnibus
 
     context "on windows" do
       before do
-        stub_ohai(platform: "windows", version: "2012")
+        stub_ohai(platform: "windows", version: "2012R2")
       end
 
       it "will perform dll base relocation checks" do
-        stub_ohai(platform: "windows", version: "2012")
+        stub_ohai(platform: "windows", version: "2012R2")
         expect(subject.relocation_checkable?).to be true
       end
 
@@ -101,7 +101,7 @@ module Omnibus
     end
 
     context "on linux" do
-      before { stub_ohai(platform: "ubuntu", version: "12.04") }
+      before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
       let(:bad_healthcheck) do
         double("Mixlib::Shellout",

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -85,7 +85,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
           sha256:   "abcd1234",
           sha512:   "abcdef123456",
           platform: "ubuntu",
-          platform_version: "12.04",
+          platform_version: "16.04",
           arch: "x86_64",
           name: "some-project",
           friendly_name: "Some Project",
@@ -130,7 +130,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       let(:architecture) { "x86_64" }
 
       before do
-        stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+        stub_ohai(platform: "ubuntu", version: "16.04") do |data|
           data["kernel"]["machine"] = architecture
         end
       end
@@ -180,17 +180,17 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
     describe ".platform_shortname" do
       it "returns el on rhel" do
-        stub_ohai(platform: "redhat", version: "6.4")
+        stub_ohai(platform: "redhat", version: "6.9")
         expect(described_class.platform_shortname).to eq("el")
       end
 
       it "returns sles on suse" do
-        stub_ohai(platform: "suse", version: "12.0")
+        stub_ohai(platform: "suse", version: "12.2")
         expect(described_class.platform_shortname).to eq("sles")
       end
 
       it "returns .platform on all other systems" do
-        stub_ohai(platform: "ubuntu", version: "12.04")
+        stub_ohai(platform: "ubuntu", version: "16.04")
         expect(described_class.platform_shortname).to eq("ubuntu")
       end
     end
@@ -199,7 +199,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       shared_examples "a version manipulator" do |platform_shortname, version, expected|
         context "on #{platform_shortname}-#{version}" do
           it "returns the correct value" do
-            stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+            stub_ohai(platform: "ubuntu", version: "16.04") do |data|
               data["platform"] = platform_shortname
               data["platform_version"] = version
             end
@@ -247,7 +247,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
       context "given an unknown platform" do
         before do
-          stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+          stub_ohai(platform: "ubuntu", version: "16.04") do |data|
             data["platform"] = "bacon"
             data["platform_version"] = "1.crispy"
           end
@@ -261,7 +261,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
       context "given an unknown windows platform version" do
         before do
-          stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+          stub_ohai(platform: "ubuntu", version: "16.04") do |data|
             data["platform"] = "windows"
             data["platform_version"] = "1.2.3"
           end

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -4,14 +4,14 @@ module Omnibus
   describe Packager do
     describe ".for_current_system" do
       context "on Mac OS X" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.9.2") }
+        before { stub_ohai(platform: "mac_os_x", version: "10.12") }
         it "prefers PKG" do
           expect(described_class.for_current_system).to eq([Packager::PKG])
         end
       end
 
-      context "on Windows 2012" do
-        before { stub_ohai(platform: "windows", version: "2012") }
+      context "on Windows 2012 R2" do
+        before { stub_ohai(platform: "windows", version: "2012R2") }
         it "prefers MSI and APPX" do
           expect(described_class.for_current_system).to eq([Packager::MSI, Packager::APPX])
         end
@@ -38,29 +38,29 @@ module Omnibus
         end
       end
 
-      context "on aix" do
+      context "on AIX" do
         before { stub_ohai(platform: "aix", version: "7.1") }
         it "prefers BFF" do
           expect(described_class.for_current_system).to eq([Packager::BFF])
         end
       end
 
-      context "on fedora" do
-        before { stub_ohai(platform: "fedora", version: "20") }
+      context "on Fedora" do
+        before { stub_ohai(platform: "fedora", version: "25") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::RPM])
         end
       end
 
-      context "on debian" do
-        before { stub_ohai(platform: "debian", version: "7.2") }
+      context "on Debian" do
+        before { stub_ohai(platform: "debian", version: "8.8") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::DEB])
         end
       end
 
-      context "on suse" do
-        before { stub_ohai(platform: "suse", version: "12.0") }
+      context "on SLES" do
+        before { stub_ohai(platform: "suse", version: "12.2") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::RPM])
         end

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -373,7 +373,7 @@ module Omnibus
 
     describe "#safe_architecture" do
       before do
-        stub_ohai(platform: "ubuntu", version: "12.04") do |data|
+        stub_ohai(platform: "ubuntu", version: "16.04") do |data|
           data["kernel"]["machine"] = "i386"
         end
       end

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -35,7 +35,7 @@ module Omnibus
       create_directory("#{staging_dir}/SOURCES")
       create_directory("#{staging_dir}/SPECS")
 
-      stub_ohai(platform: "redhat", version: "6.5") do |data|
+      stub_ohai(platform: "redhat", version: "6.9") do |data|
         data["kernel"]["machine"] = architecture
       end
     end
@@ -533,7 +533,7 @@ module Omnibus
 
     describe "#safe_architecture" do
       before do
-        stub_ohai(platform: "redhat", version: "6.5") do |data|
+        stub_ohai(platform: "redhat", version: "6.9") do |data|
           data["kernel"]["machine"] = "i386"
         end
       end
@@ -544,7 +544,7 @@ module Omnibus
 
       context "when i686" do
         before do
-          stub_ohai(platform: "redhat", version: "6.5") do |data|
+          stub_ohai(platform: "redhat", version: "6.9") do |data|
             data["kernel"]["machine"] = "i686"
           end
         end
@@ -557,9 +557,9 @@ module Omnibus
       context "on Pidora" do
         before do
           # There's no Pidora in Fauxhai :(
-          stub_ohai(platform: "fedora", version: "20") do |data|
+          stub_ohai(platform: "fedora", version: "25") do |data|
             data["platform"] = "pidora"
-            data["platform_version"] = "20"
+            data["platform_version"] = "25"
             data["kernel"]["machine"] = "armv6l"
           end
         end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -110,7 +110,7 @@ module Omnibus
 
     describe "#default_root" do
       context "on Windows" do
-        before { stub_ohai(platform: "windows", version: "2012") }
+        before { stub_ohai(platform: "windows", version: "2012R2") }
 
         it "returns C:/" do
           expect(subject.default_root).to eq("C:")
@@ -118,7 +118,7 @@ module Omnibus
       end
 
       context "on non-Windows" do
-        before { stub_ohai(platform: "ubuntu", version: "12.04") }
+        before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
         it "returns /opt" do
           expect(subject.default_root).to eq("/opt")
@@ -207,21 +207,21 @@ module Omnibus
       before { stub_ohai(fauxhai_options) }
 
       context "when on RHEL" do
-        let(:fauxhai_options) { { platform: "redhat", version: "6.4" } }
+        let(:fauxhai_options) { { platform: "redhat", version: "6.9" } }
         it "returns a RHEL iteration" do
           expect(subject.build_iteration).to eq(1)
         end
       end
 
       context "when on Debian" do
-        let(:fauxhai_options) { { platform: "debian", version: "7.2" } }
+        let(:fauxhai_options) { { platform: "debian", version: "8.8" } }
         it "returns a Debian iteration" do
           expect(subject.build_iteration).to eq(1)
         end
       end
 
       context "when on FreeBSD" do
-        let(:fauxhai_options) { { platform: "freebsd", version: "9.1" } }
+        let(:fauxhai_options) { { platform: "freebsd", version: "9.3" } }
         it "returns a FreeBSD iteration" do
           expect(subject.build_iteration).to eq(1)
         end
@@ -236,7 +236,7 @@ module Omnibus
       end
 
       context "when on OS X" do
-        let(:fauxhai_options) { { platform: "mac_os_x", version: "10.8.2" } }
+        let(:fauxhai_options) { { platform: "mac_os_x", version: "10.12" } }
         it "returns a generic iteration" do
           expect(subject.build_iteration).to eq(1)
         end
@@ -266,7 +266,7 @@ module Omnibus
     end
 
     describe "#ohai" do
-      before { stub_ohai(platform: "ubuntu", version: "12.04") }
+      before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:ohai)

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -68,7 +68,7 @@ module Omnibus
 
     describe "with_standard_compiler_flags helper" do
       context "on ubuntu" do
-        before { stub_ohai(platform: "ubuntu", version: "12.04") }
+        before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
@@ -242,7 +242,7 @@ module Omnibus
       end
 
       context "on mac_os_x" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.9.2") }
+        before { stub_ohai(platform: "mac_os_x", version: "10.12") }
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
@@ -285,7 +285,7 @@ module Omnibus
 
       context "on freebsd 9" do
         before do
-          stub_ohai(platform: "freebsd", version: "9.2")
+          stub_ohai(platform: "freebsd", version: "9.3")
         end
 
         it "sets the defaults" do
@@ -323,7 +323,7 @@ module Omnibus
 
       context "on freebsd 10" do
         before do
-          stub_ohai(platform: "freebsd", version: "10.0")
+          stub_ohai(platform: "freebsd", version: "10.3")
         end
 
         it "Clang as the default compiler" do
@@ -383,7 +383,7 @@ module Omnibus
       context "on sles 12" do
         before do
           # sles identifies as suse
-          stub_ohai(platform: "suse", version: "12.1")
+          stub_ohai(platform: "suse", version: "12.2")
         end
 
         it "sets the defaults" do
@@ -403,7 +403,7 @@ module Omnibus
         let(:win_arch_i386) { true }
 
         before do
-          stub_ohai(platform: "windows", version: "2012")
+          stub_ohai(platform: "windows", version: "2012R2")
           allow(subject).to receive(:windows_arch_i386?).and_return(win_arch_i386)
         end
 
@@ -485,7 +485,7 @@ module Omnibus
 
       context "on Windows" do
         before do
-          stub_ohai(platform: "windows", version: "2012")
+          stub_ohai(platform: "windows", version: "2012R2")
         end
 
         let(:separator) { ";" }
@@ -525,7 +525,7 @@ module Omnibus
     end
 
     describe "#ohai" do
-      before { stub_ohai(platform: "ubuntu", version: "12.04") }
+      before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:ohai)


### PR DESCRIPTION
The 3.x release is full of bogus Chef 11 data. We shouldn't be using that anywhere.

Signed-off-by: Tim Smith <tsmith@chef.io>