### PR TITLE
Whitelist files for Chef Infra Client builds

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -25,3 +25,11 @@ steps:
     executor:
       docker:
         image: ruby:3.0-buster
+
+- label: run-lint-and-specs-ruby-3.1
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1-buster

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -179,7 +179,7 @@ module Omnibus
       if null?(val)
         @install_dir || raise(MissingRequiredAttribute.new(self, :install_dir, "/opt/chef"))
       else
-        @install_dir = val.tr('\\', "/").squeeze("/").chomp("/")
+        @install_dir = val.tr('\\', "/").squeeze("/").chomp("/") # rubocop:disable Style/StringLiterals
       end
     end
     expose :install_dir

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -105,6 +105,7 @@ SOLARIS_WHITELIST_LIBS = [
   /libuutil\.so/,
   /libkstat\.so/,
   # solaris 11 libraries:
+  /libstdc\+\+\.so/,
   /libc\.so\.1/,
   /libm\.so\.2/,
   /libdl\.so\.1/,
@@ -173,6 +174,8 @@ MAC_WHITELIST_LIBS = [
 
 FREEBSD_WHITELIST_LIBS = [
   /libc\.so/,
+  /libc\+\+\.so/,
+  /libcxxrt\.so/,
   /libgcc_s\.so/,
   /libcrypt\.so/,
   /libm\.so/,

--- a/spec/functional/builder_spec.rb
+++ b/spec/functional/builder_spec.rb
@@ -222,7 +222,7 @@ module Omnibus
         output = capture_logging { subject.build }
 
         appbundler_path = File.join(embedded_bin_dir, "appbundler")
-        appbundler_path.gsub!(%r{/}, '\\') if windows?
+        appbundler_path.gsub!(%r{/}, '\\') if windows? # rubocop:disable Style/StringLiterals
         expect(output).to include("#{appbundler_path} '#{project_dir}' '#{bin_dir}'")
       end
     end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -60,7 +60,7 @@ RSpec.shared_examples "a software" do |name = "chefdk"|
 
     allow(software).to receive(:embedded_bin) do |binary|
       p = File.join(embedded_bin_dir, binary)
-      p.gsub!(%r{/}, '\\') if windows?
+      p.gsub!(%r{/}, '\\') if windows? # rubocop:disable Style/StringLiterals
       p
     end
   end

--- a/spec/support/ohai_helpers.rb
+++ b/spec/support/ohai_helpers.rb
@@ -14,7 +14,7 @@ module Omnibus
         # If we asked for Windows, we should also specify that magical
         # +File::ALT_SEPARATOR+ variable
         if options[:platform] && options[:platform] == "windows"
-          stub_const("File::ALT_SEPARATOR", '\\')
+          stub_const("File::ALT_SEPARATOR", '\\') # rubocop:disable Style/StringLiterals
         end
       end
     end

--- a/spec/unit/builder_spec.rb
+++ b/spec/unit/builder_spec.rb
@@ -23,7 +23,7 @@ module Omnibus
       allow(subject).to receive(:windows?).and_return(on_windows)
       allow(subject).to receive(:windows_safe_path) do |*args|
         path = File.join(*args)
-        path.gsub!(File::SEPARATOR, '\\') if on_windows
+        path.gsub!(File::SEPARATOR, '\\') if on_windows # rubocop:disable Style/StringLiterals
       end
     end
 

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -229,7 +229,7 @@ module Omnibus
 
       context "when on Windows" do
         before { stub_ohai(platform: "windows", version: "2019") }
-        before { stub_const("File::ALT_SEPARATOR", '\\') }
+        before { stub_const("File::ALT_SEPARATOR", '\\') } # rubocop:disable Style/StringLiterals
         it "returns a Windows iteration" do
           expect(subject.build_iteration).to eq(1)
         end


### PR DESCRIPTION
Chef Infra Client now requires the unf_ext gem which builds native
extensions that link to system files on FreeBSD and Solaris.
I confirmed that these files exist on default installs of these systems
so it should be ok to whitelist them.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
