### PR TITLE
S3 Publisher: Print the download URL for published artifacts

### DIFF
--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -30,13 +30,27 @@ module Omnibus
 
         # Upload the metadata first
         log.debug(log_key) { "Uploading '#{package.metadata.name}'" }
-        store_object(key_for(package, package.metadata.name), FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
-                     nil, access_policy)
+
+        s3_metadata_object = store_object(
+          key_for(package, package.metadata.name),
+          FFI_Yajl::Encoder.encode(package.metadata.to_hash, pretty: true),
+          nil,
+          access_policy
+        )
+
+        log.debug(log_key) { "Uploading is completed. Download URL (#{access_policy}): #{s3_metadata_object.public_url}" }
 
         # Upload the actual package
         log.info(log_key) { "Uploading '#{package.name}'" }
-        store_object(key_for(package, package.name), package.content,
-                     package.metadata[:md5], access_policy)
+
+        s3_object = store_object(
+          key_for(package, package.name),
+          package.content,
+          package.metadata[:md5],
+          access_policy
+        )
+
+        log.info(log_key) { "Uploading is completed. Download URL (#{access_policy}): #{s3_object.public_url}" }
 
         # If a block was given, "yield" the package to the caller
         yield(package) if block

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -129,7 +129,7 @@ module Omnibus
       # @param [String] content_md5
       # @param [String] acl
       #
-      # @return [true]
+      # @return [Aws::S3::Object]
       #
       def store_object(key, content, content_md5, acl)
         bucket.put_object({
@@ -138,7 +138,6 @@ module Omnibus
           content_md5: to_base64_digest(content_md5),
           acl: acl,
         })
-        true
       end
 
       #


### PR DESCRIPTION
### Description
When the S3 uploading is completed, the download URL will be printed to the Omnibus log output. That is useful if S3 is used as a final hosting platform for these artifacts, so operator can get a result URL directly from the omnibus output.

####  Example
```
$ bundle exec omnibus publish s3 my-bucket --acl public --region eu-central-1 "./pkg/*.dmg"
                    [CLI] I | 2018-03-19T09:36:47+01:00 | Using config from 'omnibus.rb'
       [Command::Publish] I | 2018-03-19T09:36:47+01:00 | Using config from 'omnibus.rb'
            [S3Publisher] I | 2018-03-19T09:36:47+01:00 | Starting S3 publisher
            [S3Publisher] I | 2018-03-19T09:36:48+01:00 | Uploading 'myproj-0.1.0+20180315142042-1.dmg'
            [S3Publisher] I | 2018-03-19T09:36:58+01:00 | Uploading is completed. Download URL (public-read): https://my-bucket.s3.eu-central-1.amazonaws.com/current/myproj/0.1.0%2B20180315142042/mac_os_x/10.10/myproj-0.1.0%2B20180315142042-1.dmg
Published 'myproj-0.1.0+20180315142042-1.dmg' for mac_os_x-10.10
```

Note: Metadata URL is printed to `debug` log level only, so it's not shown in the example above.