### PR TITLE
Whitelist libbrotlidec for curl builds on macOS

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -152,6 +152,7 @@ MAC_WHITELIST_LIBS = [
   /Foundation/,
   /IOKit$/,
   /Tk$/,
+  /libbrotlidec\.1\.dylib/,
   /libutil\.dylib/,
   /libffi\.dylib/,
   /libncurses\.5\.4\.dylib/,


### PR DESCRIPTION
Signed-off-by: skeshari12 <skeshari@msystechnologies.com>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
