### PR TITLE
Fix omnibus builds failure

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -378,10 +378,10 @@ module Omnibus
         bin_dir            = "#{install_dir}/bin"
         appbundler_bin     = embedded_bin("appbundler")
 
-        lockdir = options[:lockdir]
-        gem = options[:gem]
-        without = options[:without]
-        extra_bin_files = options[:extra_bin_files]
+        lockdir = options.delete(:lockdir)
+        gem = options.delete(:gem)
+        without = options.delete(:without)
+        extra_bin_files = options.delete(:extra_bin_files)
 
         lockdir ||=
           begin

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -246,7 +246,7 @@ module Omnibus
 
       context "when the file is less than 10240 bytes" do
         let(:source_url) { "https://downloads.chef.io/packages-chef-io-public.key" }
-        let(:source_md5) { "012a2c4e2a8edb86b2c072f02eea9f40" }
+        let(:source_md5) { "369efc3a19b9118cdf51c7e87a34f266" }
 
         it "downloads the file" do
           fetch!


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

This will fix issue for omnibus builds :
`Mixlib::ShellOut::InvalidCommandOption: option ':lockdir' is not a valid option for Mixlib::ShellOut `

Verified inspec omnibus build: https://buildkite.com/chef/inspec-inspec-master-omnibus-adhoc/builds/210#a0e01b90-5ffb-4758-8f63-0bcff2991b65


--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
