### PR TITLE
Replace ruby 2.4 test with ruby 2.7 in verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,27 +11,23 @@ expeditor:
           limit: 1
 
 steps:
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
 - label: run-lint-and-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
+  command: .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
         image: ruby:2.5-buster
 
 - label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-
+  command: .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
         image: ruby:2.6-buster
+
+- label: run-lint-and-specs-ruby-2.7
+  command: .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster


### PR DESCRIPTION
### Description

Replace ruby 2.4 test with ruby 2.7 in verify pipeline
Ruby 2.4 reached EOL March 31, 2020

reference: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/