### PR TITLE
Don't generate build-id files in RPM packages

### DIFF
--- a/resources/rpm/spec.erb
+++ b/resources/rpm/spec.erb
@@ -13,6 +13,9 @@
 
 %define _binary_payload <%= compression %>
 
+# Disable creation of build-id links
+%define _build_id_links none
+
 # Metadata
 Name: <%= name %>
 Version: <%= version %>


### PR DESCRIPTION
build-id metadata is only there in case someone wants to use debugger tools. When left enabled, build-id files are created in /usr/lib/.build-id on RHEL 8 systems. This can lead to potential conflict when multiple packages have the same build-id file. This conflict prevents the second package from installing. This conflict has been seen when installing Chef Infra Client 17.1.35+ and Chef Workstation 21.8.555+.
