### PR TITLE
Add AWS IAM authentication for S3 caching and publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,19 @@ use_git_caching false
 # Enable S3 asset caching
 # ------------------------------
 use_s3_caching true
+s3_bucket      ENV['S3_BUCKET']
+
+# There are three ways to authenticate to the S3 bucket
+
+# 1. set `s3_access_key` and `s3_secret_key`
 s3_access_key  ENV['S3_ACCESS_KEY']
 s3_secret_key  ENV['S3_SECRET_KEY']
-# You can use the Shared Credentials files in place of the s3_access_key and s3_secret_key.
+
+# 2. set `s3_profile` to use an AWS profile in the Shared Credentials files
 #s3_profile    ENV['S3_PROFILE']
-s3_bucket      ENV['S3_BUCKET']
+
+# 3. set `s3_iam_role_arn` to use an AWS IAM role
+#s3_iam_role_arn    ENV['S3_IAM_ROLE_ARN']
 ```
 
 For more information, please see the [`Config` documentation](http://www.rubydoc.info/github/chef/omnibus/Omnibus/Config).

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -285,7 +285,7 @@ module Omnibus
     #
     # @return [String, nil]
     default(:s3_access_key) do
-      if s3_profile
+      if s3_profile || s3_iam_role_arn
         nil
       else
         raise MissingRequiredAttribute.new(self, :s3_access_key, "'ABCD1234'")
@@ -296,7 +296,7 @@ module Omnibus
     #
     # @return [String, nil]
     default(:s3_secret_key) do
-      if s3_profile
+      if s3_profile || s3_iam_role_arn
         nil
       else
         raise MissingRequiredAttribute.new(self, :s3_secret_key, "'EFGH5678'")
@@ -307,6 +307,11 @@ module Omnibus
     #
     # @return [String, nil]
     default(:s3_profile, nil)
+
+    # The AWS IAM role arn to use with S3 caching.
+    #
+    # @return [String, nil]
+    default(:s3_iam_role_arn, nil)
 
     # The region of the S3 bucket you want to cache software artifacts in.
     # Defaults to 'us-east-1'
@@ -454,6 +459,11 @@ module Omnibus
     #
     # @return [String, nil]
     default(:publish_s3_profile, nil)
+
+    # The AWS IAM role arn to use with S3 publisher.
+    #
+    # @return [String, nil]
+    default(:publish_s3_iam_role_arn, nil)
 
     # Directory pattern for the S3 publisher.
     # Interpolation of metadata keys is supported.

--- a/lib/omnibus/generator_files/omnibus.rb.erb
+++ b/lib/omnibus/generator_files/omnibus.rb.erb
@@ -31,10 +31,11 @@
 # Enable S3 asset caching
 # ------------------------------
 # use_s3_caching true
-# s3_access_key  ENV['AWS_ACCESS_KEY_ID']
-# s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
-# s3_profile     ENV['AWS_S3_PROFILE']
-# s3_bucket      ENV['AWS_S3_BUCKET']
+# s3_access_key    ENV['AWS_ACCESS_KEY_ID']
+# s3_secret_key    ENV['AWS_SECRET_ACCESS_KEY']
+# s3_profile       ENV['AWS_S3_PROFILE']
+# s3_iam_role_arn  ENV['S3_IAM_ROLE_ARN']
+# s3_bucket        ENV['AWS_S3_BUCKET']
 
 # Customize compiler bits
 # ------------------------------

--- a/lib/omnibus/publishers/s3_publisher.rb
+++ b/lib/omnibus/publishers/s3_publisher.rb
@@ -65,11 +65,13 @@ module Omnibus
         bucket_name: @options[:bucket],
       }
 
-      if Config.publish_s3_profile
-        config[:profile]            = Config.publish_s3_profile
+      if Config.publish_s3_iam_role_arn
+        config[:publish_s3_iam_role_arn] = Config.publish_s3_iam_role_arn
+      elsif Config.publish_s3_profile
+        config[:profile] = Config.publish_s3_profile
       else
-        config[:access_key_id]      = Config.publish_s3_access_key
-        config[:secret_access_key]  = Config.publish_s3_secret_key
+        config[:access_key_id] = Config.publish_s3_access_key
+        config[:secret_access_key] = Config.publish_s3_secret_key
       end
 
       config

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -147,7 +147,9 @@ module Omnibus
           force_path_style: Config.s3_force_path_style,
         }
 
-        if Config.s3_profile
+        if Config.s3_iam_role_arn
+          config[:iam_role_arn] = Config.s3_iam_role_arn
+        elsif Config.s3_profile
           config[:profile] = Config.s3_profile
         else
           config[:access_key_id] = Config.s3_access_key

--- a/spec/unit/s3_cacher_spec.rb
+++ b/spec/unit/s3_cacher_spec.rb
@@ -109,10 +109,12 @@ module Omnibus
       let (:s3_access_key) { nil }
       let (:s3_secret_key) { nil }
       let (:s3_profile) { nil }
+      let (:s3_iam_role_arn) { nil }
 
       before do
         Config.s3_bucket s3_bucket
         Config.s3_region s3_region
+        Config.s3_iam_role_arn s3_iam_role_arn
         Config.s3_profile s3_profile
         Config.s3_access_key s3_access_key
         Config.s3_secret_key s3_secret_key
@@ -144,6 +146,21 @@ module Omnibus
         it "sets s3_profile only" do
           config = S3Cache.send(:s3_configuration)
           expect(config[:profile]).to eq(s3_profile)
+          expect(config[:access_key_id]).to eq(nil)
+          expect(config[:secret_access_key]).to eq(nil)
+        end
+      end
+
+      context "s3_iam_role_arn is configured" do
+        let(:s3_iam_role_arn) { "S3_IAM_ROLE_ARN" }
+        let(:s3_profile) { "SHAREDPROFILE" }
+        let(:s3_access_key) { "ACCESS_KEY_ID" }
+        let(:s3_secret_key) { "SECRET_ACCESS_KEY" }
+
+        it "sets s3_iam_role_arn only" do
+          config = S3Cache.send(:s3_configuration)
+          expect(config[:iam_role_arn]).to eq(s3_iam_role_arn)
+          expect(config[:profile]).to eq(nil)
           expect(config[:access_key_id]).to eq(nil)
           expect(config[:secret_access_key]).to eq(nil)
         end

--- a/spec/unit/s3_helpers_spec.rb
+++ b/spec/unit/s3_helpers_spec.rb
@@ -40,6 +40,8 @@ module Omnibus
       let(:instance) { klass.new }
       let(:key_pair) { { access_key_id: "key_id", secret_access_key: "access_key" } }
       let(:profile) { "my-profile" }
+      let(:iam_role_arn) { "my-iam-role-arn" }
+      let(:role_session_name) { "omnibus-assume-role-s3-access" }
       let(:config) { { bucket_name: "foo", region: "us-east-1" } }
 
       it "uses configured key pairs" do
@@ -52,16 +54,33 @@ module Omnibus
         instance.send(:get_credentials)
       end
 
-      it "preferrs shared credentials profiles over key pairs" do
+      it "prefers shared credentials profiles over key pairs" do
+        allow_any_instance_of(klass).to receive(:s3_configuration).and_return(
+          {
+            **config,
+            **key_pair,
+            iam_role_arn: nil,
+            profile: profile,
+          }
+        )
+        expect(Aws::Credentials).to_not receive(:new)
+        expect(Aws::AssumeRoleCredentials).to_not receive(:new)
+        allow(Aws::SharedCredentials).to receive(:new).with(profile_name: profile)
+        instance.send(:get_credentials)
+      end
+
+      it "prefers AWS IAM role arn over profiles and key pairs" do
         allow_any_instance_of(klass).to receive(:s3_configuration).and_return(
           {
             **config,
             **key_pair,
             profile: profile,
+            iam_role_arn: iam_role_arn,
           }
         )
         expect(Aws::Credentials).to_not receive(:new)
-        allow(Aws::SharedCredentials).to receive(:new).with(profile_name: profile)
+        expect(Aws::SharedCredentials).to_not receive(:new)
+        allow(Aws::AssumeRoleCredentials).to receive(:new).with(role_arn: iam_role_arn, role_session_name: role_session_name)
         instance.send(:get_credentials)
       end
 


### PR DESCRIPTION
### Description

This adds the ability to authenticate to the S3 bucket using an AWS IAM role.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
