### PR TITLE
Remove custom LDFLAGS and CFLAGS for osx.

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -665,11 +665,6 @@ module Omnibus
             "OBJECT_MODE" => "64",
             "ARFLAGS" => "-X64 cru",
           }
-        when "mac_os_x"
-          {
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
-          }
         when "solaris2"
           if platform_version.satisfies?("<= 5.10")
             solaris_flags = {

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -195,7 +195,7 @@ module Omnibus
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
-            "LDFLAGS"         => "-L/opt/project/embedded/lib",
+            "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
             "CFLAGS"          => "-I/opt/project/embedded/include -O2",
             "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
             "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",


### PR DESCRIPTION
### Description

OSX 10.5 or greater can use '-Wl,-rpath,/path/to/lib' so we can use
the default flags.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
