### PR TITLE
Unmount dmg before detaching

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -258,6 +258,9 @@ module Omnibus
         shellout! <<-EOH.gsub(/^ {10}/, "")
           chmod -Rf go-w "/Volumes/#{volume_name}"
           sync
+          hdiutil unmount "#{@device}"
+          # Give some time to the system so unmount dmg
+          sleep 5
           hdiutil detach "#{@device}" &&  \
           hdiutil convert \\
             "#{writable_dmg}" \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -217,6 +217,9 @@ module Omnibus
           .with <<-EOH.gsub(/^ {12}/, "")
             chmod -Rf go-w "/Volumes/Project One"
             sync
+            hdiutil unmount "#{device}"
+            # Give some time to the system so unmount dmg
+            sleep 5
             hdiutil detach "#{device}" &&\
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

hdiutil detach device fails with resource busy so clean unmount the device first then detach (eject).
This PR resolves the issue on mac builds on 10.13 and above failing with "Resource Busy" error

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
