### PR TITLE
retry download without s3 cache flag if cache miss

### DIFF
--- a/lib/omnibus/cli.rb
+++ b/lib/omnibus/cli.rb
@@ -85,7 +85,13 @@ module Omnibus
       project = Project.load(name, manifest)
       say("Building #{project.name} #{project.build_version}...")
       Omnibus::S3Cache.populate if @options[:populate_s3_cache] && !Omnibus::S3Cache.fetch_missing.empty?
-      project.download
+      begin
+        project.download
+      rescue
+        Config.use_s3_caching(false) if Config.use_s3_caching
+        project = Project.load(name, nil)
+        project.download
+      end
       project.build
 
       if @options[:output_manifest]

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -611,7 +611,7 @@ module Omnibus
     # omnibus package using artifactory as the source url.
     #
     # @return [true, false]
-    default(:use_internal_sources, true)
+    default(:use_internal_sources, false)
 
     # --------------------------------------------------
     # @!endgroup

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -611,7 +611,7 @@ module Omnibus
     # omnibus package using artifactory as the source url.
     #
     # @return [true, false]
-    default(:use_internal_sources, false)
+    default(:use_internal_sources, true)
 
     # --------------------------------------------------
     # @!endgroup

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1062,7 +1062,10 @@ module Omnibus
     end
 
     def download
-      ThreadPool.new(Config.workers) do |pool|
+      # Setting abort_on_abort_on_exception to false because it was causing
+      # errors by shutting down the main thread when encountering a cache miss
+      # in S3 and falling back to the internal source repo
+      ThreadPool.new(Config.workers, false) do |pool|
         softwares.each do |software|
           pool.schedule { software.fetch }
         end

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -1062,7 +1062,7 @@ module Omnibus
     end
 
     def download
-      # Setting abort_on_abort_on_exception to false because it was causing
+      # Setting abort_on_exception to false because it was causing
       # errors by shutting down the main thread when encountering a cache miss
       # in S3 and falling back to the internal source repo
       ThreadPool.new(Config.workers, false) do |pool|

--- a/lib/omnibus/thread_pool.rb
+++ b/lib/omnibus/thread_pool.rb
@@ -46,14 +46,16 @@ module Omnibus
     #
     # @param [Integer] size
     #   the number of items to put in the thread pool
+    # @param [Boolean] abort_on_exception
+    #   if the thread should abort the main thread also on a failure
     #
-    def initialize(size)
+    def initialize(size, abort_on_exception = true)
       @size = size
       @jobs = Queue.new
 
       @pool = Array.new(@size) do |i|
         Thread.new do
-          Thread.abort_on_exception = true
+          Thread.abort_on_exception = abort_on_exception
           Thread.current[:id] = i
 
           catch(:exit) do


### PR DESCRIPTION
Signed-off-by: Justin Gruber <justin.gruber@progress.com>

### Description

Adds a flag in the Threadpool for supplying a configuration to `abort_on_exception`, it was previously always true but this caused errors when fetching the internal sources if S3 failed. Disabling this allows for fetching from Artifactory as a fallback instead of ending the full build, disabling it only in one location and keeping the default as true so it does not interfere with anything else using the threadpool

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
