### PR TITLE
Update dmg unmount logging to start at attempt 1

### DIFF
--- a/lib/omnibus/compressors/dmg.rb
+++ b/lib/omnibus/compressors/dmg.rb
@@ -259,8 +259,8 @@ module Omnibus
           sync
           hdiutil unmount "#{@device}"
           # Give some time to the system so unmount dmg
-          ATTEMPTS=0
-          until [ $ATTEMPTS -eq 5 ] || hdiutil detach "#{@device}"; do
+          ATTEMPTS=1
+          until [ $ATTEMPTS -eq 6 ] || hdiutil detach "#{@device}"; do
             sleep 10
             echo Attempt number $(( ATTEMPTS++ ))
           done

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -219,8 +219,8 @@ module Omnibus
             sync
             hdiutil unmount "#{device}"
             # Give some time to the system so unmount dmg
-            ATTEMPTS=0
-            until [ $ATTEMPTS -eq 5 ] || hdiutil detach "/dev/sda1"; do
+            ATTEMPTS=1
+            until [ $ATTEMPTS -eq 6 ] || hdiutil detach "/dev/sda1"; do
               sleep 10
               echo Attempt number $(( ATTEMPTS++ ))
             done


### PR DESCRIPTION
The logic works great as-is, but since it starts at 0 the first attempt
logged is attempt 0.

Signed-off-by: Tim Smith <tsmith@chef.io>