### PR TITLE
allow project configuration to skip packagers

### DIFF
--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -128,6 +128,25 @@ module Omnibus
     expose :windows_safe_path
 
     #
+    # Skip this packager during build process
+    #
+    # @example
+    #   skip_package true
+    #
+    # @param [TrueClass, FalseClass] value
+    #   whether to delay validation or not
+    #
+    # @return [TrueClass, FalseClass]
+    #   whether to skip this packager type or not
+    def skip_packager(val = false)
+      unless val.is_a?(TrueClass) || val.is_a?(FalseClass)
+        raise InvalidValue.new(:iwix_light_delay_validation, "be TrueClass or FalseClass")
+      end
+      @skip_package ||= val
+    end
+    expose :skip_packager
+
+    #
     # @!endgroup
     # --------------------------------------------------
 

--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -140,7 +140,7 @@ module Omnibus
     #   whether to skip this packager type or not
     def skip_packager(val = false)
       unless val.is_a?(TrueClass) || val.is_a?(FalseClass)
-        raise InvalidValue.new(:iwix_light_delay_validation, "be TrueClass or FalseClass")
+        raise InvalidValue.new(:skip_packager, "be TrueClass or FalseClass")
       end
       @skip_package ||= val
     end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1141,6 +1141,10 @@ module Omnibus
           packager.evaluate(&block)
         end
 
+        if packager.skip_packager
+          log.info(log_key) { "Skipping #{packager.id} per project configuration." }
+          next
+        end
         # Run the actual packager
         packager.run!
 

--- a/spec/unit/packagers/base_spec.rb
+++ b/spec/unit/packagers/base_spec.rb
@@ -87,6 +87,23 @@ module Omnibus
       end
     end
 
+    describe "#skip_packager" do
+      it "is a DSL method" do
+        expect(subject).to have_exposed_method(:skip_packager)
+      end
+
+      it "requires the value to be a TrueClass or a FalseClass" do
+        expect do
+          subject.skip_packager(Object.new)
+        end.to raise_error(InvalidValue)
+      end
+
+      it "returns the given value" do
+        subject.skip_packager(true)
+        expect(subject.skip_packager).to be_truthy
+      end
+    end
+
     describe "#run!" do
       before do
         allow(subject).to receive(:remove_directory)


### PR DESCRIPTION
### Description

Since windows builds now offer multiple packagers to execute, allow the project configuration to `skip` a packager if the maintainer does not want to build that package type.

In original APPX support PR #675, there was mention of discussion on how to supporting multiple package type for a single platform being addressed during rollout, since I don't see another existing option, this is my proposal on how to add user input to determine which package types are desired.

usage in a project DSL to omit APPX build:
```
package :appx do
  skip_packager true
end
```

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
