### PR TITLE
Remove authorization from version manifest hash

### DIFF
--- a/lib/omnibus/manifest.rb
+++ b/lib/omnibus/manifest.rb
@@ -69,7 +69,10 @@ module Omnibus
 
     def to_hash
       software_hash = @data.inject({}) do |memo, (k, v)|
-        memo[k] = v.to_hash
+        h = v.to_hash
+        h[:locked_source].delete(:authorization) if h[:locked_source]
+
+        memo[k] = h
         memo
       end
       ret = {


### PR DESCRIPTION
Signed-off-by: Gregory Schofield <grschofi@progress.com>

### Description

Removes the `authorization:` key from the manifest because it exposes the artifactory token used.
This may cause omnibus packages built with authorization headers to be unable to rebuild from their version manifest.
Potentially this could be made possible with a new flag when building from a manifest?

How it looks before this PR
```
"libxslt": {
      "locked_version": "1.1.35",
      "locked_source": {
        "sha256": "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79",
        "url": "https://artifactory-internal.ps.chef.co/artifactory/omnibus-software-local/libxslt/libxslt-1.1.35.tar.xz",
        "authorization": "X-JFrog-Art-Api:<redacted>",
        "internal": true
      },
      "source_type": "url",
      "described_version": "1.1.35",
      "license": "MIT"
    },
```

How it looks after this PR
```
"libxslt": {
      "locked_version": "1.1.35",
      "locked_source": {
        "sha256": "8247f33e9a872c6ac859aa45018bc4c4d00b97e2feac9eebc10c93ce1f34dd79",
        "url": "https://artifactory-internal.ps.chef.co/artifactory/omnibus-software-local/libxslt/libxslt-1.1.35.tar.xz",
        "internal": true
      },
      "source_type": "url",
      "described_version": "1.1.35",
      "license": "MIT"
    },
```

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
