### PR TITLE
Add "cached_name" option for net fetcher

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -112,13 +112,15 @@ module Omnibus
     end
 
     #
-    # The path on disk to the downloaded asset. This method requires the
-    # presence of a +source_uri+.
+    # The path on disk to the downloaded asset. The filename is defined by
+    # +source :cached_name+. If ommited, then it comes from the software's
+    # +source :url+ value
     #
     # @return [String]
     #
     def downloaded_file
-      filename = File.basename(source[:url], "?*")
+      filename = source[:cached_name] if source[:cached_name]
+      filename ||= File.basename(source[:url], "?*")
       File.join(Config.cache_dir, filename)
     end
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -294,7 +294,7 @@ module Omnibus
         extra_keys = val.keys - [
           :git, :file, :path, :url, # fetcher types
           :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
-          :cookie, :warning, :unsafe, :extract, # used by net_fetcher
+          :cookie, :warning, :unsafe, :extract, :cached_name, # used by net_fetcher
           :options, # used by path_fetcher
           :submodules # used by git_fetcher
         ]


### PR DESCRIPTION
Fixes https://github.com/chef/omnibus/issues/836

I've added `cached_name` option for `Software#source` allowing to specify a custom filename for the source file when it is stored in the local cache. So that it could be used to work aroung a name collision issue described in #836