### PR TITLE
BS-94/use internal sources

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -607,6 +607,12 @@ module Omnibus
     # @return [true, false]
     default(:health_check, true)
 
+    # Use the internal_source URL when fetching software dependencies. e.g. when creating an
+    # omnibus package using artifactory as the source url.
+    #
+    # @return [true, false]
+    default(:use_internal_sources, false)
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/exceptions.rb
+++ b/lib/omnibus/exceptions.rb
@@ -351,4 +351,15 @@ module Omnibus
       EOH
     end
   end
+
+  class InternalSourceMissing < Error
+    def initialize(software)
+      super <<~EOH
+        Internal source missing for #{software.name}.
+
+        When :use_internal_sources is set in the configuration you must specify an
+        internal_source for sources fetched from a url.
+      EOH
+    end
+  end
 end

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -147,6 +147,8 @@ module Omnibus
     def download_url
       if Config.use_s3_caching
         S3Cache.url_for(self)
+      elsif Config.use_internal_sources && !source[:internal]
+        raise InternalSourceMissing.new(self)
       else
         source[:url]
       end

--- a/spec/functional/fetchers/net_fetcher_spec.rb
+++ b/spec/functional/fetchers/net_fetcher_spec.rb
@@ -173,6 +173,26 @@ module Omnibus
         end
       end
 
+      context "when use_internal_sources is true and no internal source url" do
+        before { Omnibus::Config.use_internal_sources(true) }
+
+        it "raises an exception" do
+          expect { fetch! }.to raise_error(InternalSourceMissing)
+        end
+      end
+
+      context "when use_internal_sources is true and internal source url given" do
+        before { Omnibus::Config.use_internal_sources(true) }
+        let(:source) do
+          { url: source_url, md5: source_md5, internal: true }
+        end
+
+        it "downloads the file" do
+          fetch!
+          expect(downloaded_file).to be_a_file
+        end
+      end
+
       context "source with sha1" do
         let(:source) do
           { url: source_url, sha1: source_sha1 }

--- a/spec/unit/software_spec.rb
+++ b/spec/unit/software_spec.rb
@@ -16,10 +16,18 @@ module Omnibus
       }
     end
 
+    let(:internal_source) do
+      {
+        url: "http://internal.com/",
+        md5: "efgh5678",
+      }
+    end
+
     let(:rel_path) { "software" }
 
     subject do
       local_source = source
+      local_internal_source = internal_source
       local_rel_path = rel_path
 
       described_class.new(project).evaluate do
@@ -27,6 +35,7 @@ module Omnibus
         default_version "1.2.3"
 
         source local_source
+        internal_source local_internal_source
         relative_path local_rel_path
       end
     end
@@ -589,6 +598,14 @@ module Omnibus
           expect(Omnibus::Fetcher).to receive(:resolve_version).with("1.2.3", { git: "https://github.com/a/b.git" } ).and_return("1.2.8")
           subject.send(:fetcher)
         end
+      end
+    end
+
+    context "when software internal_source is given" do
+      before { Omnibus::Config.use_internal_sources(true) }
+
+      it "sets the source with internal: true" do
+        expect(subject.source).to eq(url: "http://internal.com/", md5: "efgh5678", internal: true)
       end
     end
 


### PR DESCRIPTION
### Description

This is a new omnibus feature that allows users to build from only internal sources.

It works by adding a configuration value to the `omnibus.rb` file:

omnibus.rb
```ruby
use_internal_sources true
```

And then in the software definitions, you can define an `internal_source` like this:

my-software/cacerts.rb
```ruby
internal_source url: "https://my.internal.source/cacert-#{version}.pem"
```

When both source and internal_source are set, it will use the `internal_source` when `use_internal_sources` is set to true.

```ruby
source url: "https://curl.se/ca/cacert-#{version}.pem"
internal_source url: "https://my.internal.source/cacert-#{version}.pem" # uses this one
```

* When use_s3_caching is enabled, it will still use the cached sources wherever possible.
* When `use_internal_sources` is enabled and no `internal_source` is set for a dependency with a `url:` it will throw and exception
--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
