### PR TITLE
Remove EOL Windows Support (pre-2012)

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -72,19 +72,10 @@ module Omnibus
         family = "solaris"
       end
       if klass = PLATFORM_PACKAGER_MAP[family]
-        package_types = klass.is_a?(Array) ? klass : [ klass ]
-
-        if package_types.include?(APPX) &&
-            !ChefUtils::VersionString.new(version).satisfies?(">= 6.2")
-          log.warn(log_key) { "APPX generation is only supported on Windows versions 2012 and above" }
-          package_types -= [APPX]
-        end
-
-        package_types
+        klass.is_a?(Array) ? klass : [ klass ]
       else
         log.warn(log_key) do
-          "Could not determine packager for `#{family}', defaulting " \
-          "to `makeself'!"
+          "Could not determine packager for `#{family}`, defaulting to `makeself`!"
         end
         [Makeself]
       end

--- a/resources/msi/source.wxs.erb
+++ b/resources/msi/source.wxs.erb
@@ -21,19 +21,11 @@
     <Media Id="1" Cabinet="Project.cab" EmbedCab="yes" CompressionLevel="high" />
 
     <!--
-      Take advantage of Windows Installer 5.0 feature (if available) to disable 
-      checkpointing and other costings that take significant amounts of time 
+      Take advantage of Windows Installer 5.0 feature (if available) to disable
+      checkpointing and other costings that take significant amounts of time
       ref: https://msdn.microsoft.com/en-us/library/windows/desktop/dd408005(v=vs.85).aspx
     -->
     <Property Id="MSIFASTINSTALL" Value="7" />
-
-    <!--
-      Uncomment launch condition below to check for minimum OS
-      601 = Windows 7/Server 2008R2.
-    -->
-    <!-- Condition Message="!(loc.MinimumOSVersionMessage)">
-      <![CDATA[Installed OR VersionNT >= 601]]>
-    </Condition -->
 
     <!-- We always do Major upgrades -->
     <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" />

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -10,17 +10,10 @@ module Omnibus
         end
       end
 
-      context "on Windows 2012 R2" do
+      context "on Windows" do
         before { stub_ohai(platform: "windows", version: "2012R2") }
         it "prefers MSI and APPX" do
           expect(described_class.for_current_system).to eq([Packager::MSI, Packager::APPX])
-        end
-      end
-
-      context "on Windows 2008 R2" do
-        before { stub_ohai(platform: "windows", version: "2008R2") }
-        it "prefers MSI only" do
-          expect(described_class.for_current_system).to eq([Packager::MSI])
         end
       end
 


### PR DESCRIPTION
We have some code checks in place that just don't need to run at this
point. 2008 R2 is EOL and it's not going to be built on at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>