### PR TITLE
Using aws-sdk-s3

### DIFF
--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -93,6 +93,9 @@ module Omnibus
           Aws::SharedCredentials.new(profile_name: s3_configuration[:profile])
         elsif s3_configuration[:access_key_id] && s3_configuration[:secret_access_key]
           Aws::Credentials.new(s3_configuration[:access_key_id], s3_configuration[:secret_access_key])
+        else
+          # No credentials specified, only public data will be retrievable
+          Aws::Credentials.new(nil, nil)
         end
       end
 

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "aws-sdk"
+require "aws-sdk-s3"
 require "aws-sdk-core/credentials"
 require "aws-sdk-core/shared_credentials"
 require "base64"

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "aws-sdk",          "~> 2"
+  gem.add_dependency "aws-sdk-s3",       "~> 1"
   gem.add_dependency "chef-sugar",       ">= 3.3"
   gem.add_dependency "cleanroom",        "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"


### PR DESCRIPTION
The full aws-sdk gem includes a massive number of dependency gems now that AWS has broken the aws-sdk into many pieces. Trimming this dependency allows applications that depend on omnibus to avoid downloading dozens or hundreds of small packages when they run 'bundle install'