### PR TITLE
IPACK-204

### DIFF
--- a/lib/omnibus/software.rb
+++ b/lib/omnibus/software.rb
@@ -717,7 +717,7 @@ module Omnibus
           {
             "CC" => "clang",
             "CXX" => "clang++",
-            "LDFLAGS" => "-L#{install_dir}/embedded/lib -rpath #{install_dir}/embedded/lib",
+            "LDFLAGS" => "-L#{install_dir}/embedded/lib -Wl,-rpath,#{install_dir}/embedded/lib",
             "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
           }
         when "windows"

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"
   gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
+  gem.add_dependency "nokogiri",         "~> 1"
 
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "pedump"

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -239,7 +239,7 @@ module Omnibus
             "CXXFLAGS"  => "-I/opt/project/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "CPPFLAGS"  => "-I/opt/project/embedded/include -O3 -D_FORTIFY_SOURCE=2 -fstack-protector",
             "CXX" => "clang++",
-            "LDFLAGS" => "-L/opt/project/embedded/lib -rpath /opt/project/embedded/lib",
+            "LDFLAGS" => "-L/opt/project/embedded/lib -Wl,-rpath,/opt/project/embedded/lib",
             "LD_RUN_PATH" => "/opt/project/embedded/lib",
             "PKG_CONFIG_PATH" => "/opt/project/embedded/lib/pkgconfig",
             "OMNIBUS_INSTALL_DIR" => "/opt/project"


### PR DESCRIPTION
Fix rpath in LDFLAGS for FreeBSD

Add nokogiri as a dependency. nokogiri is required by aws-sdk-core which is required by aws-sdk-s3 and "bundle exec" in a ruby 3 environment won't use nokogiri unless it is explicitly defined as a dependency.
