### PR TITLE
Better healthcheck correctness

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -378,7 +378,7 @@ module Omnibus
       good_libs = {}
 
       # This algorithm runs on both Linux and FreeBSD and needs to be MANUALLY tested on both
-      read_shared_libs("find #{project.install_dir}/ -type f", "xargs -n 1 ldd") do |line|
+      read_shared_libs("find #{project.install_dir}/ -type f", "xargs ldd") do |line|
         case line
         when /^(.+):$/
           current_library = Regexp.last_match[1]

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -177,6 +177,7 @@ FREEBSD_WHITELIST_LIBS = [
   /libkvm\.so/,
   /libprocstat\.so/,
   /libmd\.so/,
+  /libdl\.so/,
 ].freeze
 
 IGNORED_ENDINGS = %w{
@@ -215,6 +216,7 @@ IGNORED_ENDINGS = %w{
   .lua
   .md
   .mkd
+  .mo
   .npmignore
   .out
   .packlist
@@ -229,19 +231,23 @@ IGNORED_ENDINGS = %w{
   .pyo
   .rake
   .rb
+  .rbs
   .rdoc
   .rhtml
   .ri
+  .rpm
   .rst
   .scss
   .sh
   .sql
   .svg
   .toml
+  .tt
   .ttf
   .txt
   .xml
   .yml
+  COPYING
   Gemfile
   LICENSE
   Makefile

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -1,5 +1,5 @@
 
-# Copyright 2012-2020, Chef Software Inc.
+# Copyright:: Copyright (c) Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -181,24 +181,29 @@ FREEBSD_WHITELIST_LIBS = [
 
 IGNORED_ENDINGS = %w{
   .TXT
-  .[ch]
-  .[ch]pp
-  .[eh]rl
   .app
   .appup
   .bat
   .beam
+  .c
   .cc
   .cmake
   .conf
+  .cpp
   .css
-  .e*rb
+  .erb
+  .erl
   .feature
   .gemspec
   .gif
   .gitignore
   .gitkeep
-  .h*h
+  .h
+  .h
+  .hh
+  .hpp
+  .hrl
+  .html
   .jar
   .java
   .jpg
@@ -219,10 +224,13 @@ IGNORED_ENDINGS = %w{
   .png
   .pod
   .properties
-  .py[oc]*
-  .r*html
+  .py
+  .pyc
+  .pyo
   .rake
+  .rb
   .rdoc
+  .rhtml
   .ri
   .rst
   .scss
@@ -243,7 +251,7 @@ IGNORED_ENDINGS = %w{
   license
 }.freeze
 
-IGNORED_PATTERNS = %w{
+IGNORED_SUBSTRINGS = %w{
   /build_info/
   /licenses/
   /LICENSES/

--- a/spec/unit/health_check_spec.rb
+++ b/spec/unit/health_check_spec.rb
@@ -99,9 +99,47 @@ module Omnibus
     context "on linux" do
       before { stub_ohai(platform: "ubuntu", version: "16.04") }
 
+      # file_list just needs to have one file which is inside of the install_dir
+      let(:file_list) do
+        double("Mixlib::Shellout",
+          error!: false,
+          stdout: <<~EOH
+            /opt/chefdk/shouldnt/matter
+          EOH
+        )
+      end
+
+      let(:empty_list) do
+        double("Mixlib::Shellout",
+          error!: false,
+          stdout: <<~EOH
+          EOH
+        )
+      end
+
+      let(:failed_list) do
+        failed_list = double("Mixlib::Shellout",
+          stdout: <<~EOH
+            /opt/chefdk/shouldnt/matter
+          EOH
+        )
+        allow(failed_list).to receive(:error!).and_raise("Mixlib::Shellout::ShellCommandFailed")
+        failed_list
+      end
+
+      let(:bad_list) do
+        double("Mixlib::Shellout",
+          error!: false,
+          stdout: <<~EOH
+            /somewhere/other/than/install/dir
+          EOH
+        )
+      end
+
       let(:bad_healthcheck) do
         double("Mixlib::Shellout",
-          stdout: <<-EOH.gsub(/^ {12}/, "")
+          error!: false,
+          stdout: <<~EOH
             /bin/ls:
               linux-vdso.so.1 =>  (0x00007fff583ff000)
               libselinux.so.1 => /lib/x86_64-linux-gnu/libselinux.so.1 (0x00007fad8592a000)
@@ -122,7 +160,8 @@ module Omnibus
 
       let(:good_healthcheck) do
         double("Mixlib::Shellout",
-          stdout: <<-EOH.gsub(/^ {12}/, "")
+          error!: false,
+          stdout: <<~EOH
             /bin/echo:
               linux-vdso.so.1 =>  (0x00007fff8a6ee000)
               libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f70f58c0000)
@@ -135,11 +174,13 @@ module Omnibus
         )
       end
 
-      let(:regexp) { ".*(\\.TXT|\\.[ch]|\\.[ch]pp|\\.[eh]rl|\\.app|\\.appup|\\.bat|\\.beam|\\.cc|\\.cmake|\\.conf|\\.css|\\.e*rb|\\.feature|\\.gemspec|\\.gif|\\.gitignore|\\.gitkeep|\\.h*h|\\.jar|\\.java|\\.jpg|\\.js|\\.jsm|\\.json|\\.lock|\\.log|\\.lua|\\.md|\\.mkd|\\.npmignore|\\.out|\\.packlist|\\.perl|\\.pl|\\.pm|\\.png|\\.pod|\\.properties|\\.py[oc]*|\\.r*html|\\.rake|\\.rdoc|\\.ri|\\.rst|\\.scss|\\.sh|\\.sql|\\.svg|\\.toml|\\.ttf|\\.txt|\\.xml|\\.yml|Gemfile|LICENSE|Makefile|README|Rakefile|VERSION|license)$|.*\\/build_info\\/.*|.*\\/licenses\\/.*|.*\\/LICENSES\\/.*|.*\\/man\\/.*|.*\\/share\\/doc\\/.*|.*\\/share\\/info\\/.*|.*\\/share\\/postgresql\\/.*|.*\\/share\\/terminfo\\/.*|.*\\/share\\/timezone\\/.*|.*\\/terminfo\\/.*" }
-
       it "raises an exception when there are external dependencies" do
         allow(subject).to receive(:shellout)
-          .with("find #{project.install_dir}/ -type f -regextype posix-extended ! -regex '#{regexp}' | xargs ldd")
+          .with("find /opt/chefdk/ -type f")
+          .and_return(file_list)
+
+        allow(subject).to receive(:shellout)
+          .with("xargs ldd", { input: "/opt/chefdk/shouldnt/matter\n" })
           .and_return(bad_healthcheck)
 
         expect { subject.run! }.to raise_error(HealthCheckFailed)
@@ -147,7 +188,11 @@ module Omnibus
 
       it "does not raise an exception when the healthcheck passes" do
         allow(subject).to receive(:shellout)
-          .with("find #{project.install_dir}/ -type f -regextype posix-extended ! -regex '#{regexp}' | xargs ldd")
+          .with("find /opt/chefdk/ -type f")
+          .and_return(file_list)
+
+        allow(subject).to receive(:shellout)
+          .with("xargs ldd", { input: "/opt/chefdk/shouldnt/matter\n" })
           .and_return(good_healthcheck)
 
         expect { subject.run! }.to_not raise_error
@@ -155,6 +200,30 @@ module Omnibus
 
       it "will not perform dll base relocation checks" do
         expect(subject.relocation_checkable?).to be false
+      end
+
+      it "raises an exception if there's nothing in the file list" do
+        allow(subject).to receive(:shellout)
+          .with("find /opt/chefdk/ -type f")
+          .and_return(empty_list)
+
+        expect { subject.run! }.to raise_error(RuntimeError, "Internal Error: Health Check found no lines")
+      end
+
+      it "raises an exception if the file list command raises" do
+        allow(subject).to receive(:shellout)
+          .with("find /opt/chefdk/ -type f")
+          .and_return(failed_list)
+
+        expect { subject.run! }.to raise_error(RuntimeError, "Mixlib::Shellout::ShellCommandFailed")
+      end
+
+      it "raises an exception if the file list command has no entries in the install_dir" do
+        allow(subject).to receive(:shellout)
+          .with("find /opt/chefdk/ -type f")
+          .and_return(bad_list)
+
+        expect { subject.run! }.to raise_error(RuntimeError, "Internal Error: Health Check lines not matching the install_dir")
       end
     end
   end


### PR DESCRIPTION
closes #1051 

Fixes healthchecks on AIX, Solaris and FreeBSD.

Extracts the solaris healthcheck routine out to its own method

This reworks the filtering introduced in https://github.com/chef/omnibus/commit/9551f72f60e60ae98c23969b090cc3df1930343d to do it in pure ruby but deliberately drops the complexity of the regexps.  This was responsible for breaking health checks on FreeBSD.

There are now some internal consistency checks which ensure that the output of the find command actually produces some output and that there is at least one file in the install_path, it also ensures that the "ldd" (or "otool", etc) routine finds at least one affirmatively good library.  These should at least catch breakages that result in silently failing NOPs.