### PR TITLE
Add marcparadise to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,3 +24,4 @@ Check out [How Chef is Maintained](https://github.com/chef/chef-rfc/blob/master/
 - [Steven Danna](https://github.com/stevendanna)
 - [Thom May](https://github.com/thommay)
 - [Yvonne Lam](http://github.com/yzl)
+- [Marc Paradise](http://github.com/marcparadise)


### PR DESCRIPTION

### Description
Adds marcparadise as a maintainer. 

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
