### PR TITLE
Add rpmsign instead of using rpmbuild for rpms

### DIFF
--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -404,6 +404,16 @@ module Omnibus
       end
     end
 
+    describe "#rpm_file" do
+      before do
+        allow(subject).to receive(:package_name).and_return("package_name.rpm")
+      end
+
+      it "includes the package_name rpm" do
+        expect(subject.rpm_file).to eq("#{staging_dir}/RPMS/#{architecture}/package_name.rpm")
+      end
+    end
+
     describe "#rpm_safe" do
       it "adds quotes when required" do
         expect(subject.rpm_safe("file path")).to eq('"file path"')


### PR DESCRIPTION
Signed-off-by: Michael Maslanka <michael.maslanka@progress.com>

### Description

Change rpmbuild to no longer sign but instead  use rpmsign. Rhel 8 also has gpg-agent running so we don't need the expect script for it.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
