### PR TITLE
Fix failing s3 accelerate test with a version pin

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "aws-sdk-s3",       "~> 1"
+  gem.add_dependency "aws-sdk-s3",       "~> 1.116.0"
   gem.add_dependency "chef-utils",       ">= 15.4"
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"


### PR DESCRIPTION
Signed-off-by: Gregory Schofield <greg.c.schofield@gmail.com>

### Description

This fixes the s3 accelerate test that is failing due to upstream changes to the `aws-sdk-s3` gem in version `1.177.0`.

If its important to be on the latest version of the `aws-sdk-s3` gem then please feel free to close this.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
