### PR TITLE
Add config option to use path style S3 URLs

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -315,6 +315,11 @@ module Omnibus
     # @return [String, nil]
     default(:s3_endpoint, nil)
 
+    # Use path style URLs instead of subdomains for S3 URLs
+    #
+    # @return [true, false]
+    default(:s3_force_path_style, false)
+
     # Enable or disable S3 Accelerate support
     #
     # @return [true, false]

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -144,6 +144,7 @@ module Omnibus
           bucket_name:              Config.s3_bucket,
           endpoint:                 Config.s3_endpoint,
           use_accelerate_endpoint:  Config.s3_accelerate,
+          force_path_style:         Config.s3_force_path_style,
         }
 
         if Config.s3_profile

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -38,6 +38,7 @@ module Omnibus
       #     bucket_name:              Config.s3_bucket,
       #     endpoint:                 Config.s3_endpoint,
       #     use_accelerate_endpoint:  Config.s3_accelerate
+      #     force_path_style:         Config.s3_force_path_style
       #   }
       #
       # @return [Hash<String, String>]
@@ -68,6 +69,7 @@ module Omnibus
       def resource_params
         params = {
           use_accelerate_endpoint:  s3_configuration[:use_accelerate_endpoint],
+          force_path_style: s3_configuration[:force_path_style],
         }
 
         if s3_configuration[:use_accelerate_endpoint]

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -200,6 +200,17 @@ module Omnibus
           end
         end
 
+        context "custom endpoint with path style urls" do
+          before do
+            Config.s3_force_path_style(true)
+            Config.s3_endpoint("http://example.com")
+          end
+
+          it "returns the url using path style" do
+            expect(subject.send(:download_url)).to eq("http://example.com/mybucket/file-1.2.3-abcd1234")
+          end
+        end
+
         context "s3 transfer acceleration" do
           before { Config.s3_accelerate(true) }
 


### PR DESCRIPTION
### Description

Self-hosted S3 solutions like Minio don't support subdomain style bucket URLs. This adds an option to use path style S3 URLs when using S3 caching.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
