### PR TITLE
omnibus/cli: Exit with non-zero code on failure

### DIFF
--- a/lib/omnibus/cli/base.rb
+++ b/lib/omnibus/cli/base.rb
@@ -32,6 +32,10 @@ module Omnibus
 
         super
       end
+
+      def exit_on_failure?
+        true
+      end
     end
 
     include Logging


### PR DESCRIPTION
### Description

Fixes #821 

Omnibus CLI inherits the base of Thor, which returns 0 for failed commands by default. Refer to https://github.com/erikhuda/thor/issues/244 for more details. 
