### PR TITLE
Fix call to URI#open

### DIFF
--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -77,7 +77,7 @@ module Omnibus
           end
         end
 
-        file = open(from_url, options)
+        file = open(from_url, **options)
         # This is a temporary file. Close and flush it before attempting to copy
         # it over.
         file.close


### PR DESCRIPTION
The hash needs to be expanded. As-is, it is an error with Ruby 2.7.0:

```
lib/omnibus/download_helpers.rb:80: warning: Splitting the last argument into positional and keyword parameters is deprecated
lib/omnibus/core_extensions/open_uri.rb:51:in `open_uri'
/usr/local/rvm/rubies/ruby-2.7.0/lib/ruby/2.7.0/open-uri.rb:153:in `open_uri': extra arguments (ArgumentError)
```

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
