### PR TITLE
Loosen the pinning on "ohai"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1
 bundler_args: "--jobs 7 --without docs local"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is managed by the CHEF Release Engineering team. For more informati
 
 Omnibus is designed to run with a minimal set of prerequisites. You will need the following:
 
-- Ruby 2.2+
+- Ruby 2.3+
 - Bundler
 
 ## Get Started

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
   matrix:
     - RUBY_VERSION: 24
     - RUBY_VERSION: 23
-    - RUBY_VERSION: 22
 
 clone_folder: c:\projects\omnibus
 clone_depth: 1

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.description    = gem.summary
   gem.homepage       = "https://github.com/chef/omnibus"
 
-  gem.required_ruby_version = ">= 2.2"
+  gem.required_ruby_version = ">= 2.3"
 
   gem.files = %w{ LICENSE README.md Rakefile Gemfile } + Dir.glob("*.gemspec") + Dir.glob("{bin,lib,resources,spec}/**/*")
   gem.bindir = "bin"
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "cleanroom",        "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  "~> 2.0"
-  gem.add_dependency "ohai",             "~> 8.0"
+  gem.add_dependency "ohai",             ">= 8.6.0.alpha.1", "< 15"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             "~> 0.18"
   gem.add_dependency "license_scout",    "~> 1.0"


### PR DESCRIPTION
### Description

Ohai requirement of ~> 8.0 is incompatible with Chef 13 and newer

Unpin the requirement a little to allow for Ohai 14.x, as we expect the Ohai api used by Omnibus is stable through to at least Chef/Ohai 14.

Closes #801 


--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
