### PR TITLE
Whitelist files for `make` on AIX

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -49,12 +49,18 @@ ARCH_WHITELIST_LIBS = [
 ].freeze
 
 AIX_WHITELIST_LIBS = [
+  /libc\.a/,
+  /libcfg\.a/,
+  /libcorcfg\.a/,
+  /libcrypt\.a/,
+  /libdl\.a/,
+  /liblvm\.a/,
+  /libodm\.a/,
+  /libperfstat\.a/,
   /libpthread\.a/,
   /libpthreads\.a/,
-  /libdl.a/,
   /librtl\.a/,
-  /libc\.a/,
-  /libcrypt\.a/,
+  /libsrc\.a/,
   /unix$/,
 ].freeze
 


### PR DESCRIPTION
Building `make` on AIX links to these files. We only noticed this now because omnibus health check was recently fixed on AIX.