### PR TITLE
Avoid using git to determine gem contents

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.2"
 
-  gem.files = `git ls-files`.split($/)
+  gem.files = %w{ LICENSE README.md Rakefile Gemfile } + Dir.glob("*.gemspec") + Dir.glob("{bin,lib,resources,spec}/**/*")
   gem.bindir = "bin"
   gem.executables = %w{omnibus}
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
@@ -29,12 +29,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ohai",             "~> 8.0"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             "~> 0.18"
+  gem.add_dependency "license_scout",    "~> 1.0"
 
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "pedump"
-
-  # from Gemfile
-  gem.add_dependency "license_scout", "~> 1.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "artifactory", "~> 2.0"


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

### Description

Avoid using git to determine file contents because it can pick up unexpected files during CI builds.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
