### PR TITLE
Whitelist Foundation framework

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -126,6 +126,7 @@ MAC_WHITELIST_LIBS = [
   /Tcl$/,
   /Cocoa$/,
   /Carbon$/,
+  /Foundation/,
   /IOKit$/,
   /Tk$/,
   /libutil\.dylib/,


### PR DESCRIPTION
The Foundation framework is fundamental on MacOS, so it seems
reasonable to whitelist it. This is required by ruby2.5