### PR TITLE
Ruby 2.7.1 adds a warning on calling open directly, needs to be URI.open

### DIFF
--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -77,7 +77,7 @@ module Omnibus
           end
         end
 
-        file = open(from_url, options)
+        file = URI.open(from_url, options)
         # This is a temporary file. Close and flush it before attempting to copy
         # it over.
         file.close

--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -77,7 +77,11 @@ module Omnibus
           end
         end
 
-        file = URI.open(from_url, options)
+        if RUBY_VERSION.to_f < 2.7
+          file = open(from_url, options)
+        else
+          file = URI.open(from_url, options)
+        end
         # This is a temporary file. Close and flush it before attempting to copy
         # it over.
         file.close


### PR DESCRIPTION
Fixes https://github.com/chef/omnibus/issues/923
https://github.com/ruby/ruby/commit/3816cd945d68eac7ca8fecbc9d71f878ff3e7b3d#diff-0f19cb99597e5fb90bfb937b22143b51

