### PR TITLE
Fix pathing for go on windows

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -314,11 +314,11 @@ module Omnibus
     #
     def go(command, options = {})
       build_commands << BuildCommand.new("go `#{command}'") do
-        bin = embedded_bin("go")
+        bin = windows? ? windows_safe_path("#{install_dir}/embedded/go/bin/go") : embedded_bin("go")
 
         # Check if we are building a go binary and then check if we are on
         # Red Hat or CentOS so we build the binary properly with a build-id
-        if command.start_with?("build", " build") && (rhel? || centos?)
+        if command.start_with?("build", " build") && rhel?
           command << " -ldflags=-linkmode=external"
         end
 


### PR DESCRIPTION
Signed-off-by: Michael Maslanka <maslanka@progress.com>

Fix condition logic

Signed-off-by: Michael Maslanka <maslanka@progress.com>

Fix if condition

Signed-off-by: Michael Maslanka <maslanka@progress.com>

### Description

Briefly describe the new feature or fix here
Windows go path is different than linux so adjust  accordingly.
--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
