### PR TITLE
add `kali` as rolling OS

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -176,7 +176,7 @@ module Omnibus
         when "aix", "alpine", "mac_os_x", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"
           # Only want MAJOR.MINOR (e.g. Mac OS X 10.9, Ubuntu 12.04)
           platform_version.split(".")[0..1].join(".")
-        when "arch", "gentoo"
+        when "arch", "gentoo", "kali"
           # Arch Linux / Gentoo do not have a platform_version ohai attribute, they are rolling release (lsb_release -r)
           "rolling"
         when "windows"

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -219,6 +219,7 @@ module Omnibus
       it_behaves_like "a version manipulator", "fedora", "11.5", "11"
       it_behaves_like "a version manipulator", "freebsd", "10.0", "10"
       it_behaves_like "a version manipulator", "gentoo", "4.9.95-gentoo", "rolling"
+      it_behaves_like "a version manipulator", "kali", "rolling", "rolling"
       it_behaves_like "a version manipulator", "mac_os_x", "10.9.1", "10.9"
       it_behaves_like "a version manipulator", "omnios", "r151010", "r151010"
       it_behaves_like "a version manipulator", "openbsd", "5.4.4", "5.4"


### PR DESCRIPTION
### Description

Add identification for `kali` linux as a rolling OS.

This fixes a stack trace being thrown during final packaging when building a `deb` package on [kali linux](https://www.kali.org/).

```
Unknown platform `kali'!
I do not know how to proceed!"


/home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/metadata.rb:222:in `truncate_platform_version'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/metadata.rb:137:in `platform_version'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/metadata.rb:55:in `generate'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/packagers/base.rb:169:in `block in run!'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/instrumentation.rb:23:in `measure'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/packagers/base.rb:163:in `run!'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/project.rb:1149:in `block in package_me'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/project.rb:1138:in `each'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/project.rb:1138:in `package_me'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/project.rb:1087:in `build'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/cli.rb:89:in `build'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/cli/base.rb:33:in `dispatch'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/lib/omnibus/cli.rb:42:in `execute!'
  /home/jenkins/.rvm/gems/ruby-2.5.3/gems/omnibus-6.1.4/bin/omnibus:16:in `<top (required)>'
  ./bin/omnibus:29:in `load'
  ./bin/omnibus:29:in `<main>'
```

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
