### PR TITLE
Replace BSD tar with GNU tar on Windows

### DIFF
--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -212,7 +212,7 @@ module Omnibus
     #   :seven_zip - use 7zip for all tar/compressed tar files on windows.
     #   :lax_tar - use tar.exe on windows but ignore errors.
     #
-    # Both 7z and bsdtar have issues on windows.
+    # 7z has issues on windows.
     #
     # 7z cannot extract and untar at the same time. You need to extract to a
     # temporary location and then extract again into project_dir.
@@ -220,15 +220,6 @@ module Omnibus
     # 7z also doesn't handle symlinks well. A symlink to a non-existent
     # location simply results in a text file with the target path written in
     # it. It does this without throwing any errors.
-    #
-    # bsdtar will exit(1) if it is encounters symlinks on windows. So we can't
-    # use shellout! directly.
-    #
-    # bsdtar will also exit(1) and fail to overwrite files at the destination
-    # during extraction if a file already exists at the destination and is
-    # marked read-only. This used to be a problem when we weren't properly
-    # cleaning an existing project_dir. It should be less of a problem now...
-    # but who knows.
     #
     def extract
       # Only used by tar
@@ -243,7 +234,7 @@ module Omnibus
           returns = [0]
           returns << 1 if source[:extract] == :lax_tar
 
-          shellout!("tar #{compression_switch}xf #{safe_downloaded_file} -C#{safe_project_dir}", returns: returns)
+          shellout!("tar #{compression_switch}xf #{downloaded_file} --force-local -C#{project_dir}", returns: returns)
         elsif downloaded_file.end_with?(*COMPRESSED_TAR_EXTENSIONS)
           Dir.mktmpdir do |temp_dir|
             log.debug(log_key) { "Temporarily extracting `#{safe_downloaded_file}' to `#{temp_dir}'" }

--- a/spec/unit/fetchers/net_fetcher_spec.rb
+++ b/spec/unit/fetchers/net_fetcher_spec.rb
@@ -421,19 +421,19 @@ module Omnibus
           it_behaves_like "an extractor", "zip", {},
             ['7z.exe x C:\\file.zip -oC:\\tmp\\project -r -y']
           it_behaves_like "an extractor", "tar", {},
-            [['tar xf C:\\file.tar -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar xf C:/file.tar --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "tgz", {},
-            [['tar zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar zxf C:/file.tgz --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "tar.gz", {},
-            [['tar zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar zxf C:/file.tar.gz --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "tar.bz2", {},
-            [['tar jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar jxf C:/file.tar.bz2 --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "txz", {},
-            [['tar Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar Jxf C:/file.txz --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "tar.xz", {},
-            [['tar Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar Jxf C:/file.tar.xz --force-local -CC:/tmp/project", { returns: [0] }]]
           it_behaves_like "an extractor", "tar.lzma", {},
-            [['tar --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0] }]]
+            [["tar --lzma -xf C:/file.tar.lzma --force-local -CC:/tmp/project", { returns: [0] }]]
         end
 
         context "when seven_zip extract strategy is chosen" do
@@ -469,19 +469,19 @@ module Omnibus
           it_behaves_like "an extractor", "zip", { extract: :lax_tar },
             ['7z.exe x C:\\file.zip -oC:\\tmp\\project -r -y']
           it_behaves_like "an extractor", "tar", { extract: :lax_tar },
-            [['tar xf C:\\file.tar -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar xf C:/file.tar --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tgz", { extract: :lax_tar },
-            [['tar zxf C:\\file.tgz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar zxf C:/file.tgz --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.gz", { extract: :lax_tar },
-            [['tar zxf C:\\file.tar.gz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar zxf C:/file.tar.gz --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.bz2", { extract: :lax_tar },
-            [['tar jxf C:\\file.tar.bz2 -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar jxf C:/file.tar.bz2 --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "txz", { extract: :lax_tar },
-            [['tar Jxf C:\\file.txz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar Jxf C:/file.txz --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.xz", { extract: :lax_tar },
-            [['tar Jxf C:\\file.tar.xz -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar Jxf C:/file.tar.xz --force-local -CC:/tmp/project", { returns: [0, 1] }]]
           it_behaves_like "an extractor", "tar.lzma", { extract: :lax_tar },
-            [['tar --lzma -xf C:\\file.tar.lzma -CC:\\tmp\\project', { returns: [0, 1] }]]
+            [["tar --lzma -xf C:/file.tar.lzma --force-local -CC:/tmp/project", { returns: [0, 1] }]]
         end
       end
 


### PR DESCRIPTION
We are using the latest version of msys2 and it comes with GNU tar.

GNU tar requires --force-local when the path to the local compressed file
has a colon in it.

GNU tar treats the "safe" path's backslash separator as an escape
character which causes problems so instead we will use the default
path separator which is the forward slash.