### PR TITLE
Fix Ruby 3.1 deprecation warning with ERB.new

### DIFF
--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -36,7 +36,7 @@ module Omnibus
     #   the list of variables to pass to the template
     #
     def render_template_content(source, variables = {})
-      template = ERB.new(File.read(source), nil, trim_mode: "-")
+      template = ERB.new(File.read(source), trim_mode: "-")
 
       struct =
         if variables.empty?

--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -36,7 +36,7 @@ module Omnibus
     #   the list of variables to pass to the template
     #
     def render_template_content(source, variables = {})
-      template = ERB.new(File.read(source), nil, "-")
+      template = ERB.new(File.read(source), nil, trim_mode: "-")
 
       struct =
         if variables.empty?

--- a/lib/omnibus/templating.rb
+++ b/lib/omnibus/templating.rb
@@ -37,7 +37,6 @@ module Omnibus
     #
     def render_template_content(source, variables = {})
       template = ERB.new(File.read(source), trim_mode: "-")
-
       struct =
         if variables.empty?
           Struct.new("Empty")


### PR DESCRIPTION
This eliminates the warning:

```
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

Per https://bugs.ruby-lang.org/issues/14256, `trim_mode` needs to be a keyword argument. This is compatible with Ruby 2.7 and on.

### Description

Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
