### PR TITLE
Update the rpm package signing to work with newer rpm version

### DIFF
--- a/resources/rpm/signing.erb
+++ b/resources/rpm/signing.erb
@@ -11,25 +11,14 @@ require 'pty'
 
 puts rpm_cmd
 PTY.spawn(rpm_cmd) do |r, w, pid|
-  prompt = r.read(19)
-
-  # match the expected prompt exactly, since that's the only way we know if
-  # something went wrong.
-  unless prompt == 'Enter pass phrase: '
-    STDERR.puts "unexpected output from `#{rpm_cmd}`: '#{prompt}'"
-    Process.kill(:KILL, pid)
-    exit 1
-  end
-
-  STDOUT.puts prompt
-  w.write("#{password}\n")
-
   # Keep printing output unti the command exits
   loop do
     begin
       line = r.gets
       puts line
-      if (line =~ /failed/) && !(line =~ /warning:/)
+      if line =~ /Enter pass phrase:/ || line =~ /Please enter the passphrase to unlock the OpenPGP secret key:/
+        w.write("#{password}\n")
+      elsif (line =~ /failed/) && !(line =~ /warning:/)
         STDERR.puts 'RPM signing failure'
         exit 1
       end

--- a/resources/rpm/signing.erb
+++ b/resources/rpm/signing.erb
@@ -11,12 +11,20 @@ require 'pty'
 
 puts rpm_cmd
 PTY.spawn(rpm_cmd) do |r, w, pid|
+  # Older versions of rpmsign will prompt right away for the passphrase
+  prompt = r.read(19)
+
+  if prompt == 'Enter pass phrase: '
+    STDOUT.puts prompt
+    w.write("#{password}\n")
+  end
+
   # Keep printing output unti the command exits
   loop do
     begin
       line = r.gets
       puts line
-      if line =~ /Enter pass phrase:/ || line =~ /Please enter the passphrase to unlock the OpenPGP secret key:/
+      if line =~ /Please enter the passphrase to unlock the OpenPGP secret key:/
         w.write("#{password}\n")
       elsif (line =~ /failed/) && !(line =~ /warning:/)
         STDERR.puts 'RPM signing failure'


### PR DESCRIPTION
### Description

Newer versions of rpmsign (rpm 4.13+), no longer prompt for the pass
phrase, but instead provide gpg with access to stdin/out to request it.

See: https://github.com/rpm-software-management/rpm/commit/0bce5fcf270711a2e077fba0fb7c5979ea007eb5#diff-c9c5aab99001a72b592ce7465ebff8a6

Because this process is deferred, you will also often end up with
warning output from rpmbuild before the prompt, so we can no longer
assume the prompt will be the first output.

This issue was discovered while trying to build rpm packages for
OpenSUSE 15 which has the newer rpm.

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
