### PR TITLE
Update truncate_platform_version with new platforms / update gentoo

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -173,11 +173,11 @@ module Omnibus
         when "centos", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos", "nexus", "ios_xr"
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split(".").first
-        when "aix", "alpine", "gentoo", "mac_os_x", "openbsd", "slackware", "solaris2", "opensuse", "ubuntu"
+        when "aix", "alpine", "mac_os_x", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"
           # Only want MAJOR.MINOR (e.g. Mac OS X 10.9, Ubuntu 12.04)
           platform_version.split(".")[0..1].join(".")
-        when "arch"
-          # Arch Linux does not have a platform_version ohai attribute, it is rolling release (lsb_release -r)
+        when "arch", "gentoo"
+          # Arch Linux / Gentoo do not have a platform_version ohai attribute, they are rolling release (lsb_release -r)
           "rolling"
         when "windows"
           # Windows has this really awesome "feature", where their version numbers

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -210,6 +210,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       end
 
       it_behaves_like "a version manipulator", "aix", "7.1", "7.1"
+      it_behaves_like "a version manipulator", "amazon", "2018.03", "2018.03"
       it_behaves_like "a version manipulator", "arch", "rolling", "rolling"
       it_behaves_like "a version manipulator", "centos", "5.9.6", "5"
       it_behaves_like "a version manipulator", "debian", "7.1", "7"
@@ -217,12 +218,13 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
       it_behaves_like "a version manipulator", "el", "6.5", "6"
       it_behaves_like "a version manipulator", "fedora", "11.5", "11"
       it_behaves_like "a version manipulator", "freebsd", "10.0", "10"
-      it_behaves_like "a version manipulator", "gentoo", "2004.3", "2004.3"
+      it_behaves_like "a version manipulator", "gentoo", "4.9.95-gentoo", "rolling"
       it_behaves_like "a version manipulator", "ios_xr", "6.0.0.14I", "6"
       it_behaves_like "a version manipulator", "mac_os_x", "10.9.1", "10.9"
       it_behaves_like "a version manipulator", "nexus", "5.0", "5"
       it_behaves_like "a version manipulator", "omnios", "r151010", "r151010"
       it_behaves_like "a version manipulator", "openbsd", "5.4.4", "5.4"
+      it_behaves_like "a version manipulator", "opensuseleap", "42.3", "42.3"
       it_behaves_like "a version manipulator", "opensuse", "5.9", "5.9"
       it_behaves_like "a version manipulator", "pidora", "11.5", "11"
       it_behaves_like "a version manipulator", "raspbian", "7.1", "7"


### PR DESCRIPTION
Gentoo is a rolling release. We used to try to (incorrectly) identify the version, but we use the kernel version now. Mark it as rolling.

This list was also missing amazon and opensuseleap