### PR TITLE
Unpin gcc-4.8 for later versions of Suse

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -700,7 +700,7 @@ module Omnibus
             "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
           # Enable gcc version 4.8 if it is available
-          if which("gcc-4.8")
+          if which("gcc-4.8") && platform_version.satisfies?("< 12")
             suse_flags["CC"] = "gcc-4.8"
             suse_flags["CXX"] = "g++-4.8"
           end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -373,7 +373,7 @@ module Omnibus
         before do
           # sles identifies as suse
           stub_ohai(platform: "suse", version: "12.2")
-          allow(subject).to receive(:which).with("gcc-4.8").and_return(false)
+          allow(subject).to receive(:which).with("gcc-4.8").and_return(true)
         end
 
         it "sets the defaults" do


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Suse platform versions later than 12 should compile using the default gcc version.
Only use gcc-4.8 for Suse platforms before version 12.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
