### PR TITLE
Generate a valid project by default

### DIFF
--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -90,6 +90,7 @@ module Omnibus
 
     def create_example_software_definitions
       template("config/software/zlib.rb.erb", "#{target}/config/software/#{name}-zlib.rb", template_options)
+      template("config/software/preparation.rb.erb", "#{target}/config/software/preparation.rb", template_options)
     end
 
     def create_kitchen_files

--- a/lib/omnibus/generator_files/Gemfile.erb
+++ b/lib/omnibus/generator_files/Gemfile.erb
@@ -16,6 +16,6 @@ group :development do
   gem 'berkshelf'
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem 'test-kitchen',
-  gem 'kitchen-vagrant',
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
 end

--- a/lib/omnibus/generator_files/config/projects/project.rb.erb
+++ b/lib/omnibus/generator_files/config/projects/project.rb.erb
@@ -21,8 +21,5 @@ dependency "preparation"
 # <%= config[:name] %> dependencies/components
 # dependency "somedep"
 
-# Version manifest file
-dependency "version-manifest"
-
 exclude "**/.git"
 exclude "**/bundler/git"

--- a/lib/omnibus/generator_files/config/software/preparation.rb.erb
+++ b/lib/omnibus/generator_files/config/software/preparation.rb.erb
@@ -1,0 +1,30 @@
+#
+# Copyright <%= Time.now.year %> YOUR NAME
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "preparation"
+description "the steps required to preprare the build"
+default_version "1.0.0"
+
+license :project_license
+skip_transitive_dependency_licensing true
+
+build do
+  block do
+    touch "#{install_dir}/embedded/lib/.gitkeep"
+    touch "#{install_dir}/embedded/bin/.gitkeep"
+    touch "#{install_dir}/bin/.gitkeep"
+  end
+end


### PR DESCRIPTION
Omnibus was previously generating an invalid project by default
because it:

- Didn't include a version-manifest software definition
- Didn't include the "preparation" software definition
- Had an invalid Gemfile

This fixes those issues, getting us a bit closer to the Getting
Starting directions working out of the box for people.

Fixes #887
Partially addresses #841

Signed-off-by: Steven Danna <steve@chef.io>

#### Maintainers

Please ensure that you check for:

- [x] If this change impacts git cache validity, it bumps the git cache
  serial number
- [x] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [x] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
