### PR TITLE
Revert "argument changes to support ruby 3", again

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -373,15 +373,10 @@ module Omnibus
     # @param (see #command)
     # @return (see #command)
     #
-    def appbundle(software_name, options = {})
+    def appbundle(software_name, lockdir: nil, gem: nil, without: nil, extra_bin_files: nil , **options)
       build_commands << BuildCommand.new("appbundle `#{software_name}'") do
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin("appbundler")
-
-        lockdir = options[:lockdir]
-        gem = options[:gem]
-        without = options[:without]
-        extra_bin_files = options[:extra_bin_files]
 
         lockdir ||=
           begin
@@ -540,7 +535,7 @@ module Omnibus
     def mkdir(directory, options = {})
       build_commands << BuildCommand.new("mkdir `#{directory}'") do
         Dir.chdir(software.project_dir) do
-          FileUtils.mkdir_p(directory, **options)
+          FileUtils.mkdir_p(directory, options)
         end
       end
     end
@@ -562,7 +557,7 @@ module Omnibus
           parent = File.dirname(file)
           FileUtils.mkdir_p(parent) unless File.directory?(parent)
 
-          FileUtils.touch(file, **options)
+          FileUtils.touch(file, options)
         end
       end
     end
@@ -583,7 +578,7 @@ module Omnibus
       build_commands << BuildCommand.new("delete `#{path}'") do
         Dir.chdir(software.project_dir) do
           FileSyncer.glob(path).each do |file|
-            FileUtils.rm_rf(file, **options)
+            FileUtils.rm_rf(file, options)
           end
         end
       end
@@ -634,7 +629,7 @@ module Omnibus
             log.warn(log_key) { "no matched files for glob #{command}" }
           else
             files.each do |file|
-              FileUtils.cp_r(file, destination, **options)
+              FileUtils.cp_r(file, destination, options)
             end
           end
         end
@@ -663,7 +658,7 @@ module Omnibus
             log.warn(log_key) { "no matched files for glob #{command}" }
           else
             files.each do |file|
-              FileUtils.mv(file, destination, **options)
+              FileUtils.mv(file, destination, options)
             end
           end
         end
@@ -695,7 +690,7 @@ module Omnibus
               log.warn(log_key) { "no matched files for glob #{command}" }
             else
               files.each do |file|
-                FileUtils.ln_s(file, destination, **options)
+                FileUtils.ln_s(file, destination, options)
               end
             end
           end

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -246,7 +246,7 @@ module Omnibus
 
       context "when the file is less than 10240 bytes" do
         let(:source_url) { "https://downloads.chef.io/packages-chef-io-public.key" }
-        let(:source_md5) { "012a2c4e2a8edb86b2c072f02eea9f40" }
+        let(:source_md5) { "369efc3a19b9118cdf51c7e87a34f266" }
 
         it "downloads the file" do
           fetch!


### PR DESCRIPTION
### Description

This (re) reverts commit fac4b91

Re fixes #1014, which was unreverted on #1019

Also updates a checksum in a testfile, which was apparently needed to get the tests to pass. I'm not familiar with this codebase, so I'm not sure if that was a typical thing to do or not.



#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
