### PR TITLE
Updates rpm spec to use SHA256 for filedigest, from MD5

### DIFF
--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -8,8 +8,8 @@
 %define __spec_clean_post true
 %define __spec_clean_pre true
 
-# Use md5
-%define _binary_filedigest_algorithm 1
+# Use SHA256 checksums for all files
+%define _binary_filedigest_algorithm 8
 
 %define _binary_payload <%= compression %>
 


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

### Description

Updates the RPM spec for packaging to use SHA256 for the file digest algorithm instead of MD5.  This should allow support of RPM package installation on EL8-variant systems with FIPS-mode enabled.

Referenced in issue from https://github.com/chef/chef/issues/11790

thanks to @teknofire for the assistance in where the logic is running via omnibus

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
