### PR TITLE
Fix comparisons for semver style git tags

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017, Chef Software Inc.
+# Copyright 2012-2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -481,6 +481,11 @@ module Omnibus
       end
 
       return if final_version.nil?
+
+      # make git caching work with semver-style versions (assuming a leading v followed by a digit is semver)
+      if final_version =~ /^v(\d+.*)/
+        final_version = $1
+      end
 
       begin
         Chef::Sugar::Constraints::Version.new(final_version)

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -891,5 +891,13 @@ module Omnibus
         end
       end
     end
+
+    describe "#version" do
+      it "handles semver style git tags correctly" do
+        project.override :software, version: "v2.3.4"
+        expect( subject.version ).to eql("2.3.4")
+        expect( subject.version ).to be_a(Chef::Sugar::Constraints::Version)
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes this issue:

```
  [Software: ohai] W | 2018-12-07T12:41:02-05:00 | Version v14.8.10 for software ohai was not parseable. Comparison methods such as #satisfies? will not be available for this version.
```
