### PR TITLE
Fix typo (fixes Project.text_manifest_path)

### DIFF
--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -794,7 +794,7 @@ module Omnibus
     #
     def text_manifest_path(path = NULL)
       if null?(path)
-        @test_manifest_path || File.join(install_dir, "version-manifest.txt")
+        @text_manifest_path || File.join(install_dir, "version-manifest.txt")
       else
         @text_manifest_path = path
       end


### PR DESCRIPTION
### Description

Correct typo: "test_manifest_path" should be "text_manifest_path"

Obvious fix.

--------------------------------------------------
