### PR TITLE
Allow ohai versions > 17 to be used

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
-  gem.add_dependency "ohai",             ">= 15", "< 17"
+  gem.add_dependency "ohai",             ">= 15", "< 18"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"


### PR DESCRIPTION
### Description

The restricton `< 17` was originally added by 2777c5b65 in https://github.com/chef/omnibus/pull/1013 because `omnibus-toolchain` was still shipping Ruby 2.6 at that time, and Ohai 17 required Ruby 17. However, starting with https://github.com/chef/omnibus-toolchain/pull/153, `omnibus-toolchain` is on Ruby 2.7+, and hence this restriction can be removed.

Without this, omnibus can't be used with Chef > 17 because of conflicting Ohai requirements between two.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
