### PR TITLE
Add Whitelist Libs for Catalina

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -133,8 +133,11 @@ MAC_WHITELIST_LIBS = [
   /libffi\.dylib/,
   /libncurses\.5\.4\.dylib/,
   /libiconv/,
+  /libidn2\.0\.dylib/,
   /libstdc\+\+\.6\.dylib/,
   /libc\+\+\.1\.dylib/,
+  /libc\+\+\.1\.dylib/,
+  /libzstd\.1\.dylib/,
   /Security/,
 ].freeze
 


### PR DESCRIPTION
### Description
Adding:
/libidn2\.0\.dylib/
/libzstd\.1\.dylib/

These were blocking the wortstation app build.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
