### PR TITLE
Improve logging when overriding a version when there is no default

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -765,7 +765,7 @@ module Omnibus
       log.internal(log_key) { "Cached builder checksum before build: #{shasum}" }
       if software.overridden?
         log.info(log_key) do
-          "Version overridden from #{software.default_version} to "\
+          "Version overridden from #{software.default_version || "n/a"} to "\
           "#{software.version}"
         end
       end


### PR DESCRIPTION
Right now if you specify a version when there is no default you get a nice message like this that has printed out a nil value:

[Builder: bundler] I | 2019-03-20T04:13:10+00:00 | Version overridden from  to 2.0.1

This would change this message to this instead:

[Builder: bundler] I | 2019-03-20T04:13:10+00:00 | Version overridden from n/a to 2.0.1

Signed-off-by: Tim Smith <tsmith@chef.io>