### PR TITLE
Change rpm sign to use rpmsign instead of using rpmbuild

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -449,6 +449,13 @@ module Omnibus
 
         with_rpm_signing do |signing_script|
           log.info(log_key) { "Signing the built rpm file" }
+
+          # RHEL 8 has gpg-agent running so we can skip the expect script since the agent
+          # takes care of the passphrase entering on the signing
+          if dist_tag != ".el8"
+            sign_cmd.prepend("#{signing_script} \"").concat("\"")
+          end
+
           shellout!("#{sign_cmd}", environment: { "HOME" => home })
         end
       end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -417,6 +417,10 @@ module Omnibus
       command << %{ -bb}
       command << %{ --buildroot #{staging_dir}/BUILD}
       command << %{ --define '_topdir #{staging_dir}'}
+      command << " #{spec_file}"
+
+      log.info(log_key) { "Creating .rpm file" }
+      shellout!("#{command}")
 
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
@@ -438,17 +442,10 @@ module Omnibus
             })
         end
 
-        command << " --sign"
-        command << " #{spec_file}"
-
         with_rpm_signing do |signing_script|
-          log.info(log_key) { "Creating .rpm file" }
-          shellout!("#{signing_script} \"#{command}\"", environment: { "HOME" => home })
+          log.info(log_key) { "Signing the built rpm file" }
+          shellout!("#{signing_script} \"rpmsign --addsign #{rpm_file}\"", environment: { "HOME" => home })
         end
-      else
-        log.info(log_key) { "Creating .rpm file" }
-        command << " #{spec_file}"
-        shellout!("#{command}")
       end
 
       FileSyncer.glob("#{staging_dir}/RPMS/**/*.rpm").each do |rpm|
@@ -481,6 +478,15 @@ module Omnibus
     #
     def spec_file
       "#{staging_dir}/SPECS/#{package_name}.spec"
+    end
+
+    #
+    # The full path to the rpm file.
+    #
+    # @return [String]
+    #
+    def rpm_file
+      "#{staging_dir}/RPMS/#{safe_architecture}/#{package_name}"
     end
 
     #

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -404,6 +404,16 @@ module Omnibus
       end
     end
 
+    describe "#rpm_file" do
+      before do
+        allow(subject).to receive(:package_name).and_return("package_name.rpm")
+      end
+
+      it "includes the package_name rpm" do
+        expect(subject.rpm_file).to eq("#{staging_dir}/RPMS/#{architecture}/package_name.rpm")
+      end
+    end
+
     describe "#rpm_safe" do
       it "adds quotes when required" do
         expect(subject.rpm_safe("file path")).to eq('"file path"')


### PR DESCRIPTION
### Description

Fixes the  RHEL 8  build to use rpmsign to to sign rpms to make sure we don't fail on unexpected output from rpmbuild.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
