### PR TITLE
fixed typo in referenced argument name

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,14 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.6
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.6-buster
-
 - label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake

--- a/lib/omnibus/packagers/pkg.rb
+++ b/lib/omnibus/packagers/pkg.rb
@@ -438,7 +438,7 @@ module Omnibus
     end
 
     def is_macho?(lib)
-      return false unless File.file?(bin) && File.executable?(bin) && !File.symlink?(bin)
+      return false unless File.file?(lib) && File.executable?(lib) && !File.symlink?(lib)
 
       if shellout!("file #{lib}").stdout.match?(/Mach-O.*(library|bundle)/) # https://rubular.com/r/nRgaQlAbkM9wHL
         log.debug(log_key) { "    skipping non-Mach-O library file from signing: #{lib}" }

--- a/spec/unit/packagers/pkg_spec.rb
+++ b/spec/unit/packagers/pkg_spec.rb
@@ -557,7 +557,9 @@ module Omnibus
 
       context "when is a Mach-O library" do
         before do
-          allow(subject).to receive(:is_binary?).with("file").and_return(true)
+          allow(File).to receive(:file?).with("file").and_return(true)
+          allow(File).to receive(:executable?).with("file").and_return(true)
+          allow(File).to receive(:symlink?).with("file").and_return(false)
           expect(subject).to receive(:shellout!).with("file file").and_return(shellout)
           allow(shellout).to receive(:stdout)
             .and_return("file: Mach-O 64-bit dynamically linked shared library x86_64")
@@ -570,7 +572,9 @@ module Omnibus
 
       context "when is a Mach-O Bundle" do
         before do
-          allow(subject).to receive(:is_binary?).with("file").and_return(true)
+          allow(File).to receive(:file?).with("file").and_return(true)
+          allow(File).to receive(:executable?).with("file").and_return(true)
+          allow(File).to receive(:symlink?).with("file").and_return(false)
           expect(subject).to receive(:shellout!).with("file file").and_return(shellout)
           allow(shellout).to receive(:stdout)
             .and_return("file: Mach-O 64-bit bundle x86_64")
@@ -583,7 +587,9 @@ module Omnibus
 
       context "when is not a Mach-O Bundle or Mach-O library" do
         before do
-          allow(subject).to receive(:is_binary?).with("file").and_return(true)
+          allow(File).to receive(:file?).with("file").and_return(true)
+          allow(File).to receive(:executable?).with("file").and_return(true)
+          allow(File).to receive(:symlink?).with("file").and_return(false)
           expect(subject).to receive(:shellout!).with("file file").and_return(shellout)
           allow(shellout).to receive(:stdout)
             .and_return("file: ASCII text")


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

### Description

Updated arg name to fix typo. Causing workstation build to fail.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
