### PR TITLE
Updating aruba version from 0.5 to 1.1

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,6 @@
 require "aruba"
 require "aruba/cucumber"
-require "aruba/in_process"
+require "aruba/processes/in_process"
 
 require "omnibus/cli"
 

--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -373,10 +373,15 @@ module Omnibus
     # @param (see #command)
     # @return (see #command)
     #
-    def appbundle(software_name, lockdir: nil, gem: nil, without: nil, extra_bin_files: nil , **options)
+    def appbundle(software_name, options = {})
       build_commands << BuildCommand.new("appbundle `#{software_name}'") do
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin("appbundler")
+
+        lockdir = options[:lockdir]
+        gem = options[:gem]
+        without = options[:without]
+        extra_bin_files = options[:extra_bin_files]
 
         lockdir ||=
           begin
@@ -535,7 +540,7 @@ module Omnibus
     def mkdir(directory, options = {})
       build_commands << BuildCommand.new("mkdir `#{directory}'") do
         Dir.chdir(software.project_dir) do
-          FileUtils.mkdir_p(directory, options)
+          FileUtils.mkdir_p(directory, **options)
         end
       end
     end
@@ -557,7 +562,7 @@ module Omnibus
           parent = File.dirname(file)
           FileUtils.mkdir_p(parent) unless File.directory?(parent)
 
-          FileUtils.touch(file, options)
+          FileUtils.touch(file, **options)
         end
       end
     end
@@ -578,7 +583,7 @@ module Omnibus
       build_commands << BuildCommand.new("delete `#{path}'") do
         Dir.chdir(software.project_dir) do
           FileSyncer.glob(path).each do |file|
-            FileUtils.rm_rf(file, options)
+            FileUtils.rm_rf(file, **options)
           end
         end
       end
@@ -629,7 +634,7 @@ module Omnibus
             log.warn(log_key) { "no matched files for glob #{command}" }
           else
             files.each do |file|
-              FileUtils.cp_r(file, destination, options)
+              FileUtils.cp_r(file, destination, **options)
             end
           end
         end
@@ -658,7 +663,7 @@ module Omnibus
             log.warn(log_key) { "no matched files for glob #{command}" }
           else
             files.each do |file|
-              FileUtils.mv(file, destination, options)
+              FileUtils.mv(file, destination, **options)
             end
           end
         end
@@ -690,7 +695,7 @@ module Omnibus
               log.warn(log_key) { "no matched files for glob #{command}" }
             else
               files.each do |file|
-                FileUtils.ln_s(file, destination, options)
+                FileUtils.ln_s(file, destination, **options)
               end
             end
           end

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -29,12 +29,13 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"
+  gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
 
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "pedump"
 
   gem.add_development_dependency "artifactory", "~> 3.0"
-  gem.add_development_dependency "aruba",       "~> 0.5"
+  gem.add_development_dependency "aruba",       "~> 1.1"
   gem.add_development_dependency "chefstyle",   "= 1.7.5"
   gem.add_development_dependency "fauxhai-ng",  ">= 7.5"
   gem.add_development_dependency "rspec",       "~> 3.0"

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -127,17 +127,8 @@ module Omnibus
         end
       end
 
-      context "when the source has read-only files" do
-        let(:source_url) { "http://dl.bintray.com/oneclick/OpenKnapsack/x86/openssl-1.0.0q-x86-windows.tar.lzma" }
-        let(:source_md5) { "577dbe528415c6f178a9431fd0554df4" }
-
-        it "extracts the asset without crashing" do
-          subject.clean
-          expect(extracted).to_not be_a_file
-          subject.clean
-          expect(extracted).to_not be_a_file
-        end
-      end
+      # we need to find a new test fixture because this one no longer exists
+      # context "when the source has read-only files"
 
       context "when the source has broken symlinks" do
         let(:source_url) { "http://www.openssl.org/source/openssl-1.0.1q.tar.gz" }
@@ -255,7 +246,7 @@ module Omnibus
 
       context "when the file is less than 10240 bytes" do
         let(:source_url) { "https://downloads.chef.io/packages-chef-io-public.key" }
-        let(:source_md5) { "369efc3a19b9118cdf51c7e87a34f266" }
+        let(:source_md5) { "012a2c4e2a8edb86b2c072f02eea9f40" }
 
         it "downloads the file" do
           fetch!


### PR DESCRIPTION
Signed-off-by: Swati Keshari <skeshari@msystechnologies.com>

### Description

Updating aruba version from 0.5 to 1.1

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
