### PR TITLE
Pin ohai to 16.17.0

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
-  gem.add_dependency "ohai",             ">= 15", "< 18"
+  gem.add_dependency "ohai",             "~> 16.17"   # pin ohai to 16.17.0 until we support ruby 2.6
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"


### PR DESCRIPTION
Verify pipeline is failing with below error -

```
Gem::RuntimeRequirementNotMetError: ohai requires Ruby version >= 2.7. The
current ruby version is 2.6.9.207.
An error occurred while installing ohai (17.7.12), and Bundler
cannot continue.
Make sure that `gem install ohai -v '17.7.12' --source 'https://rubygems.org/'`
succeeds before bundling.
```
Build - https://buildkite.com/chef-oss/chef-omnibus-main-verify/builds/585
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
