### PR TITLE
New projects lacked critical files, such as kitchen and package scripts

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.4"
 
-  gem.files = %w{ LICENSE README.md Rakefile Gemfile } + Dir.glob("*.gemspec") + Dir.glob("{bin,lib,resources,spec}/**/*")
+  gem.files = %w{ LICENSE README.md Rakefile Gemfile } + Dir.glob("*.gemspec") + Dir.glob("{bin,lib,resources,spec}/**/{*,.kitchen*}")
   gem.bindir = "bin"
   gem.executables = %w{omnibus}
   gem.test_files = gem.files.grep(/^(test|spec|features)\//)


### PR DESCRIPTION
### Description

Related: #831

It looks like #820 prevented `omnibus` from creating some critical files.  `Dir.glob()` does not see hidden files by default.  Since the kitchen files were failing, any instructions after were failing to execute, which led to package-scripts from also not being included.

https://ruby-doc.org/core-2.5.1/Dir.html
> Note, this will not match Unix-like hidden files (dotfiles). In order to include those in the match results, you must use the File::FNM_DOTMATCH flag or something like "{*,.*}".

**BEFORE** 

```sh
$ omnibus new omnibus-test
      create  omnibus-test/Gemfile
      create  omnibus-test/gitignore
      create  omnibus-test/README.md
      create  omnibus-test/omnibus.rb
      create  omnibus-test/config/projects/openssl-fips.rb
      create  omnibus-test/config/software/openssl-fips-zlib.rb
Could not find ".kitchen.local.yml.erb" in any of your source paths. Your current source paths are:
/Users/iamjohnnym/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/omnibus-6.0.1/lib/omnibus/generator_files
```

**AFTER**
```sh
$ omnibus new test
      create  omnibus-test/Gemfile
      create  omnibus-test/.gitignore
      create  omnibus-test/README.md
      create  omnibus-test/omnibus.rb
      create  omnibus-test/config/projects/test.rb
      create  omnibus-test/config/software/test-zlib.rb
      create  omnibus-test/.kitchen.local.yml
      create  omnibus-test/.kitchen.yml
      create  omnibus-test/Berksfile
      create  omnibus-test/package-scripts/test/preinst
       chmod  omnibus-test/package-scripts/test/preinst
      create  omnibus-test/package-scripts/test/prerm
       chmod  omnibus-test/package-scripts/test/prerm
      create  omnibus-test/package-scripts/test/postinst
       chmod  omnibus-test/package-scripts/test/postinst
      create  omnibus-test/package-scripts/test/postrm
       chmod  omnibus-test/package-scripts/test/postrm
```

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
