### PR TITLE
Enable entitlements file for macOS

### DIFF
--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -412,6 +412,7 @@ module Omnibus
     def sign_binary(bin, hardened_runtime = false)
       command = "codesign -s '#{signing_identity}' '#{bin}'"
       command << %q{ --options=runtime} if hardened_runtime
+      command << %Q{ --entitlements #{resource_path("entitlements.plist")}} if File.exist?(resource_path("entitlements.plist")) && hardened_runtime
       ## Force re-signing to deal with binaries that have the same sha.
       command << %q{ --force}
       command << %Q{\n}

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -518,25 +518,19 @@ module Omnibus
       end
 
       context "when not an executable" do
-        before do
+        it "returns false" do
           allow(File).to receive(:file?).with("file").and_return(true)
           allow(File).to receive(:executable?).with("file").and_return(false)
           allow(File).to receive(:symlink?).with("file").and_return(false)
-        end
-
-        it "returns false" do
           expect(subject.is_binary?("file")).to be false
         end
       end
 
       context "when is symlink" do
-        before do
+        it "returns false" do
           allow(File).to receive(:file?).with("file").and_return(true)
           allow(File).to receive(:executable?).with("file").and_return(true)
           allow(File).to receive(:symlink?).with("file").and_return(true)
-        end
-
-        it "returns false" do
           expect(subject.is_binary?("file")).to be false
         end
       end
@@ -612,6 +606,18 @@ module Omnibus
           expect(subject).to receive(:shellout!)
             .with("codesign -s '#{subject.signing_identity}' 'file' --options=runtime --force\n")
           subject.sign_binary("file", true)
+        end
+
+        context "with entitlements" do
+          let(:entitlements_file) { File.join(tmp_path, "project-full-name/resources/project-full-name/pkg/entitlements.plist") }
+
+          it "it signs the binary with the entitlements" do
+            allow(subject).to receive(:resource_path).with("entitlements.plist").and_return(entitlements_file)
+            allow(File).to receive(:exist?).with(entitlements_file).and_return(true)
+            expect(subject).to receive(:shellout!)
+              .with("codesign -s '#{subject.signing_identity}' 'file' --options=runtime --entitlements #{entitlements_file} --force\n")
+            subject.sign_binary("file", true)
+          end
         end
       end
     end


### PR DESCRIPTION
### Description

This change updates codesigning to look for entitlements.plist in the pkg
resource dir. If it is found the entitlements are applied during deep signing.

Signed-off-by: Jon Morrow <jmorrow@chef.io>

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
