### PR TITLE
Whitlist libffi.so.6 lib

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -31,6 +31,7 @@ WHITELIST_LIBS = [
     /libutil\.so/,
     /linux-vdso.+/,
     /linux-gate\.so/,
+    /libffi\.so\.6/,
   ].freeze
 
 ARCH_WHITELIST_LIBS = [


### PR DESCRIPTION
omnibus-software - Build is failing while performing health check for python software definition version 3.10.2

[HealthCheck] E \| 2022-01-18T12:55:12+00:00 \| The following binaries have unsafe or unmet dependencies:
--
  |  
  | [HealthCheck] E \| 2022-01-18T12:55:12+00:00 \| The following libraries cannot be guaranteed to be on target systems:
  | --> /lib/x86_64-linux-gnu/libreadline.so.7 (0x00007f718c393000)
  | --> /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007f718bb59000)
  | --> /usr/lib/x86_64-linux-gnu/libffi.so.6 (0x00007f5fe7cf8000)
  |  
  | [HealthCheck] E \| 2022-01-18T12:55:12+00:00 \| The precise failures were:
  | --> /opt/test/embedded/lib/python3.9/lib-dynload/readline.cpython-39-x86_64-linux-gnu.so
  | DEPENDS ON: libreadline.so.7
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libreadline.so.7 (0x00007f718c393000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/test/embedded/lib/python3.9/lib-dynload/readline.cpython-39-x86_64-linux-gnu.so
  | DEPENDS ON: libtinfo.so.5
  | COUNT: 1
  | PROVIDED BY: /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007f718bb59000)
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/test/embedded/lib/python3.9/lib-dynload/_ctypes.cpython-39-x86_64-linux-gnu.so
  | DEPENDS ON: libffi.so.6
  | COUNT: 1
  | PROVIDED BY: /usr/lib/x86_64-linux-gnu/libffi.so.6 (0x00007f5fe7cf8000)
  | FAILED BECAUSE: Unsafe dependency

https://github.com/chef/omnibus-software/pull/1516

Signed-off-by: jgarud@msystechnologies.com

### Description

Briefly describe the new feature or fix here

--------------------------------------------------


#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
