### PR TITLE
Allow setting a custom directory pattern for publishers

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -333,13 +333,6 @@ module Omnibus
     # @return [Integer]
     default(:publish_retries, 2)
 
-    # Directory pattern for publisher. Interpolation of matadata keys are supported.
-    #
-    # @example 'custom_prefix/%{platform}/%{platform_version}/%{arch}/%{basename}'
-    #
-    # @return [String]
-    default(:publish_dir_pattern, nil)
-
     # --------------------------------------------------
     # @!endgroup
     #
@@ -377,6 +370,14 @@ module Omnibus
     default(:artifactory_base_path) do
       raise MissingRequiredAttribute.new(self, :artifactory_base_path, "'com/mycompany'")
     end
+
+    # Directory pattern for the Artifactory publisher.
+    # Interpolation of metadata keys is supported.
+    #
+    # @example '%{platform}/%{platform_version}/%{arch}/%{basename}'
+    #
+    # @return [String]
+    default(:artifactory_publish_pattern, "%{name}/%{version}/%{platform}/%{platform_version}/%{basename}")
 
     # The path on disk to an SSL pem file to sign requests with.
     #
@@ -442,6 +443,14 @@ module Omnibus
     #
     # @return [String, nil]
     default(:publish_s3_profile, nil)
+
+    # Directory pattern for the S3 publisher.
+    # Interpolation of metadata keys is supported.
+    #
+    # @example '%{platform}/%{platform_version}/%{arch}/%{basename}'
+    #
+    # @return [String]
+    default(:s3_publish_pattern, "%{platform}/%{platform_version}/%{arch}/%{basename}")
 
     # --------------------------------------------------
     # @!endgroup

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -333,6 +333,13 @@ module Omnibus
     # @return [Integer]
     default(:publish_retries, 2)
 
+    # Directory pattern for publisher. Interpolation of matadata keys are supported.
+    #
+    # @example 'custom_prefix/%{platform}/%{platform_version}/%{arch}/%{basename}'
+    #
+    # @return [String]
+    default(:publish_dir_pattern, nil)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -268,10 +268,9 @@ module Omnibus
     # @return [String]
     #
     def remote_path_for(package)
-      pattern = Config.publish_dir_pattern || "%{name}/%{version}/%{platform}/%{platform_version}/%{basename}"
       File.join(
         Config.artifactory_base_path,
-        pattern % package.metadata
+        Config.artifactory_publish_pattern % package.metadata
       )
     end
   end

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -260,7 +260,7 @@ module Omnibus
     # and the package metadata.
     #
     # @example
-    #   chef/11.6.0/chef-11.6.0-1.el6.x86_64.rpm
+    #   com/getchef/chef/11.6.0/ubuntu/14.04/chef-11.6.0-1.el6.x86_64.rpm
     #
     # @param [Package] package
     #   the package to generate the remote path for
@@ -268,13 +268,10 @@ module Omnibus
     # @return [String]
     #
     def remote_path_for(package)
+      pattern = Config.publish_dir_pattern || "%{name}/%{version}/%{platform}/%{platform_version}/%{basename}"
       File.join(
         Config.artifactory_base_path,
-        package.metadata[:name],
-        package.metadata[:version],
-        package.metadata[:platform],
-        package.metadata[:platform_version],
-        package.metadata[:basename]
+        pattern % package.metadata
       )
     end
   end

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -65,19 +65,20 @@ module Omnibus
     # The unique upload key for this package. The additional "stuff" is
     # postfixed to the end of the path.
     #
+    # @example
+    #   'el/6/x86_64/chef-11.6.0-1.el6.x86_64.rpm/chef-11.6.0-1.el6.x86_64.rpm'
+    #
     # @param [Package] package
     #   the package this key is for
     # @param [Array<String>] stuff
-    #   the additional things to prepend
+    #   the additional things to append
     #
     # @return [String]
     #
     def key_for(package, *stuff)
+      pattern = Config.publish_dir_pattern || "%{platform}/%{platform_version}/%{arch}/%{basename}"
       File.join(
-        package.metadata[:platform],
-        package.metadata[:platform_version],
-        package.metadata[:arch],
-        package.name,
+        pattern % package.metadata,
         *stuff
       )
     end

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -76,9 +76,8 @@ module Omnibus
     # @return [String]
     #
     def key_for(package, *stuff)
-      pattern = Config.publish_dir_pattern || "%{platform}/%{platform_version}/%{arch}/%{basename}"
       File.join(
-        pattern % package.metadata,
+        Config.s3_publish_pattern % package.metadata,
         *stuff
       )
     end

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -249,9 +249,9 @@ module Omnibus
         end
       end
 
-      context "custom publish_dir_pattern is set" do
+      context "custom artifactory_publish_pattern is set" do
         before do
-          Config.publish_dir_pattern("%{platform}/%{platform_version}/%{arch}/%{basename}")
+          Config.artifactory_publish_pattern("%{platform}/%{platform_version}/%{arch}/%{basename}")
         end
 
         it "uploads the package to the provided path" do

--- a/spec/unit/publishers/artifactory_publisher_spec.rb
+++ b/spec/unit/publishers/artifactory_publisher_spec.rb
@@ -248,6 +248,22 @@ module Omnibus
           subject.publish
         end
       end
+
+      context "custom publish_dir_pattern is set" do
+        before do
+          Config.publish_dir_pattern("%{platform}/%{platform_version}/%{arch}/%{basename}")
+        end
+
+        it "uploads the package to the provided path" do
+          expect(artifact).to receive(:upload).with(
+            repository,
+            "com/getchef/ubuntu/14.04/x86_64/chef.deb",
+            hash_including(metadata_json_properites)
+          ).once
+
+          subject.publish
+        end
+      end
     end
 
     describe "#metadata_properties_for" do

--- a/spec/unit/publishers/s3_publisher_spec.rb
+++ b/spec/unit/publishers/s3_publisher_spec.rb
@@ -100,6 +100,23 @@ module Omnibus
         end
       end
 
+      context "when the custom publish_dir_pattern is set" do
+        before do
+          Config.publish_dir_pattern("custom_prefix/%{name}/%{version}/%{platform}/%{platform_version}")
+        end
+
+        it "uploads the package to the provided path" do
+          expect(subject).to receive(:store_object).with(
+            "custom_prefix/chef/11.0.6/ubuntu/14.04/chef.deb.metadata.json",
+            FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
+            nil,
+            "private"
+          ).once
+
+          subject.publish
+        end
+      end
+
       context "when a block is given" do
         it "yields the package to the block" do
           block = ->(package) { package.do_something! }

--- a/spec/unit/publishers/s3_publisher_spec.rb
+++ b/spec/unit/publishers/s3_publisher_spec.rb
@@ -100,9 +100,9 @@ module Omnibus
         end
       end
 
-      context "when the custom publish_dir_pattern is set" do
+      context "when the custom s3_publish_pattern is set" do
         before do
-          Config.publish_dir_pattern("custom_prefix/%{name}/%{version}/%{platform}/%{platform_version}")
+          Config.s3_publish_pattern("custom_prefix/%{name}/%{version}/%{platform}/%{platform_version}")
         end
 
         it "uploads the package to the provided path" do


### PR DESCRIPTION
### Description
This PR adds a possibility to set a custom pattern for publisher's directory. 

It's done by adding a new config option, `publish_dir_pattern`, which supports interpolation of package metadata keys, such as `platform`, `platform_version`, `arch`, `version`, `basename` and other. 
It uses a simple %-formatting, so it also supports any custom prefixes/suffixes for publisher's dir if needed.

The default values of this option are kept unchanged, so the backward compatibility is saved and unit tests should pass fine.

P.s. I'm not sure that `publish_dir_pattern` is the best option name for this case. Suggestions are welcome! ;)

--------------------------------------------------
/cc @chef/omnibus-maintainers