### PR TITLE
Update rocky - architecture

### DIFF
--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -44,6 +44,7 @@ module Omnibus
       "rhel" => RPM,
       "wrlinux" => RPM,
       "amazon" => RPM,
+      "rocky"  => RPM,
       "aix" => BFF,
       "solaris" => Solaris,
       "omnios" => IPS,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -441,7 +441,7 @@ module Omnibus
         command1 << %{cp}
         command1 << " #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm "
         command1 << " #{rpm_file}"
-        log.info(log_key) { " COMMAND1 : #{command1}"}
+        log.info(log_key) { " COMMAND1 : #{command1}" }
         shellout!("#{command1}")
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,10 +285,15 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      if dist_tag
-        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
+      plat = Ohai["platform"]
+      if plat == "rocky"
+        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
       else
-        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
+        if dist_tag
+          "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
+        else
+          "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
+        end
       end
     end
 
@@ -412,6 +417,7 @@ module Omnibus
     # @return [void]
     #
     def create_rpm_file
+      plat = Ohai["platform"]
       command =  %{rpmbuild}
       command << %{ --target #{safe_architecture}}
       command << %{ -bb}

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -442,7 +442,6 @@ module Omnibus
         command1 << " #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm "
         command1 << " #{rpm_file}"
         shellout!("#{command1}")
-        
       end
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -429,7 +429,7 @@ module Omnibus
       plat = Ohai["platform"]
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
-        rpm_file.gsub(".el8", "rocky.el8")
+        rpm_file.gsub("el8", "rocky.el8")
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file}" }
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -438,9 +438,11 @@ module Omnibus
       if Ohai["platform"] == "rocky"
         # rename rpm_file to rocky_rpm_file
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        command1 << %{mv}
+        log.info(log_key) { " CP #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm " }
+        command1 << %{cp}
         command1 << " #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm "
         command1 << " #{rpm_file}"
+        log.info(log_key) { " COMMAND1 : #{command1}"}
         shellout!("#{command1}")
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -287,7 +287,7 @@ module Omnibus
     def package_name
       plat = Ohai["platform"]
       if plat == "rocky"
-        package_name_old = #{package_name}
+        package_name_old = "#{package_name}"
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
       else
         if dist_tag

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -427,7 +427,7 @@ module Omnibus
       command << " #{spec_file}"
 
       plat = Ohai["platform"]
-      og.info(log_key) { "WITHIN create_rpm_file : SPEC_FILE :
+      log.info(log_key) { "WITHIN create_rpm_file : SPEC_FILE : " }
       log.info(log_key) { "WITHIN create_rpm_file SAFE_ARCHITECTURE : #{safe_architecture}" }
       log.info(log_key) { "with in create_rpm_file PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
       log.info(log_key) { "within create_rpm_file #{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,7 +285,6 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      plat = Ohai["platform"]
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
@@ -420,6 +419,7 @@ module Omnibus
       command << %{ --define '_topdir #{staging_dir}'}
       command << " #{spec_file}"
 
+      plat = Ohai["platform"]
       log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}" }
       log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
       log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -446,6 +446,12 @@ module Omnibus
             })
         end
 
+        plat = Ohai["platform"]
+        log.info(log_key) { "BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
+        if Ohai["platform"] == "rocky"
+          rpm_file.sub(".el8", "rocky.el8")
+          log.info(log_key) { "RPM FILE after replace : #{rpm_file}" }
+        end
         sign_cmd = "rpmsign --addsign #{rpm_file}"
         with_rpm_signing do |signing_script|
           log.info(log_key) { "Signing the built rpm file" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -225,7 +225,7 @@ module Omnibus
         @dist_tag = val
       end
       if Ohai["platform"] == "rocky" && dist_tag == ".el8"
-        dist_tag = "rocky-8"
+        @dist_tag = "rocky-8"
       end
     end
     expose :dist_tag

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -557,9 +557,7 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
-      if Ohai["platform"] == "rocky"
-        package_name.sub(".el8", "rocky.el8")
-      end
+      log.info(log_key) { "PLATFORM : Ohai["platform"] " }
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -558,7 +558,7 @@ module Omnibus
     #
     def safe_base_package_name
       if Ohai["platform"] == "rocky"
-        package_name.sub(".el8","rocky.el8")
+        package_name.sub(".el8", "rocky.el8")
       end
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -287,6 +287,7 @@ module Omnibus
     def package_name
       plat = Ohai["platform"]
       if plat == "rocky"
+         package_name_old = #{package_name}
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
       else
         if dist_tag
@@ -426,6 +427,7 @@ module Omnibus
       command << " #{spec_file}"
 
       plat = Ohai["platform"]
+      og.info(log_key) { "WITHIN create_rpm_file : SPEC_FILE :
       log.info(log_key) { "WITHIN create_rpm_file SAFE_ARCHITECTURE : #{safe_architecture}" }
       log.info(log_key) { "with in create_rpm_file PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
       log.info(log_key) { "within create_rpm_file #{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
@@ -435,8 +437,12 @@ module Omnibus
       plat = Ohai["platform"]
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
-        rpm_file.gsub("el8", "rocky.el8")
-        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file}" }
+        #rename rpm_file to rocky_rpm_file
+        temp_rpm_file = "/tmp/#{package_name_old}"
+        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} and old_file #{temp_rpm_file}" }
+        command1 << "mv #{temp_rpm_file} #{rpm_file}"
+        shellout!("#{command1}")
+        
       end
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -224,6 +224,9 @@ module Omnibus
       else
         @dist_tag = val
       end
+      if Ohai["platform"] == "rocky" && dist_tag == ".el8"
+        dist_tag = "rocky-8"
+      end
     end
     expose :dist_tag
 
@@ -285,9 +288,6 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      if Ohai["platform"] == "rocky" && dist_tag == "el8"
-        dist_tag = "rocky-8"
-      end
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,16 +285,14 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      plat = Ohai["platform"] 
+      plat = Ohai["platform"]
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
-        log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-        log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
-        log.info(log_key) { "PACKGAE PARAMS : SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION : SAFE_ARCH" }
-        log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}" }
       end
+      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
     end
 
     #

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -656,7 +656,7 @@ module Omnibus
           "armv6l"
         end
       else
-          Ohai["kernel"]["machine"]
+        Ohai["kernel"]["machine"]
       end
     end
   end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -429,7 +429,7 @@ module Omnibus
       plat = Ohai["platform"]
       log.info(log_key) { "BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
-        rpm_file.sub(".el8", "rocky.el8")
+        rpm_file.gsub(".el8", "rocky.el8")
         log.info(log_key) { "RPM FILE after replace : #{rpm_file}" }
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -500,6 +500,7 @@ module Omnibus
     # @return [String]
     #
     def spec_file
+      log.info(log_key) { "Within spec_file(502)  package name is :  #{package_name}" }
       "#{staging_dir}/SPECS/#{package_name}.spec"
     end
 
@@ -509,6 +510,7 @@ module Omnibus
     # @return [String]
     #
     def rpm_file
+      log.info(log_key) { "Within rpm_file(512)  package name is :  #{package_name}" }
       "#{staging_dir}/RPMS/#{safe_architecture}/#{package_name}"
     end
 
@@ -568,12 +570,6 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
-      plat = Ohai["platform"]
-      log.info(log_key) { "WITHin SFAE_PKG BEFORE REPLACE PLATFORM PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
-      if Ohai["platform"] == "rocky"
-        project.package_name.gsub(".el8", "rocky.el8")
-        log.info(log_key) { "WITHin SFAE_PKG PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
-      end
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -438,7 +438,6 @@ module Omnibus
       if Ohai["platform"] == "rocky"
         # rename rpm_file to rocky_rpm_file
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        log.info(log_key) { " CP #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm " }
         command1 << %{cp}
         command1 << " #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm "
         command1 << " #{rpm_file}"

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -287,7 +287,6 @@ module Omnibus
     def package_name
       plat = Ohai["platform"]
       if plat == "rocky"
-        package_name_old = "#{package_name}"
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
       else
         if dist_tag
@@ -438,9 +437,8 @@ module Omnibus
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
         # rename rpm_file to rocky_rpm_file
-        temp_rpm_file = "/tmp/#{package_name_old}"
-        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} and old_file #{temp_rpm_file}" }
-        command1 << "mv #{temp_rpm_file} #{rpm_file}"
+        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
+        command1 << "mv #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm" #{rpm_file}"
         shellout!("#{command1}")
         
       end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -419,6 +419,7 @@ module Omnibus
       command << %{ --define '_topdir #{staging_dir}'}
       command << " #{spec_file}"
 
+      log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}"}
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
 
@@ -652,7 +653,11 @@ module Omnibus
           "armv6l"
         end
       else
-        Ohai["kernel"]["machine"]
+        if Ohai["platform"] == "rocky"
+          "rocky"
+        else
+          Ohai["kernel"]["machine"]
+        end
       end
     end
   end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -293,7 +293,6 @@ module Omnibus
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
       end
-      
     end
 
     #

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -420,17 +420,17 @@ module Omnibus
       command << " #{spec_file}"
 
       plat = Ohai["platform"]
-      log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}" }
-      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
+      log.info(log_key) { "WITHIN create_rpm_file SAFE_ARCHITECTURE : #{safe_architecture}" }
+      log.info(log_key) { "with in create_rpm_file PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+      log.info(log_key) { "within create_rpm_file #{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
-      log.info(log_key) { "CREATED rpm file is  : #{rpm_file} " }
+      log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
       plat = Ohai["platform"]
-      log.info(log_key) { "BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
+      log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
         rpm_file.gsub(".el8", "rocky.el8")
-        log.info(log_key) { "RPM FILE after replace : #{rpm_file}" }
+        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file}" }
       end
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
@@ -563,10 +563,10 @@ module Omnibus
     #
     def safe_base_package_name
       plat = Ohai["platform"]
-      log.info(log_key) { "BEFORE REPLACE PLATFORM PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
+      log.info(log_key) { "WITHin SFAE_PKG BEFORE REPLACE PLATFORM PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
       if Ohai["platform"] == "rocky"
-        project.package_name.sub(".el8", "rocky.el8")
-        log.info(log_key) { "PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
+        project.package_name.gsub(".el8", "rocky.el8")
+        log.info(log_key) { "WITHin SFAE_PKG PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
       end
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,7 +285,7 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      if Ohai["platform"] == "rocky" and dist_tag == "el8"
+      if Ohai["platform"] == "rocky" && dist_tag == "el8"
         dist_tag = "rocky-8"
       end
       if dist_tag

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -219,14 +219,10 @@ module Omnibus
     #   the dist_tag for this package
     #
     def dist_tag(val = NULL)
-      if Ohai["platform"] == "rocky" && @dist_tag == ".el8"
-        @dist_tag = "rocky-8"
+      if null?(val)
+        @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
       else
-        if null?(val)
-          @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
-        else
-          @dist_tag = val
-        end
+        @dist_tag = val
       end
     end
     expose :dist_tag
@@ -561,6 +557,9 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
+      if Ohai["platform"] == "rocky"
+        package_name.sub(".el8","rocky.el8")
+      end
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -419,7 +419,7 @@ module Omnibus
       command << %{ --define '_topdir #{staging_dir}'}
       command << " #{spec_file}"
 
-      log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}"}
+      log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}" }
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -290,9 +290,6 @@ module Omnibus
     #
     def package_name
       if dist_tag
-        if dist_tag == ".el8" && Ohai["platform"] == "rocky"
-          dist_tag = "rocky-8"
-        end
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -287,8 +287,12 @@ module Omnibus
     def package_name
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
+        log.info(log_key) { "PACKGAE PARAMS : SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+        log.info(log_key) { "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
+        log.info(log_key) { "PACKGAE PARAMS : SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION : SAFE_ARCH" }
+        log.info(log_key) { "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}" }
       end
     end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -425,7 +425,13 @@ module Omnibus
       log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
-
+      log.info(log_key) { "CREATED rpm file is  : #{rpm_file} " }
+      plat = Ohai["platform"]
+      log.info(log_key) { "BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
+      if Ohai["platform"] == "rocky"
+        rpm_file.sub(".el8", "rocky.el8")
+        log.info(log_key) { "RPM FILE after replace : #{rpm_file}" }
+      end
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
 
@@ -444,13 +450,6 @@ module Omnibus
               gpg_name: "Opscode Packages",
               gpg_path: "#{ENV["HOME"]}/.gnupg", # TODO: Make this configurable
             })
-        end
-
-        plat = Ohai["platform"]
-        log.info(log_key) { "BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
-        if Ohai["platform"] == "rocky"
-          rpm_file.sub(".el8", "rocky.el8")
-          log.info(log_key) { "RPM FILE after replace : #{rpm_file}" }
         end
         sign_cmd = "rpmsign --addsign #{rpm_file}"
         with_rpm_signing do |signing_script|

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -557,7 +557,8 @@ module Omnibus
     # @return [String]
     #
     def safe_base_package_name
-      log.info(log_key) { "PLATFORM : Ohai["platform"] " }
+      plat = Ohai["platform"]
+      log.info(log_key) { "PLATFORM : #{plat} " }
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -438,7 +438,9 @@ module Omnibus
       if Ohai["platform"] == "rocky"
         # rename rpm_file to rocky_rpm_file
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        command1 << "mv #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm" #{rpm_file}"
+        command1 << %{mv}
+        command1 << " #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm "
+        command1 << " #{rpm_file}"
         shellout!("#{command1}")
         
       end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -558,7 +558,11 @@ module Omnibus
     #
     def safe_base_package_name
       plat = Ohai["platform"]
-      log.info(log_key) { "PLATFORM : #{plat} " }
+      log.info(log_key) { "BEFORE REPLACE PLATFORM PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
+      if Ohai["platform"] == "rocky"
+        project.package_name.sub(".el8", "rocky.el8")
+        log.info(log_key) { "PLATFORM : #{plat}  PACKAGE_NAME : #{project.package_name}" }
+      end
       if project.package_name =~ /\A[a-z0-9\.\+\-]+\z/
         project.package_name.dup
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -219,7 +219,7 @@ module Omnibus
     #   the dist_tag for this package
     #
     def dist_tag(val = NULL)
-      if Ohai["platform"] == "rocky" && dist_tag == ".el8"
+      if Ohai["platform"] == "rocky" && @dist_tag == ".el8"
         @dist_tag = "rocky-8"
       else
         if null?(val)
@@ -290,6 +290,9 @@ module Omnibus
     #
     def package_name
       if dist_tag
+        if dist_tag == ".el8" && Ohai["platform"] == "rocky"
+          dist_tag = "rocky-8"
+        end
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,14 +285,15 @@ module Omnibus
     # @return [String]
     #
     def package_name
+      plat = Ohai["platform"] 
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
-        log.info(log_key) { "PACKGAE PARAMS : SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-        log.info(log_key) { "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
+        log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+        log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
         log.info(log_key) { "PACKGAE PARAMS : SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION : SAFE_ARCH" }
-        log.info(log_key) { "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}" }
+        log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}" }
       end
     end
 
@@ -657,11 +658,7 @@ module Omnibus
           "armv6l"
         end
       else
-        if Ohai["platform"] == "rocky"
-          "rocky"
-        else
           Ohai["kernel"]["machine"]
-        end
       end
     end
   end

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -219,13 +219,14 @@ module Omnibus
     #   the dist_tag for this package
     #
     def dist_tag(val = NULL)
-      if null?(val)
-        @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
-      else
-        @dist_tag = val
-      end
       if Ohai["platform"] == "rocky" && dist_tag == ".el8"
         @dist_tag = "rocky-8"
+      else
+        if null?(val)
+          @dist_tag || ".#{Omnibus::Metadata.platform_shortname}#{Omnibus::Metadata.platform_version}"
+        else
+          @dist_tag = val
+        end
       end
     end
     expose :dist_tag

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,6 +285,9 @@ module Omnibus
     # @return [String]
     #
     def package_name
+      if Ohai["platform"] == "rocky" and dist_tag == "el8"
+        dist_tag = "rocky-8"
+      end
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -287,7 +287,7 @@ module Omnibus
     def package_name
       plat = Ohai["platform"]
       if plat == "rocky"
-         package_name_old = #{package_name}
+        package_name_old = #{package_name}
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
       else
         if dist_tag
@@ -437,7 +437,7 @@ module Omnibus
       plat = Ohai["platform"]
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
-        #rename rpm_file to rocky_rpm_file
+        # rename rpm_file to rocky_rpm_file
         temp_rpm_file = "/tmp/#{package_name_old}"
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} and old_file #{temp_rpm_file}" }
         command1 << "mv #{temp_rpm_file} #{rpm_file}"

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -286,13 +286,14 @@ module Omnibus
     #
     def package_name
       plat = Ohai["platform"]
+      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
       end
-      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
+      
     end
 
     #

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -286,8 +286,6 @@ module Omnibus
     #
     def package_name
       plat = Ohai["platform"]
-      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       if dist_tag
         "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
@@ -423,6 +421,8 @@ module Omnibus
       command << " #{spec_file}"
 
       log.info(log_key) { "SAFE_ARCHITECTURE : #{safe_architecture}" }
+      log.info(log_key) { "PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
+      log.info(log_key) { "#{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
 


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here
Rocky-Linux package is creating as el-8 instead of rocky. Hence updating the safe-architecture to detect rocky.
--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
