### PR TITLE
Update package signing condition to exclude el9 as well

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -448,7 +448,7 @@ module Omnibus
 
           # RHEL 8 has gpg-agent running so we can skip the expect script since the agent
           # takes care of the passphrase entering on the signing
-          if dist_tag != ".el8"
+          if dist_tag != ".el8" && dist_tag != ".el9"
             sign_cmd.prepend("#{signing_script} \"").concat("\"")
           end
 


### PR DESCRIPTION
### Description

The additional package signing arguments are not need for `el8` and above. 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
