### PR TITLE
Remove generator file pins

### DIFF
--- a/lib/omnibus/generator_files/Gemfile.erb
+++ b/lib/omnibus/generator_files/Gemfile.erb
@@ -13,9 +13,9 @@ gem 'omnibus', '~> <%= Omnibus::VERSION.split('.')[0...-1].join('.') %>'
 # by running `bundle install --without development` to speed up build times.
 group :development do
   # Use Berkshelf for resolving cookbook dependencies
-  gem 'berkshelf', '~> 3.3'
+  gem 'berkshelf'
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem 'test-kitchen',    '~> 1.4'
-  gem 'kitchen-vagrant', '~> 0.18'
+  gem 'test-kitchen',
+  gem 'kitchen-vagrant',
 end


### PR DESCRIPTION
berkshelf is up to 7.x now.  faraday is almost all gone, ridley is gone, etc.

replaces #713 