### PR TITLE
Bump versions of ohai, chef-sugar, and fauxhai

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 rvm:
-  - 2.5
-  - 2.4
+  - 2.5.1
+  - 2.4.4
 bundler_args: "--jobs 7 --without docs local"
 branches:
   only:

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "aws-sdk",          "~> 2"
-  gem.add_dependency "chef-sugar",       "~> 3.3"
+  gem.add_dependency "chef-sugar",       ">= 3.3"
   gem.add_dependency "cleanroom",        "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  "~> 2.0"
-  gem.add_dependency "ohai",             ">= 8.6.0.alpha.1", "< 15"
+  gem.add_dependency "ohai",             ">= 13", "< 15"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             "~> 0.18"
   gem.add_dependency "license_scout",    "~> 1.0"
@@ -38,7 +38,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "artifactory", "~> 2.0"
   gem.add_development_dependency "aruba",       "~> 0.5"
   gem.add_development_dependency "chefstyle",   "= 0.6"
-  gem.add_development_dependency "fauxhai",     "~> 5.2"
+  gem.add_development_dependency "fauxhai",     ">= 5.2"
   gem.add_development_dependency "rspec",       "~> 3.0"
   gem.add_development_dependency "rspec-json_expectations"
   gem.add_development_dependency "rspec-its"

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -253,11 +253,11 @@ module Omnibus
     end
 
     describe "#package_name" do
-      it 'reflects the packager\'s unmodified package_name' do
+      it "reflects the packager's unmodified package_name" do
         expect(subject.package_name).to eq("project-1.2.3-2.dmg")
       end
 
-      it 'reflects the packager\'s modified package_name' do
+      it "reflects the packager's modified package_name" do
         package_basename = "projectsub-1.2.3-3"
         allow(project.packagers_for_system[0]).to receive(:package_name)
           .and_return("#{package_basename}.pkg")

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -4,7 +4,7 @@ module Omnibus
   describe Packager do
     describe ".for_current_system" do
       context "on Mac OS X" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.12") }
+        before { stub_ohai(platform: "mac_os_x", version: "10.13") }
         it "prefers PKG" do
           expect(described_class.for_current_system).to eq([Packager::PKG])
         end
@@ -46,21 +46,21 @@ module Omnibus
       end
 
       context "on Fedora" do
-        before { stub_ohai(platform: "fedora", version: "25") }
+        before { stub_ohai(platform: "fedora", version: "28") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::RPM])
         end
       end
 
       context "on Debian" do
-        before { stub_ohai(platform: "debian", version: "8.8") }
+        before { stub_ohai(platform: "debian", version: "8.11") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::DEB])
         end
       end
 
       context "on SLES" do
-        before { stub_ohai(platform: "suse", version: "12.2") }
+        before { stub_ohai(platform: "suse", version: "12.3") }
         it "prefers RPM" do
           expect(described_class.for_current_system).to eq([Packager::RPM])
         end

--- a/spec/unit/packagers/bff_spec.rb
+++ b/spec/unit/packagers/bff_spec.rb
@@ -167,13 +167,13 @@ module Omnibus
         end
 
         context "creates a config script" do
-          it 'when there wasn\'t one provided' do
+          it "when there wasn't one provided" do
             FileUtils.rm_f("#{subject.scripts_staging_dir}/config")
             subject.write_gen_template
             expect(File).to exist("#{subject.scripts_staging_dir}/config")
           end
 
-          it 'when one is provided in the project\'s def' do
+          it "when one is provided in the project's def" do
             create_file("#{project_root}/package-scripts/project/config")
             subject.write_gen_template
             contents = File.read("#{subject.scripts_staging_dir}/config")

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -557,9 +557,9 @@ module Omnibus
       context "on Pidora" do
         before do
           # There's no Pidora in Fauxhai :(
-          stub_ohai(platform: "fedora", version: "25") do |data|
+          stub_ohai(platform: "fedora", version: "27") do |data|
             data["platform"] = "pidora"
-            data["platform_version"] = "25"
+            data["platform_version"] = "27"
             data["kernel"]["machine"] = "armv6l"
           end
         end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -214,14 +214,14 @@ module Omnibus
       end
 
       context "when on Debian" do
-        let(:fauxhai_options) { { platform: "debian", version: "8.8" } }
+        let(:fauxhai_options) { { platform: "debian", version: "8.11" } }
         it "returns a Debian iteration" do
           expect(subject.build_iteration).to eq(1)
         end
       end
 
       context "when on FreeBSD" do
-        let(:fauxhai_options) { { platform: "freebsd", version: "9.3" } }
+        let(:fauxhai_options) { { platform: "freebsd", version: "10.4" } }
         it "returns a FreeBSD iteration" do
           expect(subject.build_iteration).to eq(1)
         end
@@ -236,7 +236,7 @@ module Omnibus
       end
 
       context "when on OS X" do
-        let(:fauxhai_options) { { platform: "mac_os_x", version: "10.12" } }
+        let(:fauxhai_options) { { platform: "mac_os_x", version: "10.13" } }
         it "returns a generic iteration" do
           expect(subject.build_iteration).to eq(1)
         end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -283,16 +283,18 @@ module Omnibus
         end
       end
 
-      context "on freebsd 9" do
+      context "on freebsd 10" do
         before do
           stub_ohai(platform: "freebsd", version: "10.4")
         end
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
+            "CC"=>"clang",
             "CFLAGS" => "-I/opt/project/embedded/include -O2",
             "CXXFLAGS"  => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",
+            "CXX" => "clang++",
             "LDFLAGS" => "-L/opt/project/embedded/lib",
             "LD_RUN_PATH" => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
@@ -303,20 +305,6 @@ module Omnibus
         context "with gcc 4.9 installed" do
           before do
             allow(subject).to receive(:which).and_return("/usr/local/bin/gcc49")
-          end
-
-          it "sets the compiler args" do
-            expect(subject.with_standard_compiler_flags).to eq(
-              "CC"              => "gcc49",
-              "CXX"             => "g++49",
-              "CFLAGS" => "-I/opt/project/embedded/include -O2",
-              "CXXFLAGS"  => "-I/opt/project/embedded/include -O2",
-              "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",
-              "LDFLAGS" => "-L/opt/project/embedded/lib",
-              "LD_RUN_PATH" => "/opt/project/embedded/lib",
-              "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
-              "OMNIBUS_INSTALL_DIR" => "/opt/project"
-            )
           end
         end
       end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -290,7 +290,7 @@ module Omnibus
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
-            "CC"=>"clang",
+            "CC" => "clang",
             "CFLAGS" => "-I/opt/project/embedded/include -O2",
             "CXXFLAGS"  => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -242,7 +242,7 @@ module Omnibus
       end
 
       context "on mac_os_x" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.12") }
+        before { stub_ohai(platform: "mac_os_x", version: "10.13") }
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
@@ -323,7 +323,7 @@ module Omnibus
 
       context "on freebsd 10" do
         before do
-          stub_ohai(platform: "freebsd", version: "10.3")
+          stub_ohai(platform: "freebsd", version: "10.4")
         end
 
         it "Clang as the default compiler" do

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -285,7 +285,7 @@ module Omnibus
 
       context "on freebsd 9" do
         before do
-          stub_ohai(platform: "freebsd", version: "9.3")
+          stub_ohai(platform: "freebsd", version: "10.4")
         end
 
         it "sets the defaults" do


### PR DESCRIPTION
Only support the supported Ohai release. Allow for the latest
fauxhai/chef-sugar releases

Signed-off-by: Tim Smith <tsmith@chef.io>