### PR TITLE
Rename RockyLinux_pkg 

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -145,7 +145,11 @@ module Omnibus
       #
       def platform_shortname
         if rhel?
-          "el"
+          if "rocky" == Ohai["platform"]
+            "rocky"
+          else
+            "el"
+          end
         elsif suse?
           "sles"
         else

--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -174,7 +174,7 @@ module Omnibus
       # rubocop:disable Lint/DuplicateCaseCondition
       def truncate_platform_version(platform_version, platform)
         case platform
-        when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos"
+        when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "rocky", "sles", "suse", "smartos"
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split(".").first
         when "aix", "alpine", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"

--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -44,6 +44,7 @@ module Omnibus
       "rhel" => RPM,
       "wrlinux" => RPM,
       "amazon" => RPM,
+      "rocky"  => RPM,
       "aix" => BFF,
       "solaris" => Solaris,
       "omnios" => IPS,

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -429,7 +429,7 @@ module Omnibus
 
       if Ohai["platform"] == "rocky"
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        rpm_file.gsub! "#{dist_tag}", rocky.el8'
+        rpm_file.gsub! "#{dist_tag}", "rocky.el8"
         log.info(log_key) {"Copied the old_rpm content to new_rpm_file"}
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -418,14 +418,8 @@ module Omnibus
       command << %{ --buildroot #{staging_dir}/BUILD}
       command << %{ --define '_topdir #{staging_dir}'}
       command << " #{spec_file}"
-
-      plat = Ohai["platform"]
-      log.info(log_key) { "with in create_rpm_file PACKGAE PARAMS : PLATFORM SAFE_BASE_PKG_NAME : SAFE_VER : SFAE_BUILD_ITERATION  : DIST_TAG : : SAFE_ARCH" }
-      log.info(log_key) { "within create_rpm_file #{plat} : #{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}" }
       log.info(log_key) { "Creating .rpm file" }
       shellout!("#{command}")
-      log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
-      log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
 
@@ -488,7 +482,6 @@ module Omnibus
     # @return [String]
     #
     def spec_file
-      log.info(log_key) { "Within spec_file(502)  package name is :  #{package_name}" }
       "#{staging_dir}/SPECS/#{package_name}.spec"
     end
 
@@ -498,7 +491,6 @@ module Omnibus
     # @return [String]
     #
     def rpm_file
-      log.info(log_key) { "Within rpm_file(512)  package name is :  #{package_name}" }
       "#{staging_dir}/RPMS/#{safe_architecture}/#{package_name}"
     end
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -429,7 +429,7 @@ module Omnibus
 
       if Ohai["platform"] == "rocky"
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        rpm_file.gsub! 'el8', 'rocky.el8'
+        rpm_file.gsub! "#{dist_tag}", rocky.el8'
         log.info(log_key) {"Copied the old_rpm content to new_rpm_file"}
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -426,12 +426,7 @@ module Omnibus
       shellout!("#{command}")
       log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
-
-      if Ohai["platform"] == "rocky"
-        log.info(log_key) { "within create_rpm_file RPM FILE before  replace : #{rpm_file} " }
-        rpm_file.gsub! "#{dist_tag}", "rocky.el8"
-        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-      end
+      
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -432,10 +432,8 @@ module Omnibus
       log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
       if Ohai["platform"] == "rocky"
-        # rename rpm_file to rocky_rpm_file
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        copy_file("#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm")
-        copy_file#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm", #{rpm_file})
+        copy_file("#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm", #{rpm_file} )
         log.info(log_key) {"Copied the old_rpm content to new_rpm_file"}
       end
       if signing_passphrase

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -426,7 +426,6 @@ module Omnibus
       shellout!("#{command}")
       log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
-      
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }
 

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -428,9 +428,9 @@ module Omnibus
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
 
       if Ohai["platform"] == "rocky"
-        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
+        log.info(log_key) { "within create_rpm_file RPM FILE before  replace : #{rpm_file} " }
         rpm_file.gsub! "#{dist_tag}", "rocky.el8"
-        log.info(log_key) {"Copied the old_rpm content to new_rpm_file"}
+        log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
       end
       if signing_passphrase
         log.info(log_key) { "Signing enabled for .rpm file" }

--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -285,15 +285,10 @@ module Omnibus
     # @return [String]
     #
     def package_name
-      plat = Ohai["platform"]
-      if plat == "rocky"
-        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{plat}#{dist_tag}.#{safe_architecture}.rpm"
+      if dist_tag
+        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
       else
-        if dist_tag
-          "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm"
-        else
-          "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
-        end
+        "#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}.#{safe_architecture}.rpm"
       end
     end
 
@@ -431,9 +426,10 @@ module Omnibus
       shellout!("#{command}")
       log.info(log_key) { "within create_rpm_file CREATED rpm file is  : #{rpm_file} " }
       log.info(log_key) { "within create_rpm_file BEFORE REPLACE RPM FILE : #{plat}  RPM FILE : #{rpm_file} " }
+
       if Ohai["platform"] == "rocky"
         log.info(log_key) { "within create_rpm_file RPM FILE after replace : #{rpm_file} " }
-        copy_file("#{safe_base_package_name}-#{safe_version}-#{safe_build_iteration}#{dist_tag}.#{safe_architecture}.rpm", #{rpm_file} )
+        rpm_file.gsub! 'el8', 'rocky.el8'
         log.info(log_key) {"Copied the old_rpm content to new_rpm_file"}
       end
       if signing_passphrase


### PR DESCRIPTION
### Description
Briefly describe the new feature or fix here
Rocky-Linux package is creating as el-8 instead of rocky. Hence updating the safe-architecture to detect rocky.
Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
