### PR TITLE
Add ":file" to the list of supported sources

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -292,7 +292,7 @@ module Omnibus
         val = canonicalize_source(val)
 
         extra_keys = val.keys - [
-          :git, :path, :url, # fetcher types
+          :git, :file, :path, :url, # fetcher types
           :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
           :cookie, :warning, :unsafe, :extract, # used by net_fetcher
           :options, # used by path_fetcher
@@ -303,7 +303,7 @@ module Omnibus
             "only include valid keys. Invalid keys: #{extra_keys.inspect}")
         end
 
-        duplicate_keys = val.keys & [:git, :path, :url]
+        duplicate_keys = val.keys & [:git, :file, :path, :url]
         unless duplicate_keys.size < 2
           raise InvalidValue.new(:source,
             "not include duplicate keys. Duplicate keys: #{duplicate_keys.inspect}")
@@ -1053,6 +1053,8 @@ module Omnibus
           :url
         elsif source[:git]
           :git
+        elsif source[:file]
+          :file
         elsif source[:path]
           :path
         end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -824,6 +824,40 @@ module Omnibus
           end
         end
       end
+
+      context "when given source is a local file path" do
+        let(:source) do
+          {
+            file: "../foo.tar.gz",
+          }
+        end
+
+        context "when relative_path is the same as name" do
+          let(:rel_path) { "software" }
+
+          it "for back-compat, changes fetch_dir" do
+            subject.send(:fetcher)
+            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
+          end
+
+          it "sets the fetcher project_dir to project_dir" do
+            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/software"))
+          end
+        end
+
+        context "when relative_path is different from name" do
+          let(:rel_path) { "foo" }
+
+          it "ignores back-compat and leaves fetch_dir alone" do
+            subject.send(:fetcher)
+            expect(subject.project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
+          end
+
+          it "sets the fetcher project_dir to project_dir" do
+            expect(subject.send(:fetcher).project_dir).to eq(File.expand_path("#{Config.source_dir}/software/foo"))
+          end
+        end
+      end
     end
 
     describe "#canonicalize_source" do


### PR DESCRIPTION
### Description

That is a continuation of https://github.com/chef/omnibus/pull/795. 
In order to use file fetcher in `source` DSL method of software, we need to add it to the list of valid arguments. Otherwise, the following error will occur:

```
Invalid value for `source'. Expected source to only include valid keys. Invalid keys: [:file]!
```

Use case:
```ruby
# config/software/my_software.rb
# <...>

version("local_file") do
  source file: "../../my_dir/artifact.zip"
end

# <...>
```