### PR TITLE
Use BUILD_TIMESTAMP instead of BUILD_ID

### DIFF
--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -125,8 +125,8 @@ module Omnibus
     end
 
     # We'll attempt to retrieve the timestamp from the Jenkin's set BUILD_TIMESTAMP
-    # environment variable. This will ensure platform specfic packages for the
-    # same build will share the same timestamp.
+    # or fall back to BUILD_ID environment variable. This will ensure platform specfic
+    # packages for the same build will share the same timestamp.
     def build_start_time
       @build_start_time ||= begin
                               if ENV["BUILD_TIMESTAMP"]
@@ -134,6 +134,15 @@ module Omnibus
                                   Time.strptime(ENV["BUILD_TIMESTAMP"], "%Y-%m-%d_%H-%M-%S")
                                 rescue ArgumentError
                                   error_message =  "BUILD_TIMESTAMP environment variable "
+                                  error_message << "should be in YYYY-MM-DD_hh-mm-ss "
+                                  error_message << "format."
+                                  raise ArgumentError, error_message
+                                end
+                              elsif ENV["BUILD_ID"]
+                                begin
+                                  Time.strptime(ENV["BUILD_ID"], "%Y-%m-%d_%H-%M-%S")
+                                rescue ArgumentError
+                                  error_message =  "BUILD_ID environment variable "
                                   error_message << "should be in YYYY-MM-DD_hh-mm-ss "
                                   error_message << "format."
                                   raise ArgumentError, error_message

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -124,16 +124,16 @@ module Omnibus
       build_tag
     end
 
-    # We'll attempt to retrive the timestamp from the Jenkin's set BUILD_ID
+    # We'll attempt to retrive the timestamp from the Jenkin's set BUILD_TIMESTAMP
     # environment variable. This will ensure platform specfic packages for the
     # same build will share the same timestamp.
     def build_start_time
       @build_start_time ||= begin
-                              if ENV["BUILD_ID"]
+                              if ENV["BUILD_TIMESTAMP"]
                                 begin
-                                  Time.strptime(ENV["BUILD_ID"], "%Y-%m-%d_%H-%M-%S")
+                                  Time.strptime(ENV["BUILD_TIMESTAMP"], "%Y-%m-%d_%H-%M-%S")
                                 rescue ArgumentError
-                                  error_message =  "BUILD_ID environment variable "
+                                  error_message =  "BUILD_TIMESTAMP environment variable "
                                   error_message << "should be in YYYY-MM-DD_hh-mm-ss "
                                   error_message << "format."
                                   raise ArgumentError, error_message

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -124,7 +124,7 @@ module Omnibus
       build_tag
     end
 
-    # We'll attempt to retrive the timestamp from the Jenkin's set BUILD_TIMESTAMP
+    # We'll attempt to retrieve the timestamp from the Jenkin's set BUILD_TIMESTAMP
     # environment variable. This will ensure platform specfic packages for the
     # same build will share the same timestamp.
     def build_start_time

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -112,13 +112,13 @@ module Omnibus
         expect(build_version.semver).to match(/11.0.0-alpha1\+#{today_string}[0-9]+.git.207.694b062/)
       end
 
-      it "uses ENV['BUILD_ID'] to generate timestamp if set" do
-        stub_env("BUILD_ID", "2012-12-25_16-41-40")
+      it "uses ENV['BUILD_TIMESTAMP'] to generate timestamp if set" do
+        stub_env("BUILD_TIMESTAMP", "2012-12-25_16-41-40")
         expect(build_version.semver).to eq("11.0.0-alpha1+20121225164140.git.207.694b062")
       end
 
-      it "fails on invalid ENV['BUILD_ID'] values" do
-        stub_env("BUILD_ID", "AAAA")
+      it "fails on invalid ENV['BUILD_TIMESTAMP'] values" do
+        stub_env("BUILD_TIMESTAMP", "AAAA")
         expect { build_version.semver }.to raise_error(ArgumentError)
       end
 

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -122,6 +122,17 @@ module Omnibus
         expect { build_version.semver }.to raise_error(ArgumentError)
       end
 
+      it "uses ENV['BUILD_ID'] to generate timestamp if set and BUILD_TIMESTAMP is not set" do
+        stub_env("BUILD_ID", "2012-12-25_16-41-40")
+        expect(build_version.semver).to eq("11.0.0-alpha1+20121225164140.git.207.694b062")
+      end
+
+      it "fails on invalid ENV['BUILD_ID'] values" do
+        stub_env("BUILD_ID", "AAAA")
+        expect { build_version.semver }.to raise_error(ArgumentError)
+      end
+
+
       context "prerelease version with dashes" do
         let(:git_describe) { "11.0.0-alpha-3-207-g694b062" }
 

--- a/spec/unit/build_version_spec.rb
+++ b/spec/unit/build_version_spec.rb
@@ -132,7 +132,6 @@ module Omnibus
         expect { build_version.semver }.to raise_error(ArgumentError)
       end
 
-
       context "prerelease version with dashes" do
         let(:git_describe) { "11.0.0-alpha-3-207-g694b062" }
 


### PR DESCRIPTION
As explained in #481 Jenkins has changed the format of BUILD_ID
from being a timestamp to the same value as BUILD_NUMBER.

This patch uses BUILD_TIMESTAMP instead of BUILD_ID but don't use
any fall back.

Signed-off-by: itsuugo <antonio.ojea.garcia@gmail.com>