### PR TITLE
Pin ffi to < 0.13 for windows

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk-s3",       "~> 1"
   gem.add_dependency "chef-sugar",       ">= 3.3"
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
+  gem.add_dependency "ffi",              "< 1.13" # 1.13 does not work on Windows: https://github.com/ffi/ffi/issues/784
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
   gem.add_dependency "ohai",             ">= 13", "< 17"


### PR DESCRIPTION
ffi 0.13 crashes Ruby on windows - see https://github.com/ffi/ffi/issues/784

Example of the crash for InSpec:
https://buildkite.com/chef/inspec-inspec-master-omnibus-release/builds/265#a71f492b-abe1-4b53-8f3a-15fd1cac69a8/94-168

https://github.com/inspec/inspec/pull/5065 demonstrates the ffi pin getting the Windows build working again, but I think the pin should be here in omnibus rather than in individual projects.

Signed-off-by: James Stocks <jstocks@chef.io>