### PR TITLE
Switch off my fork of rspec-json_expectations & fix spec failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ group :debug do
   gem "pry-stack_explorer"
 end
 
-# this brings in several fixes to rspec-json_expectations that are causing test failures
-gem "rspec-json_expectations", git: "https://github.com/tas50/rspec-json_expectations.git"
-
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
   gem "ohai", "<15"
 end

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![Omnibus Icon](lib/omnibus/assets/README-logo.png) Omnibus
 
 [![Gem Version](http://img.shields.io/gem/v/omnibus.svg)][gem]
-[![Travis Build Status](http://img.shields.io/travis/chef/omnibus.svg?label=Travis%20CI)][travis]
+[![Build Status](https://badge.buildkite.com/446fd6049a9a5eeab50112aba117d3b7670ec085acb91f78dd.svg?branch=master)](https://buildkite.com/chef-oss/chef-omnibus-master-verify)
 [![AppVeyor Build Status](http://img.shields.io/appveyor/ci/chef/omnibus.svg?label=AppVeyor)][appveyor]
 
 Easily create full-stack installers for your project across a variety of platforms.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+Encoding.default_external = Encoding::UTF_8
+
 require "rspec"
 require "rspec/its"
 require "rspec/json_expectations"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,10 @@ def mac?
 end
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = 1000
+  end
+
   # Custom matchers and shared examples
   require_relative "support/examples"
   require_relative "support/matchers"

--- a/spec/unit/generator_spec.rb
+++ b/spec/unit/generator_spec.rb
@@ -36,6 +36,7 @@ module Omnibus
           omnibus-name/config/projects/name.rb
           omnibus-name/config/software
           omnibus-name/config/software/name-zlib.rb
+          omnibus-name/config/software/preparation.rb
           omnibus-name/omnibus.rb
           omnibus-name/package-scripts
           omnibus-name/package-scripts/name


### PR DESCRIPTION
The upstream released the fix we needed.

This also fixes spec failures to get the build green. It forces the spec encoding to UTF 8 to prevent failures in the new Buildkite containers, adds a missing array value that was causing a spec failure, and configures rspec to give us longer diffs when a comparison fails.

Signed-off-by: Tim Smith <tsmith@chef.io>