### PR TITLE
Optimize our requires

### DIFF
--- a/lib/omnibus.rb
+++ b/lib/omnibus.rb
@@ -17,7 +17,7 @@
 require "omnibus/core_extensions"
 
 require "cleanroom"
-require "pathname"
+require "pathname" unless defined?(Pathname)
 
 require "omnibus/digestable"
 require "omnibus/exceptions"

--- a/lib/omnibus/build_version.rb
+++ b/lib/omnibus/build_version.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Omnibus
   # Provides methods for generating Omnibus project build version

--- a/lib/omnibus/build_version_dsl.rb
+++ b/lib/omnibus/build_version_dsl.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "time"
+require "time" unless defined?(Time.zone_offset)
 
 module Omnibus
   class BuildVersionDSL

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-require "fileutils"
-require "mixlib/shellout"
-require "ostruct"
-require "pathname"
+require "fileutils" unless defined?(FileUtils)
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "ostruct" unless defined?(OpenStruct)
+require "pathname" unless defined?(Pathname)
 require "omnibus/whitelist"
 
 module Omnibus

--- a/lib/omnibus/cleaner.rb
+++ b/lib/omnibus/cleaner.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "thor"
+require "thor" unless defined?(Thor)
 
 module Omnibus
   class Cleaner < Thor::Group

--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-require "thor"
+require "thor" unless defined?(Thor)
 require "omnibus"
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module Omnibus
   class CLI < Command::Base

--- a/lib/omnibus/cli/changelog.rb
+++ b/lib/omnibus/cli/changelog.rb
@@ -18,7 +18,7 @@ require "omnibus/changelog"
 require "omnibus/changelog_printer"
 require "omnibus/manifest_diff"
 require "omnibus/semantic_version"
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module Omnibus
   class Command::ChangeLog < Command::Base

--- a/lib/omnibus/compressors/base.rb
+++ b/lib/omnibus/compressors/base.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   class Compressor::Base < Packager::Base

--- a/lib/omnibus/compressors/tgz.rb
+++ b/lib/omnibus/compressors/tgz.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "rubygems/package"
-require "zlib"
+require "rubygems/package" unless defined?(Gem::Package)
+require "zlib" unless defined?(Zlib)
 
 module Omnibus
   class Compressor::TGZ < Compressor::Base

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "singleton"
+require "singleton" unless defined?(Singleton)
 
 module Omnibus
   class Config

--- a/lib/omnibus/core_extensions/open_uri.rb
+++ b/lib/omnibus/core_extensions/open_uri.rb
@@ -1,4 +1,4 @@
-require "open-uri"
+require "open-uri" unless defined?(OpenURI)
 
 module OpenURI
   class << self

--- a/lib/omnibus/digestable.rb
+++ b/lib/omnibus/digestable.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "openssl"
-require "pathname"
+require "openssl" unless defined?(OpenSSL)
+require "pathname" unless defined?(Pathname)
 require "omnibus/logging"
 
 module Omnibus

--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "open-uri"
+require "open-uri" unless defined?(OpenURI)
 require "ruby-progressbar"
 
 module Omnibus

--- a/lib/omnibus/fetchers/file_fetcher.rb
+++ b/lib/omnibus/fetchers/file_fetcher.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   class FileFetcher < Fetcher

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "omnibus/download_helpers"
 
 module Omnibus

--- a/lib/omnibus/fetchers/path_fetcher.rb
+++ b/lib/omnibus/fetchers/path_fetcher.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   class PathFetcher < Fetcher

--- a/lib/omnibus/file_syncer.rb
+++ b/lib/omnibus/file_syncer.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   module FileSyncer

--- a/lib/omnibus/generator.rb
+++ b/lib/omnibus/generator.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "thor"
+require "thor" unless defined?(Thor)
 
 module Omnibus
   class Generator < Thor::Group

--- a/lib/omnibus/git_cache.rb
+++ b/lib/omnibus/git_cache.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "digest"
-require "fileutils"
+require "digest" unless defined?(Digest)
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   class GitCache

--- a/lib/omnibus/licensing.rb
+++ b/lib/omnibus/licensing.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "fileutils"
+require "uri" unless defined?(URI)
+require "fileutils" unless defined?(FileUtils)
 require "omnibus/download_helpers"
 require "license_scout/collector"
 require "license_scout/reporter"

--- a/lib/omnibus/logger.rb
+++ b/lib/omnibus/logger.rb
@@ -17,7 +17,7 @@
 module Omnibus
   class Logger
 
-    require "time"
+    require "time" unless defined?(Time.zone_offset)
 
     #
     # The amount of padding on the left column.

--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module Omnibus
   class Manifest

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module Omnibus
   class Metadata

--- a/lib/omnibus/ohai.rb
+++ b/lib/omnibus/ohai.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "ohai"
+require "ohai" unless defined?(Ohai::System)
 
 module Omnibus
   class Ohai

--- a/lib/omnibus/package.rb
+++ b/lib/omnibus/package.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module Omnibus
   class Package

--- a/lib/omnibus/packagers/base.rb
+++ b/lib/omnibus/packagers/base.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module Omnibus
   class Packager::Base

--- a/lib/omnibus/packagers/msi.rb
+++ b/lib/omnibus/packagers/msi.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "pathname"
+require "pathname" unless defined?(Pathname)
 require "omnibus/packagers/windows_base"
 
 module Omnibus

--- a/lib/omnibus/packagers/solaris.rb
+++ b/lib/omnibus/packagers/solaris.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "socket"
+require "socket" unless defined?(Socket)
 
 module Omnibus
   class Packager::Solaris < Packager::Base

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-require "time"
-require "ffi_yajl"
+require "time" unless defined?(Time.zone_offset)
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require "omnibus/manifest"
 require "omnibus/manifest_entry"
 require "omnibus/reports"

--- a/lib/omnibus/publishers/artifactory_publisher.rb
+++ b/lib/omnibus/publishers/artifactory_publisher.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "uri"
-require "benchmark"
+require "uri" unless defined?(URI)
+require "benchmark" unless defined?(Benchmark)
 
 module Omnibus
   class ArtifactoryPublisher < Publisher

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 require "omnibus/s3_helpers"
 
 module Omnibus

--- a/lib/omnibus/s3_helpers.rb
+++ b/lib/omnibus/s3_helpers.rb
@@ -17,7 +17,7 @@
 require "aws-sdk-s3"
 require "aws-sdk-core/credentials"
 require "aws-sdk-core/shared_credentials"
-require "base64"
+require "base64" unless defined?(Base64)
 
 module Omnibus
   module S3Helpers

--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-require "fileutils"
-require "uri"
+require "fileutils" unless defined?(FileUtils)
+require "uri" unless defined?(URI)
 require "omnibus/manifest_entry"
 
 module Omnibus

--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require "erb"
+require "erb" unless defined?(Erb)
 
 module Omnibus
   module Templating

--- a/lib/omnibus/util.rb
+++ b/lib/omnibus/util.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module Omnibus
   module Util


### PR DESCRIPTION
Rubygems is very slow traversing the filesystem even when a require has already been done. Gate things to avoid that.

Signed-off-by: Tim Smith <tsmith@chef.io>