### PR TITLE
with_clean_env should clean BUNDLER_ variables

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -928,6 +928,7 @@ module Omnibus
       original = ENV.to_hash
 
       ENV.delete("_ORIGINAL_GEM_PATH")
+      ENV.delete_if { |k, _| k.start_with?("BUNDLER_") }
       ENV.delete_if { |k, _| k.start_with?("BUNDLE_") }
       ENV.delete_if { |k, _| k.start_with?("GEM_") }
       ENV.delete_if { |k, _| k.start_with?("RUBY") }


### PR DESCRIPTION
In version 1.13.0, bundler moved from BUNDLE_ to BUNDLER_ as the
prefix for their environment variables.

Signed-off-by: Steven Danna <steve@chef.io>

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
