### PR TITLE
adding this lib as a safe dependency to solve the error on an aix build

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -62,6 +62,7 @@ AIX_WHITELIST_LIBS = [
   /librtl\.a/,
   /libsrc\.a/,
   /unix$/,
+  /libcrypto.so/,
 ].freeze
 
 OMNIOS_WHITELIST_LIBS = [

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -62,7 +62,7 @@ AIX_WHITELIST_LIBS = [
   /librtl\.a/,
   /libsrc\.a/,
   /unix$/,
-  /libcrypto.so/,
+  /libcrypto\.so/,
 ].freeze
 
 OMNIOS_WHITELIST_LIBS = [


### PR DESCRIPTION
### Description

The error we are getting on our build AIX machines:

```
<html>
<body>
<!--StartFragment-->

--> /opt/chef/embedded/lib/libssl.so.1.0.0
--
  |  
  | [HealthCheck] E \| 2023-02-16T18:34:45-06:00 \| The following binaries have unsafe or unmet dependencies:
  |  
  | [HealthCheck] E \| 2023-02-16T18:34:45-06:00 \| The following libraries cannot be guaranteed to be on target systems:
  | --> /usr/lib/libcrypto.so
  |  
  | [HealthCheck] E \| 2023-02-16T18:34:45-06:00 \| The precise failures were:
  | --> /opt/chef/embedded/lib/engines/lib4758cca.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libaep.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libatalla.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libcapi.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libchil.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libcswift.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libgmp.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libgost.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libnuron.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libpadlock.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libsureware.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/engines/libubsec.so
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  | --> /opt/chef/embedded/lib/libssl.so.1.0.0
  | DEPENDS ON: /usr/lib/libcrypto.so
  | COUNT: 1
  | PROVIDED BY: /usr/lib/libcrypto.so
  | FAILED BECAUSE: Unsafe dependency
  |  
  | [HealthCheck] I \| 2023-02-16T18:34:45-06:00 \| Health check time: 22.9879s

<!--EndFragment-->
</body>
</html>
```

This should address the error and produce a valid build. 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan

