### PR TITLE
Update gpg_name to fix RockyLinux rpm signing issue

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -437,7 +437,7 @@ module Omnibus
           render_template(resource_path("rpmmacros.erb"),
             destination: "#{home}/.rpmmacros",
             variables: {
-              gpg_name: project.maintainer,
+              gpg_name: "Opscode Packages",
               gpg_path: "#{ENV["HOME"]}/.gnupg", # TODO: Make this configurable
             })
         end


### PR DESCRIPTION
## Description

rpm package signing failed for RockyLinux with below error.
```Error:
warning: Could not set GPG_TTY to stdin: Inappropriate ioctl for device  gpg: skipped "Chef Software Inc": No secret key  gpg: signing failed: No secret key
```
--------------------------------------------------

### Maintainers

Please ensure that you check for:

- [x] If this change impacts git cache validity, it bumps the git cache
  serial number
- [x] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
