### PR TITLE
Support authenticated HTTP URLs (fixes #851)

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -171,6 +171,7 @@ module Omnibus
 
       # Set the cookie if one was given
       options["Cookie"] = source[:cookie] if source[:cookie]
+      options["Authorization"] = source[:authorization] if source[:authorization]
 
       download_file!(download_url, downloaded_file, options)
     end

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -263,6 +263,8 @@ module Omnibus
     #
     # @option val [String] :cookie (nil)
     #   a cookie to set
+    # @option val [String] :authorization (nil)
+    #   an authorization header to set
     # @option val [String] :warning (nil)
     #   a warning message to print when downloading
     # @option val [Symbol] :extract (nil)
@@ -294,7 +296,7 @@ module Omnibus
         extra_keys = val.keys - [
           :git, :file, :path, :url, # fetcher types
           :md5, :sha1, :sha256, :sha512, # hash type - common to all fetchers
-          :cookie, :warning, :unsafe, :extract, :cached_name, # used by net_fetcher
+          :cookie, :warning, :unsafe, :extract, :cached_name, :authorization, # used by net_fetcher
           :options, # used by path_fetcher
           :submodules # used by git_fetcher
         ]

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -25,6 +25,34 @@ module Omnibus
 
     subject { described_class.new(manifest_entry, project_dir, build_dir) }
 
+    describe "authorization" do
+      context "when none passed" do
+        it "does not get passed" do
+          expect(subject).to receive(:download_file!) do |url_arg, path_arg, options_arg|
+            expect(options_arg).to_not have_key("Authorization")
+          end
+
+          subject.send(:download)
+        end
+      end
+
+      context "when passed" do
+        let(:auth_header) { "a fake auth header" }
+        let(:source) do
+          { url: "https://get.example.com/file.tar.gz", md5: "abcd1234", authorization: auth_header }
+        end
+
+        it "does get passed" do
+          expect(subject).to receive(:download_file!) do |url_arg, path_arg, options_arg|
+            expect(options_arg).to have_key("Authorization")
+            expect(options_arg["Authorization"]).to eq(auth_header)
+          end
+
+          subject.send(:download)
+        end
+      end
+    end
+
     describe "#fetch_required?" do
       context "when file is not downloaded" do
         before { allow(File).to receive(:exist?).and_return(false) }


### PR DESCRIPTION
This PR fixes issue #851.

### Description

Software `source` method now supports the `authorization` option.
This allows the user to supply an HTTP Authorization header which will
be passed to the source URL.

For the common case of basic authentication, that looks like this:

```
require 'base64'

username = 'XXX'
password = 'YYY'
credentials = Base64.encode64("#{username}:#{password}")

version 'the_version' do
  source url: 'https://example.com/path/to/the/file',
         authorization: "Basic #{credentials}",
         ...
end
```

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
