### PR TITLE
Remove Solaris 10 platform and enable some hardening flags on Linux/Mac/FreeBSD

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -668,33 +668,22 @@ module Omnibus
             "ARFLAGS" => "-X64 cru",
           }
         when "solaris2"
-          if platform_version.satisfies?("<= 5.10")
-            solaris_flags = {
-              # this override is due to a bug in libtool documented here:
-              # http://lists.gnu.org/archive/html/bug-libtool/2005-10/msg00004.html
-              "CC" => "gcc -static-libgcc",
-              "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
-              "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
-            }
-          elsif platform_version.satisfies?(">= 5.11")
-            solaris_flags = {
-              "CC" => "gcc -m64 -static-libgcc",
-              "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
-              "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
-            }
-          end
-          solaris_flags
+          {
+            "CC" => "gcc -m64 -static-libgcc",
+            "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+          }
         when "freebsd"
           {
             "CC" => "clang",
             "CXX" => "clang++",
             "LDFLAGS" => "-L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
           }
         when "suse"
           suse_flags = {
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
           }
           # Enable gcc version 4.8 if it is available
           if which("gcc-4.8") && platform_version.satisfies?("< 12")
@@ -721,7 +710,7 @@ module Omnibus
         else
           {
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
           }
         end
 

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -671,7 +671,7 @@ module Omnibus
           {
             "CC" => "gcc -m64 -static-libgcc",
             "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -static-libgcc",
-            "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CFLAGS" => "-I#{install_dir}/embedded/include -O2",
           }
         when "freebsd"
           {

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -73,9 +73,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -84,9 +84,9 @@ module Omnibus
         it "overrides LDFLAGS" do
           expect(subject.with_standard_compiler_flags("LDFLAGS" => "foo")).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -95,9 +95,9 @@ module Omnibus
         it "overrides CFLAGS" do
           expect(subject.with_standard_compiler_flags("CFLAGS" => "foo")).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -106,9 +106,9 @@ module Omnibus
         it "overrides CXXFLAGS" do
           expect(subject.with_standard_compiler_flags("CXXFLAGS" => "foo")).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -117,9 +117,9 @@ module Omnibus
         it "overrides CPPFLAGS" do
           expect(subject.with_standard_compiler_flags("CPPFLAGS" => "foo")).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -129,9 +129,9 @@ module Omnibus
           expect(subject.with_standard_compiler_flags("numberwang" => 4)).to eq(
             "numberwang"      => 4,
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -196,9 +196,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -240,9 +240,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             "CC" => "clang",
-            "CFLAGS" => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"  => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"  => "-I/opt/project/embedded/include -O2",
+            "CFLAGS" => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"  => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"  => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "CXX" => "clang++",
             "LDFLAGS" => "-L/opt/project/embedded/lib",
             "LD_RUN_PATH" => "/opt/project/embedded/lib",
@@ -267,9 +267,9 @@ module Omnibus
           expect(subject.with_standard_compiler_flags).to eq(
             "CC"              => "clang",
             "CXX"             => "clang++",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LDFLAGS"         => "-L/opt/project/embedded/lib",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
@@ -287,9 +287,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -307,9 +307,9 @@ module Omnibus
               "CC"              => "gcc-4.8",
               "CXX"             => "g++-4.8",
               "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-              "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-              "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-              "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+              "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+              "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+              "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
               "LD_RUN_PATH"     => "/opt/project/embedded/lib",
               "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
               "OMNIBUS_INSTALL_DIR" => "/opt/project"
@@ -328,9 +328,9 @@ module Omnibus
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(
             "LDFLAGS"         => "-Wl,-rpath,/opt/project/embedded/lib -L/opt/project/embedded/lib",
-            "CFLAGS"          => "-I/opt/project/embedded/include -O2",
-            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2",
-            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2",
+            "CFLAGS"          => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CXXFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
+            "CPPFLAGS"        => "-I/opt/project/embedded/include -O2 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "LD_RUN_PATH"     => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"


### PR DESCRIPTION
We don't build or support Solaris 10 any more since it is EOL

This adds `-D_FORTIFY_SOURCE=2 -fstack-protector` to Linux/Mac/BSD.  Tried to add it to Solaris and it failed.  AIX is not gcc so its not applicable, and Windows mostly terrifies me.

This is likely a NOP since most distros have added this anyway, but it establishes a baseline.

This passed tests here:

https://buildkite.com/chef/chef-chef-master-omnibus-adhoc/builds/133

On 15.5.2 on Ubuntu we already have these settings:

```
# hardening-check /opt/chef/embedded/bin/openssl
/opt/chef/embedded/bin/openssl:
 Position Independent Executable: no, normal executable!
 Stack protected: yes
 Fortify Source functions: yes (some protected functions found)
 Read-only relocations: yes
 Immediate binding: no, not found!
```

This might do something useful like enable hardening on RHEL6 but I didn't exhaustively check.