### PR TITLE
Pin to Ohai gem < 17

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
-  gem.add_dependency "ohai",             ">= 15"
+  gem.add_dependency "ohai",             ">= 15", "< 17"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"


### PR DESCRIPTION
Ohai 17 requires Ruby 2.7+ but we currently ship Ruby 2.6 inside of
Omnibus Toolchain. This pinning of Ohai should be viewed as a temporary
fix until we can ship a new version of Omnibus Toolchain which contains
Ruby 2.7+.

Signed-off-by: Seth Chisamore <schisamo@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
