### PR TITLE
Add Debian (.deb) package signing (implementing debsig)

### DIFF
--- a/docs/Building on Debian.md
+++ b/docs/Building on Debian.md
@@ -39,6 +39,7 @@ package :deb do
   license 'Apache 2.0'
   priority 'extra'
   section 'databases'
+  signing_passphrase 'acbd1234'
 end
 ```
 
@@ -46,6 +47,7 @@ Some DSL methods available include:
 
 | DSL Method           | Description                                 |
 | :------------------: | --------------------------------------------|
+| `signing_passphrase` | The passphrase to sign the RPM with         |
 | `vendor`             | The name of the package producer            |
 | `license`            | The default license for the package         |
 | `priority`           | The priority for the package                |
@@ -56,4 +58,4 @@ If you are unfamiliar with any of these terms, you should just accept the defaul
 For more information, please see the [`Packager::DEB` documentation](http://www.rubydoc.info/github/chef/omnibus/Omnibus/Packager/DEB).
 
 ### Notes on DEB-signing
-At this time, signing Debian packages is not supported.
+To sign an DEB, you will need a GPG keypair. You can [create your own signing key](http://www.madboa.com/geek/gpg-quickstart/) or [import an existing one](http://irtfweb.ifa.hawaii.edu/~lockhart/gpg/gpg-cs.html). Omnibus will automatically call `gpg` with arguments that assume the real name associated to the GPG key is the same as the name of the project maintainer as specified in your Omnibus config.

--- a/spec/unit/packagers/deb_spec.rb
+++ b/spec/unit/packagers/deb_spec.rb
@@ -337,6 +337,46 @@ module Omnibus
       end
     end
 
+    describe "#sign_deb_file", :not_supported_on_windows do
+      context "when DEB signing is not enabled" do
+        before do
+          subject.signing_passphrase(nil)
+        end
+
+        it "logs a message" do
+          output = capture_logging { subject.sign_deb_file }
+          expect(output).to include("Signing not enabled for .deb file")
+        end
+      end
+
+      context "when DEB signing is enabled" do
+        before do
+          allow(subject).to receive(:shellout!)
+          allow(subject).to receive(:package_name).and_return("safe")
+          subject.signing_passphrase("foobar")
+        end
+
+        it "logs a message" do
+          output = capture_logging { subject.sign_deb_file }
+          expect(output).to include("Signing enabled for .deb file")
+        end
+
+        it "finds gpg and ar commands" do
+          output = capture_logging { subject.sign_deb_file }
+          expect(output).not_to include("Signing not possible.")
+        end
+
+        it "runs correct commands" do
+          expect(subject).to receive(:shellout!)
+            .at_least(:once).with(/ar x/)
+            .at_least(:once).with(/cat debian-binary control\.tar/)
+            .at_least(:once).with(/fakeroot gpg/)
+            .at_least(:once).with(/fakeroot ar rc/)
+          subject.sign_deb_file
+        end
+      end
+    end
+
     describe "#package_size" do
       before do
         project.install_dir(staging_dir)


### PR DESCRIPTION
See:

- https://gitlab.com/gitlab-org/omnibus/merge_requests/7
- https://github.com/chef/omnibus/issues/402

## What
Add Debian package signing, via methodology describe in `debsigs` documentation
https://gitlab.com/debsigs/debsigs

## How
Addition of a `sign_deb_file` function to `Packager::DEB`, after `create_deb_file`. The essential concepts of what is required to sign a `.deb` with with a `type: origin` signature is delineated per the link to `debsigs` above. There is no current functionailty built into dpkg scripting akin to `rpm --addsign`. Since the `.deb` file format is simple, we extract the contents of the archvice (`ar x`), sign the concatenated (specifically ordered) contents, and then append the created signature to the archive (`ar rc debfile _gpgorigin`).

These steps could have been accomplished in pure Ruby with the addition of several modules (GPGME, libarchive) except for two concerns: age & maintenance, `fakeroot` requirements.

Tests have been added to attempt to cover the behavior correctly.

## External Program Requirements
- `gpg` : This is already an existing requirement of `Packager::RPM` due to the use of `rpmsign`
- `ar` : Most systems that attempt to build Debian packages will have the `ar` command, and it has been confirmed that MacOS also has this utility.

Adding `ar` to the required tools compiled by Omnibus may be required.

There is *no need* to add `debsigs`/`debsig-verify` as a requirement, as we are implementing the logic in Ruby and `Shellout`.

## Concerns Addressed

### GPG versions
Care was taken to ensure compatibility with distribution provided binary versions of `gpg2` or `gpg` for LTS versions of distributions supported by GitLab. This list can be seen at https://gitlab.com/gitlab-org/omnibus/merge_requests/7#note_35053215 . The code is written to prefer `gpg2` if present.

### GPG Keys
GitLab experienced issues in regards to `gpg --import`, and eventually settled on `gpg --batch --no-tty --allow-secret-key-import --import` as a part of our CI job. So long as the key is present for the GPG calls (via `--homedir #{ENV['HOME']}/.gnupg`) this should not be an issue for any non-automated use. As the GPG key import process is not a part of Omnibus itself, this should be of little concern to this code changes in this MR.

Relates to https://gitlab.com/gitlab-org/omnibus-gitlab/issues/2537
Closes https://github.com/chef/omnibus/issues/402
