### PR TITLE
Use architecture from platform mappings file when publishing packages

### DIFF
--- a/features/step_definitions/generator_steps.rb
+++ b/features/step_definitions/generator_steps.rb
@@ -46,10 +46,10 @@ end
 Given(/^I have a platform mappings file named "(.+)"$/) do |name|
   write_file(name, <<-EOH.gsub(/^ {4}/, ""))
     {
-      "ubuntu-10.04": [
-        "ubuntu-10.04",
-        "ubuntu-12.04",
-        "ubuntu-14.04"
+      "ubuntu-10.04-x86_64": [
+        "ubuntu-10.04-x86_64",
+        "ubuntu-12.04-x86_64",
+        "ubuntu-14.04-x86_64"
       ]
     }
   EOH

--- a/lib/omnibus/cli/publish.rb
+++ b/lib/omnibus/cli/publish.rb
@@ -26,10 +26,10 @@ module Omnibus
     #
     # @example JSON
     #   {
-    #     "ubuntu-10.04": [
-    #       "ubuntu-10.04",
-    #       "ubuntu-12.04",
-    #       "ubuntu-14.04"
+    #     "ubuntu-10.04-x86_64": [
+    #       "ubuntu-10.04-x86_64",
+    #       "ubuntu-12.04-x86_64",
+    #       "ubuntu-14.04-x86_64"
     #     ]
     #   }
     #
@@ -99,7 +99,7 @@ module Omnibus
       end
 
       klass.publish(pattern, options) do |package|
-        say("Published '#{package.name}' for #{package.metadata[:platform]}-#{package.metadata[:platform_version]}", :green)
+        say("Published '#{package.name}' for #{package.metadata[:platform]}-#{package.metadata[:platform_version]}-#{package.metadata[:arch]}", :green)
       end
     end
   end

--- a/spec/unit/publisher_spec.rb
+++ b/spec/unit/publisher_spec.rb
@@ -47,9 +47,9 @@ module Omnibus
         let(:options) do
           {
             platform_mappings: {
-              "ubuntu-12.04" => [
-                "ubuntu-12.04",
-                "ubuntu-14.04",
+              "ubuntu-12.04-x86_64" => [
+                "ubuntu-12.04-x86_64",
+                "ubuntu-14.04-x86_64",
               ],
             },
           }
@@ -155,9 +155,9 @@ module Omnibus
           let(:options) do
             {
               platform_mappings: {
-                "ubuntu-10.04" => [
-                  "ubuntu-12.04",
-                  "ubuntu-14.04",
+                "ubuntu-10.04-x86_64" => [
+                  "ubuntu-12.04-x86_64",
+                  "ubuntu-14.04-x86_64",
                 ],
               },
             }
@@ -165,7 +165,7 @@ module Omnibus
 
           it "prints a warning" do
             output = capture_logging { subject.packages }
-            expect(output).to include("Could not locate a package for build platform ubuntu-10.04. Publishing will be skipped for: ubuntu-12.04, ubuntu-14.04")
+            expect(output).to include("Could not locate a package for build platform ubuntu-10.04-x86_64. Publishing will be skipped for: ubuntu-12.04-x86_64, ubuntu-14.04-x86_64")
           end
         end
       end


### PR DESCRIPTION
### Description

This fixes the issue when in certain conditions packages published erroneously because the matching logic wasn't taking the architecture into account.

reference: https://github.com/chef/omnibus-buildkite-plugin/issues/22