### PR TITLE
Change exclude to use `**` to skip levels

### DIFF
--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -56,13 +56,13 @@ module Omnibus
     #
     def all_files_under(source, options = {})
       excludes = Array(options[:exclude]).map do |exclude|
-        [exclude, "#{exclude}/*"]
+        [exclude, "#{exclude}/**"]
       end.flatten
 
       source_files = glob(File.join(source, "**/*"))
       source_files = source_files.reject do |source_file|
         basename = relative_path_for(source_file, source)
-        excludes.any? { |exclude| File.fnmatch?(exclude, basename, File::FNM_DOTMATCH) }
+        excludes.any? { |exclude| File.fnmatch?(exclude, basename, File::FNM_DOTMATCH | File::FNM_PATHNAME) }
       end
     end
 

--- a/spec/functional/file_syncer_spec.rb
+++ b/spec/functional/file_syncer_spec.rb
@@ -56,6 +56,14 @@ module Omnibus
         FileUtils.touch(File.join(source, ".dot_folder", "file_f"))
 
         FileUtils.touch(File.join(source, ".file_g"))
+
+        FileUtils.mkdir_p(File.join(source, "nested", "deep", "folder"))
+        FileUtils.touch(File.join(source, "nested", "deep", "folder", "file_h"))
+        FileUtils.touch(File.join(source, "nested", "deep", "folder", "file_i"))
+
+        FileUtils.mkdir_p(File.join(source, "nested", "deep", "deep", "folder"))
+        FileUtils.touch(File.join(source, "nested", "deep", "deep", "folder", "file_j"))
+        FileUtils.touch(File.join(source, "nested", "deep", "deep", "folder", "file_k"))
         source
       end
 
@@ -232,6 +240,24 @@ module Omnibus
           expect("#{destination}/.dot_folder/file_f").to_not be_a_file
           expect("#{destination}/.file_g").to be_a_file
         end
+
+        it "does not copy files and folders that match the wildcard pattern" do
+          described_class.sync(source, destination, exclude: "nested/*/folder")
+
+          expect("#{destination}/file_a").to be_a_file
+          expect("#{destination}/file_b").to be_a_file
+          expect("#{destination}/file_c").to be_a_file
+          expect("#{destination}/folder/file_d").to be_a_file
+          expect("#{destination}/folder/file_e").to be_a_file
+          expect("#{destination}/.dot_folder").to be_a_directory
+          expect("#{destination}/.dot_folder/file_f").to be_a_file
+          expect("#{destination}/.file_g").to be_a_file
+          expect("#{destination}/nested/deep/folder/file_h").to_not be_a_file
+          expect("#{destination}/nested/deep/folder/file_i").to_not be_a_file
+          expect("#{destination}/nested/deep/deep/folder/file_j").to_not be_a_file
+          expect("#{destination}/nested/deep/deep/folder/file_k").to_not be_a_file
+        end
+
 
         it "removes existing files and folders in destination" do
           FileUtils.mkdir_p("#{destination}/existing_folder")

--- a/spec/functional/file_syncer_spec.rb
+++ b/spec/functional/file_syncer_spec.rb
@@ -254,10 +254,26 @@ module Omnibus
           expect("#{destination}/.file_g").to be_a_file
           expect("#{destination}/nested/deep/folder/file_h").to_not be_a_file
           expect("#{destination}/nested/deep/folder/file_i").to_not be_a_file
+          expect("#{destination}/nested/deep/deep/folder/file_j").to be_a_file
+          expect("#{destination}/nested/deep/deep/folder/file_k").to be_a_file
+        end
+
+        it "does not copy files and folders that match the super wildcard pattern" do
+          described_class.sync(source, destination, exclude: "nested/**/folder")
+
+          expect("#{destination}/file_a").to be_a_file
+          expect("#{destination}/file_b").to be_a_file
+          expect("#{destination}/file_c").to be_a_file
+          expect("#{destination}/folder/file_d").to be_a_file
+          expect("#{destination}/folder/file_e").to be_a_file
+          expect("#{destination}/.dot_folder").to be_a_directory
+          expect("#{destination}/.dot_folder/file_f").to be_a_file
+          expect("#{destination}/.file_g").to be_a_file
+          expect("#{destination}/nested/deep/folder/file_h").to_not be_a_file
+          expect("#{destination}/nested/deep/folder/file_i").to_not be_a_file
           expect("#{destination}/nested/deep/deep/folder/file_j").to_not be_a_file
           expect("#{destination}/nested/deep/deep/folder/file_k").to_not be_a_file
         end
-
 
         it "removes existing files and folders in destination" do
           FileUtils.mkdir_p("#{destination}/existing_folder")


### PR DESCRIPTION
### Description

As raised in #833 I find the current behaviour of exclude to be a little alarming, I expect the exclude `'start/*/end'` to match `'start/middle/end'` but not `'start/on/the/way/to/the/end'`

Here we specify File::FNM_PATHNAME to the fnmatch call, so `'start/*/end'` still matches `'start/middle/end'`, but you need `'start/**/end'` if you want to match  `'start/on/the/way/to/the/end'`


Closes #833 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
