### PR TITLE
Whitelist  SystemConfiguration libs

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -161,8 +161,8 @@ MAC_WHITELIST_LIBS = [
   /libc\+\+\.1\.dylib/,
   /libc\+\+\.1\.dylib/,
   /libzstd\.1\.dylib/,
-  /libcurl\.4\.dylib/,
   /Security/,
+  /SystemConfiguration/,
 ].freeze
 
 FREEBSD_WHITELIST_LIBS = [

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -161,6 +161,7 @@ MAC_WHITELIST_LIBS = [
   /libc\+\+\.1\.dylib/,
   /libc\+\+\.1\.dylib/,
   /libzstd\.1\.dylib/,
+  /libcurl\.4\.dylib/,
   /Security/,
 ].freeze
 


### PR DESCRIPTION
### Description

This will fix issue on mac_os :
```
The precise failures were:
--> /opt/chef-workstation//embedded/lib/libcurl.4.dylib
DEPENDS ON: SystemConfiguration
COUNT: 1
PROVIDED BY: /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration
FAILED BECAUSE: Unsafe dependency
```


--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
