### PR TITLE
Add support of LGPL-2.0 license

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -657,6 +657,7 @@ EOH
       "AGPL-3.0",      # GNU Affero General Public License v3
       "GPL-2.0",       # GNU General Public License version 2.0
       "GPL-3.0",       # GNU General Public License version 3.0
+      "LGPL-2.0",      # GNU Library or "Lesser" General Public License version 2.0
       "LGPL-2.1",      # GNU Library or "Lesser" General Public License version 2.1
       "LGPL-3.0",      # GNU Library or "Lesser" General Public License version 3.0
       "HPND",          # Historical Permission Notice and Disclaimer


### PR DESCRIPTION
LGPL-2.0 was superseded by the GNU Lesser General Public License (LGPL-2.1 and higher) a while ago.
However there are still projects licensed under LGPL-2.0, such as [`GTK+3`](http://www.linuxfromscratch.org/blfs/view/svn/x/gtk3.html), so it should not be reported as an unknown/non-standart license.

License page: https://opensource.org/licenses/LGPL-2.0

