### PR TITLE
Break dmg creation and assets copying into separate steps

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -36,6 +36,7 @@ module Omnibus
     build do
       create_writable_dmg
       attach_dmg
+      copy_assets_to_dmg
       # Give some time to the system so attached dmg shows up in Finder
       sleep 5
       set_volume_icon
@@ -138,11 +139,9 @@ module Omnibus
 
       shellout! <<-EOH.gsub(/^ {8}/, "")
         hdiutil create \\
-          -srcfolder "#{resources_dir}" \\
           -volname "#{volume_name}" \\
           -fs HFS+ \\
           -fsargs "-c c=64,a=16,e=16" \\
-          -format UDRW \\
           -size 512000k \\
           "#{writable_dmg}"
       EOH
@@ -167,6 +166,17 @@ module Omnibus
         EOH
 
         cmd.stdout.strip
+      end
+    end
+
+    #
+    # Copy assets to dmg
+    #
+    def copy_assets_to_dmg
+      log.info(log_key) { "Copying assets into dmg" }
+
+      FileSyncer.glob("#{resources_dir}/*").each do |file|
+        FileUtils.cp_r(file, "/Volumes/#{volume_name}")
       end
     end
 

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -86,11 +86,9 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil create \\
-              -srcfolder "#{staging_dir}/Resources" \\
               -volname "Project One" \\
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
-              -format UDRW \\
               -size 512000k \\
               "#{staging_dir}/project-writable.dmg"
           EOH
@@ -127,6 +125,13 @@ module Omnibus
 
       it "returns the stripped stdout" do
         expect(subject.attach_dmg).to eq("hello")
+      end
+    end
+
+    describe "#copy_assets_to_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.copy_assets_to_dmg }
+        expect(output).to include("Copying assets into dmg")
       end
     end
 


### PR DESCRIPTION
### Description

We are transitioning our CI to use Veertu Anka for macos builds.
When `anka run` runs the omnibus build it fails when it shells out
the `hdiutil create` command in the `create_writable_dmg` method.
The `hdiutil create` command creates the dmg and copies assets
into it. Most of the `hdiutil create` command works fine but it
fails with `hdiutil: create failed - Resource busy` when it attempts
to eject the disk used to mount the dmg. The easiest solution is
to use `hdiutil create` to only create the dmg and then copy
the assets in a separate step.