### PR TITLE
reset ruby windows devkit. this is deprecated anyway.

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -175,7 +175,7 @@ module Omnibus
       # means. This can be anything from x86_64-pc-mingw64 to i686-pc-mingw32
       # which doesn't even make any sense...
       if windows?
-        platform = windows_arch_i386? ? "i686-w64-mingw32" : "x86_64-w64-mingw32"
+        platform = windows_arch_i386? ? "i686-w64-mingw32" : "x64-mingw-ucrt"
         configure_cmd << "--build=#{platform}"
       end
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -484,6 +484,7 @@ module Omnibus
 
       puts "Im trying to find this command : #{find_command}\n"
       find_output = shellout!(find_command).stdout.lines
+      puts "This is the results I got back from that find : \n #{find_output}"
 
       find_output.reject! { |file| IGNORED_ENDINGS.any? { |ending| file.end_with?("#{ending}\n") } }
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -482,6 +482,7 @@ module Omnibus
       # construct the list of files to check
       #
 
+      puts "Im trying to find this command : #{find_command}\n"
       find_output = shellout!(find_command).stdout.lines
 
       find_output.reject! { |file| IGNORED_ENDINGS.any? { |ending| file.end_with?("#{ending}\n") } }


### PR DESCRIPTION
Signed-off-by: John McCrae <john.mccrae@progress.com>

### Description

Changing the windows platform version to ucrt for a test build

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
