### PR TITLE
Pin omnibus to license_scout ~> 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source "https://rubygems.org"
 gemspec
 
-# Always use license_scout from master
-gem "license_scout", git: "https://github.com/chef/license_scout"
-
 # net-ssh 4.x does not work with Ruby 2.2 on Windows. Chef and ChefDK
 # are pinned to 3.2 so pinning that here. Only used by fauxhai in this project
 gem "net-ssh", "3.2.0"

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pedump"
 
   # from Gemfile
-  gem.add_dependency "license_scout"
+  gem.add_dependency "license_scout", "~> 1.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"


### PR DESCRIPTION
### Description

Pin LicenseScout to the 1.x release

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
