### PR TITLE
Switch back to chef-sugar

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "aws-sdk-s3",       "~> 1"
-  gem.add_dependency "chef-sugar-ng",    ">= 3.3"
+  gem.add_dependency "chef-sugar",       ">= 3.3"
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"


### PR DESCRIPTION
Both are valid, but there's no need to use the ng gem anymore.

Signed-off-by: Tim Smith <tsmith@chef.io>