### PR TITLE
Avoid double logging removal of non-mach-o libs

### DIFF
--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -431,23 +431,21 @@ module Omnibus
     end
 
     def is_binary?(bin)
-      is_binary = File.file?(bin) &&
-        File.executable?(bin) &&
-        !File.symlink?(bin)
-      log.debug(log_key) { "    removing non-binary file from signing: #{bin}" } unless is_binary
-      is_binary
+      return false unless File.file?(bin) && File.executable?(bin) && !File.symlink?(bin)
+
+      log.debug(log_key) { "    skipping non-binary file from signing: #{bin}" }
+      true
     end
 
     def is_macho?(lib)
-      is_macho = false
-      if is_binary?(lib)
-        command = "file #{lib}"
+      return false unless File.file?(bin) && File.executable?(bin) && !File.symlink?(bin)
 
-        stdout = shellout!(command).stdout
-        is_macho = stdout.match?(/Mach-O.*(library|bundle)/)
+      if shellout!("file #{lib}").stdout.match?(/Mach-O.*(library|bundle)/) # https://rubular.com/r/nRgaQlAbkM9wHL
+        log.debug(log_key) { "    skipping non-Mach-O library file from signing: #{lib}" }
+        return true
       end
-      log.debug(log_key) { "    removing non-Mach-O library file from signing: #{lib}" } unless is_macho
-      is_macho
+
+      false
     end
   end
 end


### PR DESCRIPTION
is_macho? would call is_binary?, which resulted in double logging. Just
duplicate the 1 line of logic and avoid double logging in the builds.
This will nuke hundreds of lines of log output on macs. I also changed
up these methods to returns instead of carrying around a boolean. It
feels more "ruby-like" now. Maybe that's just my personal preference for
flow control though.

Signed-off-by: Tim Smith <tsmith@chef.io>