### PR TITLE
add support for light to delay validation

### DIFF
--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -167,6 +167,29 @@ module Omnibus
     expose :wix_light_extension
 
     #
+    # Signal delay validation for wix light
+    #
+    # @example
+    #   wix_light_deplay_validation true
+    #
+    # @param [TrueClass, FalseClass] value
+    #   whether to delay validation or not
+    #
+    # @return [String]
+    #   whether we're a bundle or not
+    def wix_light_delay_validation(val = false)
+      unless val.is_a?(TrueClass) || val.is_a?(FalseClass)
+        raise InvalidValue.new(:iwix_light_delay_validation, "be TrueClass or FalseClass")
+      end
+      @delay_validation ||= val
+      unless @delay_validation
+        return ""
+      end
+      "-sval"
+    end
+    expose :wix_light_delay_validation
+
+    #
     # Set the wix candle extensions to load
     #
     # @example
@@ -465,6 +488,7 @@ module Omnibus
         <<-EOH.split.join(" ").squeeze(" ").strip
         light.exe
           -nologo
+          #{wix_light_delay_validation}
           -ext WixUIExtension
           -ext WixBalExtension
           #{wix_extension_switches(wix_light_extensions)}
@@ -477,6 +501,7 @@ module Omnibus
         <<-EOH.split.join(" ").squeeze(" ").strip
           light.exe
             -nologo
+            #{wix_light_delay_validation}
             -ext WixUIExtension
             #{wix_extension_switches(wix_light_extensions)}
             -cultures:en-us

--- a/spec/unit/packagers/msi_spec.rb
+++ b/spec/unit/packagers/msi_spec.rb
@@ -269,6 +269,28 @@ module Omnibus
       end
     end
 
+    describe "#wix_light_delay_validation" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:wix_light_delay_validation)
+      end
+
+      it "requires the value to be a TrueClass or a FalseClass" do
+        expect do
+          subject.wix_light_delay_validation(Object.new)
+        end.to raise_error(InvalidValue)
+      end
+
+      it "defaults to an empty String" do
+        expect(subject.wix_light_delay_validation).to be_a(String)
+        expect(subject.wix_light_delay_validation).to be_empty
+      end
+
+      it "returns the string `-sval` when true" do
+        subject.wix_light_delay_validation(true)
+        expect(subject.wix_light_delay_validation).to eq("-sval")
+      end
+    end
+
     describe "#wix_candle_extension" do
       it "is a DSL method" do
         expect(subject).to have_exposed_method(:wix_candle_extension)


### PR DESCRIPTION
### Description

Add support for delayed validation in WiX `light.exe` tool, see `-sval` option.
> Build the MSI that will be run against Smoke. Pass the -sval argument to delay validation until Smoke is run.

usage:
```
package :msi do
  wix_light_delay_validation true
end
```

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
