### PR TITLE
Add support for macOS 11 and multiple architectures

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -173,9 +173,13 @@ module Omnibus
         when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos"
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split(".").first
-        when "aix", "alpine", "mac_os_x", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"
-          # Only want MAJOR.MINOR (e.g. Mac OS X 10.9, Ubuntu 12.04)
+        when "aix", "alpine", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"
+          # Only want MAJOR.MINOR (e.g. Ubuntu 12.04)
           platform_version.split(".")[0..1].join(".")
+        when "mac_os_x", "darwin", "macos"
+          # If running macOS >= 11, use only MAJOR version. Otherwise, use MAJOR.MINOR
+          pv_bits = platform_version.split(".")
+          pv_bits[0].to_i >= 11 ? pv_bits[0] : pv_bits[0..1].join(".")
         when "arch", "gentoo", "kali"
           # Arch Linux / Gentoo do not have a platform_version ohai attribute, they are rolling release (lsb_release -r)
           "rolling"

--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -125,7 +125,7 @@ module Omnibus
 
     # @see Base#package_name
     def package_name
-      "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.pkg"
+      "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.pkg"
     end
 
     #
@@ -318,6 +318,15 @@ module Omnibus
     #
     def component_pkg
       "#{safe_base_package_name}-core.pkg"
+    end
+
+    #
+    # Return the architecture
+    #
+    # @return [String]
+    #
+    def safe_architecture
+      @safe_architecture ||= Ohai["kernel"]["machine"]
     end
 
     #

--- a/spec/unit/compressors/dmg_spec.rb
+++ b/spec/unit/compressors/dmg_spec.rb
@@ -190,7 +190,7 @@ module Omnibus
 
         expect(contents).to include('set found_disk to do shell script "ls /Volumes/ | grep \'Project One*\'"')
         expect(contents).to include("	set the bounds of Finder window 1 to {100, 100, 750, 600}")
-        expect(contents).to include('  	set position of item "project-1.2.3-2.pkg" of container window to {535, 50}')
+        expect(contents).to include('  	set position of item "project-1.2.3-2.x86_64.pkg" of container window to {535, 50}')
       end
 
       it "runs the apple script" do
@@ -229,7 +229,7 @@ module Omnibus
               -format UDZO \\
               -imagekey \\
               zlib-level=9 \\
-              -o "#{package_dir}/project-1.2.3-2.dmg" \\
+              -o "#{package_dir}/project-1.2.3-2.x86_64.dmg" \\
               -puppetstrings
           EOH
 
@@ -247,7 +247,7 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with <<-EOH.gsub(/^ {12}/, "")
             hdiutil verify \\
-              "#{package_dir}/project-1.2.3-2.dmg" \\
+              "#{package_dir}/project-1.2.3-2.x86_64.dmg" \\
               -puppetstrings
           EOH
 
@@ -289,10 +289,10 @@ module Omnibus
             DeRez -only icns "#{icon}" > tmp.rsrc
 
             # Append the icon reosurce to the DMG
-            Rez -append tmp.rsrc -o "#{package_dir}/project-1.2.3-2.dmg"
+            Rez -append tmp.rsrc -o "#{package_dir}/project-1.2.3-2.x86_64.dmg"
 
             # Source the icon
-            SetFile -a C "#{package_dir}/project-1.2.3-2.dmg"
+            SetFile -a C "#{package_dir}/project-1.2.3-2.x86_64.dmg"
           EOH
 
         subject.set_dmg_icon
@@ -301,11 +301,11 @@ module Omnibus
 
     describe "#package_name" do
       it "reflects the packager's unmodified package_name" do
-        expect(subject.package_name).to eq("project-1.2.3-2.dmg")
+        expect(subject.package_name).to eq("project-1.2.3-2.x86_64.dmg")
       end
 
       it "reflects the packager's modified package_name" do
-        package_basename = "projectsub-1.2.3-3"
+        package_basename = "projectsub-1.2.3-3.x86_64"
         allow(project.packagers_for_system[0]).to receive(:package_name)
           .and_return("#{package_basename}.pkg")
 

--- a/spec/unit/compressors/tgz_spec.rb
+++ b/spec/unit/compressors/tgz_spec.rb
@@ -38,25 +38,25 @@ module Omnibus
 
     describe "#package_name" do
       it "returns the name of the packager" do
-        expect(subject.package_name).to eq("project-1.2.3-2.pkg.tar.gz")
+        expect(subject.package_name).to eq("project-1.2.3-2.x86_64.pkg.tar.gz")
       end
     end
 
     describe "#write_tgz" do
       before do
-        File.open("#{staging_dir}/project-1.2.3-2.pkg", "wb") do |f|
+        File.open("#{staging_dir}/project-1.2.3-2.x86_64.pkg", "wb") do |f|
           f.write " " * 1_000_000
         end
       end
 
       it "generates the file" do
         subject.write_tgz
-        expect("#{staging_dir}/project-1.2.3-2.pkg.tar.gz").to be_a_file
+        expect("#{staging_dir}/project-1.2.3-2.x86_64.pkg.tar.gz").to be_a_file
       end
 
       it "has the correct content" do
         subject.write_tgz
-        file = File.open("#{staging_dir}/project-1.2.3-2.pkg.tar.gz", "rb")
+        file = File.open("#{staging_dir}/project-1.2.3-2.x86_64.pkg.tar.gz", "rb")
         contents = file.read
         file.close
 

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -218,6 +218,8 @@ module Omnibus
       it_behaves_like "a version manipulator", "gentoo", "4.9.95-gentoo", "rolling"
       it_behaves_like "a version manipulator", "kali", "rolling", "rolling"
       it_behaves_like "a version manipulator", "mac_os_x", "10.9.1", "10.9"
+      it_behaves_like "a version manipulator", "mac_os_x", "10.15.7", "10.15"
+      it_behaves_like "a version manipulator", "mac_os_x", "11.2.1", "11"
       it_behaves_like "a version manipulator", "omnios", "r151010", "r151010"
       it_behaves_like "a version manipulator", "openbsd", "5.4.4", "5.4"
       it_behaves_like "a version manipulator", "opensuseleap", "42.3", "42.3"

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -47,8 +47,8 @@ module Omnibus
     end
 
     describe "#package_name" do
-      it "includes the name, version, and build iteration" do
-        expect(subject.package_name).to eq("project-full-name-1.2.3-2.pkg")
+      it "includes the name, version, build iteration, and architecture" do
+        expect(subject.package_name).to eq("project-full-name-1.2.3-2.x86_64.pkg")
       end
     end
 
@@ -301,7 +301,7 @@ module Omnibus
             productbuild \\
               --distribution "#{staging_dir}/Distribution" \\
               --resources "#{staging_dir}/Resources" \\
-              "#{package_dir}/project-full-name-1.2.3-2.pkg"
+              "#{package_dir}/project-full-name-1.2.3-2.x86_64.pkg"
           EOH
 
           subject.build_product_pkg
@@ -319,7 +319,7 @@ module Omnibus
               --distribution "#{staging_dir}/Distribution" \\
               --resources "#{staging_dir}/Resources" \\
               --sign "My Special Identity" \\
-              "#{package_dir}/project-full-name-1.2.3-2.pkg"
+              "#{package_dir}/project-full-name-1.2.3-2.x86_64.pkg"
           EOH
           subject.build_product_pkg
         end


### PR DESCRIPTION
### Description

Make the necessary modifications to be able to build Omnibus packages on macOS Big Sur on Apple's M1 hardware. 

* Properly detect the platform version for macOS 11 and beyond. 
* Add the architecture (e.g., x86_64, arm64) to the file name 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
