### PR TITLE
Pretty print version manifest to pkg folder

### DIFF
--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -91,7 +91,7 @@ module Omnibus
       if @options[:output_manifest]
         FileUtils.mkdir_p("pkg")
         File.open(::File.join("pkg", "version-manifest.json"), "w") do |f|
-          f.write(FFI_Yajl::Encoder.encode(project.built_manifest.to_hash))
+          f.write(FFI_Yajl::Encoder.encode(project.built_manifest.to_hash, pretty: true))
         end
       end
     end


### PR DESCRIPTION
### Description

The version-manifest file that goes into the package is already being pretty printed - https://github.com/chef/omnibus/blob/master/lib/omnibus/project.rb#L1100 . Let's do that to the one being stored to `pkg` folder so it is easier to read.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
