### PR TITLE
Revert "Fix mac_x-10 failure for chef-workstation"

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -152,7 +152,6 @@ MAC_WHITELIST_LIBS = [
   /Foundation/,
   /IOKit$/,
   /Tk$/,
-  /libbrotlidec\.1\.dylib/,
   /libutil\.dylib/,
   /libffi\.dylib/,
   /libncurses\.5\.4\.dylib/,


### PR DESCRIPTION
This reverts commit 133ee319922d50441eae30092ad30f114ea5e65c.

### Description

It turns out we don't need to whitelist this library file.