### PR TITLE
[trivial] Fixed bad constant reference

### DIFF
--- a/lib/omnibus/builder.rb
+++ b/lib/omnibus/builder.rb
@@ -637,7 +637,7 @@ module Omnibus
     #
     def strip(path)
       regexp_ends = ".*(" + IGNORED_ENDINGS.map { |e| e.gsub(/\./, '\.') }.join("|") + ")$"
-      regexp_patterns = IGNORED_PATTERNS.map { |e| ".*" + e.gsub(%r{/}, '\/') + ".*" }.join("|")
+      regexp_patterns = IGNORED_SUBSTRINGS.map { |e| ".*" + e.gsub(%r{/}, '\/') + ".*" }.join("|")
       regexp = regexp_ends + "|" + regexp_patterns
 
       # Do not actually care if strip runs on non-strippable file, as its a no-op.  Hence the `|| true` appended.


### PR DESCRIPTION
### Description

In builder library's strip() function there is a reference to IGNORED_PATTERNS which was renamed to IGNORED_SUBSTRINGS in whitelist file. This bugfix updates the constant name to allow the strip() function to work.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
