### PR TITLE
Add cumulus platform support

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -170,7 +170,7 @@ module Omnibus
       # rubocop:disable Lint/DuplicateCaseCondition
       def truncate_platform_version(platform_version, platform)
         case platform
-        when "centos", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos"
+        when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos"
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split(".").first
         when "aix", "alpine", "mac_os_x", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"


### PR DESCRIPTION
Signed-off-by: Graham Weldon <graham@grahamweldon.com>

### Description

Allows omnibus to parse version information from Cumulus Linux.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
