### PR TITLE
Whitelist the Security framework library on macOS

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -135,6 +135,7 @@ MAC_WHITELIST_LIBS = [
   /libiconv/,
   /libstdc\+\+\.6\.dylib/,
   /libc\+\+\.1\.dylib/,
+  /Security/,
 ].freeze
 
 FREEBSD_WHITELIST_LIBS = [


### PR DESCRIPTION
This is required to compile ruby 2.6.

Signed-off-by: Tim Smith <tsmith@chef.io>