### PR TITLE
Revert "Pin ffi to < 0.13 for windows" now that 1.13.1 is out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@ end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5")
   gem "ohai", "<15"
+  gem "activesupport", "~> 5.0"
 end

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "aws-sdk-s3",       "~> 1"
   gem.add_dependency "chef-sugar",       ">= 3.3"
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
-  gem.add_dependency "ffi",              "< 1.13" # 1.13 does not work on Windows: https://github.com/ffi/ffi/issues/784
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
   gem.add_dependency "ohai",             ">= 13", "< 17"


### PR DESCRIPTION
This reverts commit 2e7b7b3fb8b2c8bdb9af7c10cc91ae625c31b41c.

1.13.1 reverts the change that broke Windows.