### PR TITLE
Prevent test failures with the latest fauxhai

### DIFF
--- a/spec/unit/compressor_spec.rb
+++ b/spec/unit/compressor_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Omnibus
   describe Compressor do
     describe ".for_current_system" do
-      context "on Mac OS X" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.15") }
+      context "on macOS" do
+        before { stub_ohai(platform: "mac_os_x") }
 
         context "when :dmg is activated" do
           it "prefers dmg" do

--- a/spec/unit/packager_spec.rb
+++ b/spec/unit/packager_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 module Omnibus
   describe Packager do
     describe ".for_current_system" do
-      context "on Mac OS X" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.15") }
+      context "on macOS" do
+        before { stub_ohai(platform: "mac_os_x") }
         it "prefers PKG" do
           expect(described_class.for_current_system).to eq([Packager::PKG])
         end

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -235,8 +235,8 @@ module Omnibus
         end
       end
 
-      context "when on OS X" do
-        let(:fauxhai_options) { { platform: "mac_os_x", version: "10.15" } }
+      context "when on macOS" do
+        let(:fauxhai_options) { { platform: "mac_os_x" } }
         it "returns a generic iteration" do
           expect(subject.build_iteration).to eq(1)
         end

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -190,8 +190,8 @@ module Omnibus
         end
       end
 
-      context "on mac_os_x" do
-        before { stub_ohai(platform: "mac_os_x", version: "10.13") }
+      context "on macOS" do
+        before { stub_ohai(platform: "mac_os_x") }
 
         it "sets the defaults" do
           expect(subject.with_standard_compiler_flags).to eq(


### PR DESCRIPTION
mac_os_x 10.13 data is no longer in Fauxhai. We shouldn't specify the version at all. Let fauxhai just use the latest

Signed-off-by: Tim Smith <tsmith@chef.io>