### PR TITLE
Use RPM on Amazon Linux 2

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -43,6 +43,7 @@ module Omnibus
       "suse"     => RPM,
       "rhel"     => RPM,
       "wrlinux"  => RPM,
+      "amazon"   => RPM,
       "aix"      => BFF,
       "solaris"  => Solaris,
       "ips"      => IPS,

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -52,6 +52,13 @@ module Omnibus
         end
       end
 
+      context "on Amazon Linux 2" do
+        before { stub_ohai(platform: "amazon", version: "2") }
+        it "prefers RPM" do
+          expect(described_class.for_current_system).to eq([Packager::RPM])
+        end
+      end
+
       context "on Debian" do
         before { stub_ohai(platform: "debian", version: "8.11") }
         it "prefers RPM" do


### PR DESCRIPTION
Newer ohai returns `amazon` for `platform_family`

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>

### Description

ohai fixed [amazon linux 2 issue](https://github.com/chef/ohai/blob/a946ff969ae335b163a1766901ccd960ad6dc4eb/CHANGELOG.md#v1430-2018-07-09) before.
omnibus doesn't follow this change and it breaks package build on Amazon Linux 2. Use `rpm`, not `makeself`.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
