### PR TITLE
Require Ruby 2.6 or later

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,6 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 ---
+
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
   notify_channel:

--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -5,49 +5,12 @@
 set -ue
 
 export USER="root"
-
-echo "--- dependencies"
 export LANG=C.UTF-8 LANGUAGE=C.UTF-8
-S3_URL="s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}"
-
-pull_s3_file() {
-    aws s3 cp "${S3_URL}/$1" "$1" || echo "Could not pull $1 from S3"
-}
-
-push_s3_file() {
-    if [ -f "$1" ]; then
-        aws s3 cp "$1" "${S3_URL}/$1" || echo "Could not push $1 to S3 for caching."
-    fi
-}
-
-apt-get update -y
-apt-get install awscli -y
 
 echo "--- bundle install"
-pull_s3_file "bundle.tar.gz"
-pull_s3_file "bundle.sha256"
-
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
-
-if [ -n "${RESET_BUNDLE_CACHE:-}" ]; then
-    rm bundle.sha256
-fi
 
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
-
-echo "--- bundle cache"
-if test -f bundle.sha256 && shasum --check bundle.sha256 --status; then
-    echo "Bundled gems have not changed. Skipping upload to s3"
-else
-    echo "Bundled gems have changed. Uploading to s3"
-    shasum -a 256 Gemfile.lock > bundle.sha256
-    tar -czf bundle.tar.gz vendor/
-    push_s3_file bundle.tar.gz
-    push_s3_file bundle.sha256
-fi
 
 echo "+++ bundle exec task"
 bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,32 +1,15 @@
 ---
 expeditor:
+  cached_folders:
+    - vendor
   defaults:
     buildkite:
       retry:
         automatic:
           limit: 1
       timeout_in_minutes: 30
-      retry:
-        automatic:
-          limit: 1
 
 steps:
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
-- label: run-lint-and-specs-ruby-2.5
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-buster
-
 - label: run-lint-and-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.6
+
 # all of these could/should be corrected. Have at it if you want.
 
 Layout/ClosingHeredocIndentation:

--- a/lib/omnibus/build_version_dsl.rb
+++ b/lib/omnibus/build_version_dsl.rb
@@ -136,12 +136,10 @@ module Omnibus
       return false if build_info.nil?
 
       build_info.split(".").any? do |part|
-        begin
-          Time.strptime(part, Omnibus::BuildVersion::TIMESTAMP_FORMAT)
-          true
-        rescue ArgumentError
-          false
-        end
+        Time.strptime(part, Omnibus::BuildVersion::TIMESTAMP_FORMAT)
+        true
+      rescue ArgumentError
+        false
       end
     end
 

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.description    = gem.summary
   gem.homepage       = "https://github.com/chef/omnibus"
 
-  gem.required_ruby_version = ">= 2.4"
+  gem.required_ruby_version = ">= 2.6"
 
   gem.files = %w{ LICENSE README.md Rakefile Gemfile } + Dir.glob("*.gemspec") + Dir.glob("{bin,lib,resources,spec}/**/{*,.kitchen*}")
   gem.bindir = "bin"
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
-  gem.add_dependency "ohai",             ">= 13", "< 17"
+  gem.add_dependency "ohai",             ">= 15"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"


### PR DESCRIPTION
Our policy in general has been N-1 on Ruby releases when there is a
conflict that prevents us from supporting older releases. Ohai pulls in
chef-config, which requires Ruby 2.6+ now.

Signed-off-by: Tim Smith <tsmith@chef.io>