### PR TITLE
CentOS packages for Raspberry Pi 3s are 'armv7hl' not 'armv7l'

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -630,6 +630,8 @@ module Omnibus
       case Ohai["kernel"]["machine"]
       when "i686"
         "i386"
+      when "armv7l" # raspberry pi 3 CentOS
+        "armv7hl"
       when "armv6l"
         if Ohai["platform"] == "pidora"
           "armv6hl"


### PR DESCRIPTION
Signed-off-by: Matt Ray <matthewhray@gmail.com>

### Description

CentOS provides packages for the Raspberry Pi 3 platform, but the arch is 'armv7hl' not 'armv7l'. If other 32-bit ARM platforms using RPMs need to be supported in the future, we can update as necessary.
https://wiki.centos.org/SpecialInterestGroup/AltArch/Arm32/RaspberryPi3

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
