### PR TITLE
Separate removing writable dmg

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -4,7 +4,6 @@
 slack:
   notify_channel:
     - chef-found-notify
-    - omnibus-rfr
 
 # This publish is triggered by the `built_in:publish_rubygems` artifact_action.
 rubygems:

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -43,6 +43,7 @@ module Omnibus
       prettify_dmg
       compress_dmg
       set_dmg_icon
+      verify_dmg
       remove_writable_dmg
     end
 
@@ -264,6 +265,23 @@ module Omnibus
             -imagekey \\
             zlib-level=9 \\
             -o "#{package_path}" \\
+            -puppetstrings
+        EOH
+      end
+    end
+
+    #
+    # Verify checksum on created dmg.
+    #
+    # @return [void]
+    #
+    def verify_dmg
+      log.info(log_key) { "Verifying dmg" }
+
+      Dir.chdir(staging_dir) do
+        shellout! <<-EOH.gsub(/^ {10}/, "")
+          hdiutil verify \\
+            "#{package_path}" \\
             -puppetstrings
         EOH
       end

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -43,6 +43,7 @@ module Omnibus
       prettify_dmg
       compress_dmg
       set_dmg_icon
+      remove_writable_dmg
     end
 
     #
@@ -261,6 +262,20 @@ module Omnibus
             -imagekey \\
             zlib-level=9 \\
             -o "#{package_path}"
+        EOH
+      end
+    end
+
+    #
+    # Remove writable dmg.
+    #
+    # @return [void]
+    #
+    def remove_writable_dmg
+      log.info(log_key) { "Removing writable dmg" }
+
+      Dir.chdir(staging_dir) do
+        shellout! <<-EOH.gsub(/^ {10}/, "")
           rm -rf "#{writable_dmg}"
         EOH
       end

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -144,7 +144,8 @@ module Omnibus
           -fs HFS+ \\
           -fsargs "-c c=64,a=16,e=16" \\
           -size 512000k \\
-          "#{writable_dmg}"
+          "#{writable_dmg}" \\
+          -puppetstrings
       EOH
     end
 
@@ -160,6 +161,7 @@ module Omnibus
 
         cmd = shellout! <<-EOH.gsub(/^ {10}/, "")
           hdiutil attach \\
+            -puppetstrings \\
             -readwrite \\
             -noverify \\
             -noautoopen \\
@@ -261,7 +263,8 @@ module Omnibus
             -format UDZO \\
             -imagekey \\
             zlib-level=9 \\
-            -o "#{package_path}"
+            -o "#{package_path}" \\
+            -puppetstrings
         EOH
       end
     end

--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -258,7 +258,7 @@ module Omnibus
         shellout! <<-EOH.gsub(/^ {10}/, "")
           chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
-          hdiutil detach "#{@device}"
+          hdiutil detach "#{@device}" &&  \
           hdiutil convert \\
             "#{writable_dmg}" \\
             -format UDZO \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -90,7 +90,8 @@ module Omnibus
               -fs HFS+ \\
               -fsargs "-c c=64,a=16,e=16" \\
               -size 512000k \\
-              "#{staging_dir}/project-writable.dmg"
+              "#{staging_dir}/project-writable.dmg" \\
+              -puppetstrings
           EOH
 
         subject.create_writable_dmg
@@ -114,6 +115,7 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil attach \\
+              -puppetstrings \\
               -readwrite \\
               -noverify \\
               -noautoopen \\
@@ -221,7 +223,8 @@ module Omnibus
               -format UDZO \\
               -imagekey \\
               zlib-level=9 \\
-              -o "#{package_dir}/project-1.2.3-2.dmg"
+              -o "#{package_dir}/project-1.2.3-2.dmg" \\
+              -puppetstrings
           EOH
 
         subject.compress_dmg

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -222,10 +222,25 @@ module Omnibus
               -imagekey \\
               zlib-level=9 \\
               -o "#{package_dir}/project-1.2.3-2.dmg"
-            rm -rf "#{staging_dir}/project-writable.dmg"
           EOH
 
         subject.compress_dmg
+      end
+    end
+
+    describe "#remove_writable_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.remove_writable_dmg }
+        expect(output).to include("Removing writable dmg")
+      end
+
+      it "runs the command" do
+        expect(subject).to receive(:shellout!)
+          .with <<-EOH.gsub(/^ {12}/, "")
+            rm -rf "#{staging_dir}/project-writable.dmg"
+          EOH
+
+        subject.remove_writable_dmg
       end
     end
 

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -217,7 +217,7 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             chmod -Rf go-w "/Volumes/Project One"
             sync
-            hdiutil detach "#{device}"
+            hdiutil detach "#{device}" &&\
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\
               -format UDZO \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -231,6 +231,24 @@ module Omnibus
       end
     end
 
+    describe "#verify_dmg" do
+      it "logs a message" do
+        output = capture_logging { subject.verify_dmg }
+        expect(output).to include("Verifying dmg")
+      end
+
+      it "runs the command" do
+        expect(subject).to receive(:shellout!)
+          .with <<-EOH.gsub(/^ {12}/, "")
+            hdiutil verify \\
+              "#{package_dir}/project-1.2.3-2.dmg" \\
+              -puppetstrings
+          EOH
+
+        subject.verify_dmg
+      end
+    end
+
     describe "#remove_writable_dmg" do
       it "logs a message" do
         output = capture_logging { subject.remove_writable_dmg }


### PR DESCRIPTION
Taking three step approach to solving this:
* Separate the remove writeable dmg call
* puppetstrings option enables progress output on hdiutil
* Verify the checksum for the final image created
* check detach completes before compressing the dmg

These put together shouldresolve the hdiutil resource busy failure
during compress_dmg

Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
