### PR TITLE
Change 'pretans' to 'pretrans'

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -31,7 +31,7 @@ module Omnibus
       preun:        "preun",
       postun:       "postun",
       verifyscript: "verifyscript",
-      pretans:      "pretans",
+      pretrans:      "pretrans",
       posttrans:    "posttrans",
     }.freeze
 

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -267,7 +267,7 @@ module Omnibus
       end
 
       context "when scripts are given" do
-        let(:scripts) { %w{ pre post preun postun verifyscript pretans posttrans } }
+        let(:scripts) { %w{ pre post preun postun verifyscript pretrans posttrans } }
 
         before do
           scripts.each do |script_name|


### PR DESCRIPTION
The script used by RPM is named 'pretrans', not 'pretans' per the
Fedora packaging guidelines. See the following link for more details:
https://fedoraproject.org/wiki/Packaging:Scriptlets?rd=Packaging:ScriptletSnippets#Syntax

### Description

In the RPM packager, I simply changed 'pretans' to 'pretrans' so that it will run correctly. 

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
