### PR TITLE
Replace dependency on nokogiri with rexml

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
   gem.add_dependency "license_scout",    "~> 1.0"
   gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
-  gem.add_dependency "nokogiri",         "~> 1"
+  gem.add_dependency "rexml",            "~> 3.2"
 
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "pedump"


### PR DESCRIPTION
aws-sdk-s3 needs a gem that can parse xml.
nokogiri requires native extensions to be built which
can be problematic on some platforms (e.g. AIX).
The rexml gem is less performant but it doesn't require native extensions.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
