### PR TITLE
Add -rpath to LDFLAGS for FreeBSD

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -717,7 +717,7 @@ module Omnibus
           {
             "CC" => "clang",
             "CXX" => "clang++",
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib -rpath #{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
           }
         when "windows"

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -239,7 +239,7 @@ module Omnibus
             "CXXFLAGS"  => "-I/opt/project/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "CPPFLAGS"  => "-I/opt/project/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "CXX" => "clang++",
-            "LDFLAGS" => "-L/opt/project/embedded/lib",
+            "LDFLAGS" => "-L/opt/project/embedded/lib -rpath /opt/project/embedded/lib",
             "LD_RUN_PATH" => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"


### PR DESCRIPTION
FreeBSD 12's linker doesn't see LD_RUN_PATH so we need to use -rpath.