### PR TITLE
Fix dependency path for env with racc gem

### DIFF
--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -2,3 +2,4 @@
 <transform file depend -> edit pkg.debug.depend.file ruby env>
 <transform file depend -> edit pkg.debug.depend.file make env>
 <transform file depend -> edit pkg.debug.depend.file perl env>
+<transform file depend -> edit pkg.debug.depend.path usr/local/bin usr/bin>

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -155,6 +155,7 @@ module Omnibus
         expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file ruby env>")
         expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file make env>")
         expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.file perl env>")
+        expect(transform_file_contents).to include("<transform file depend -> edit pkg.debug.depend.path usr/local/bin usr/bin>")
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Jaymala Sinha <jsinha@chef.io>

### Description

The racc gem dependency on env searches for the binary in /usr/local/bin.  Since all our current dependencies live in /usr/bin forcing the override here for packaging chef-16

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
