### PR TITLE
Create sleep loop in compress_dmg

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -259,8 +259,11 @@ module Omnibus
           sync
           hdiutil unmount "#{@device}"
           # Give some time to the system so unmount dmg
-          sleep 5
-          hdiutil detach "#{@device}" &&  \
+          ATTEMPTS=0
+          until [ $ATTEMPTS -eq 5 ] || hdiutil detach "#{@device}"; do
+            sleep 10
+            echo Attempt number $(( ATTEMPTS++ ))
+          done
           hdiutil convert \\
             "#{writable_dmg}" \\
             -format UDZO \\

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -219,8 +219,11 @@ module Omnibus
             sync
             hdiutil unmount "#{device}"
             # Give some time to the system so unmount dmg
-            sleep 5
-            hdiutil detach "#{device}" &&\
+            ATTEMPTS=0
+            until [ $ATTEMPTS -eq 5 ] || hdiutil detach "/dev/sda1"; do
+              sleep 10
+              echo Attempt number $(( ATTEMPTS++ ))
+            done
             hdiutil convert \\
               "#{staging_dir}/project-writable.dmg" \\
               -format UDZO \\


### PR DESCRIPTION
This helps avoid failure when hdiutil is not able to successfully detach the disk.