### PR TITLE
point to 1-stable branch for changes to the overrides.rb file.

### DIFF
--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -439,7 +439,7 @@ module Omnibus
 
       if Config.fatal_transitive_dependency_licensing_warnings && !transitive_dependency_licensing_warnings.empty?
         warnings_to_raise << transitive_dependency_licensing_warnings
-        warnings_to_raise << "If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/master/lib/license_scout/overrides.rb#L93"
+        warnings_to_raise << "If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/1-stable/lib/license_scout/overrides.rb#L93"
       end
 
       warnings_to_raise.flatten!


### PR DESCRIPTION
After the refactor on license_scout, the overrides.rb file exists only on 1-stable branch. Omnibus currently points to the old version of license_scout which is the 1-stable branch. Changing the error message to avoid confusion.
