### PR TITLE
Update metadata with rocky platform

### DIFF
--- a/lib/omnibus/metadata.rb
+++ b/lib/omnibus/metadata.rb
@@ -145,7 +145,11 @@ module Omnibus
       #
       def platform_shortname
         if rhel?
-          "el"
+          if "rocky" == Ohai["platform"]
+            "rocky"
+          else
+            "el"
+          end
         elsif suse?
           "sles"
         else
@@ -170,7 +174,7 @@ module Omnibus
       # rubocop:disable Lint/DuplicateCaseCondition
       def truncate_platform_version(platform_version, platform)
         case platform
-        when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "sles", "suse", "smartos"
+        when "centos", "cumulus", "debian", "el", "fedora", "freebsd", "omnios", "pidora", "raspbian", "rhel", "rocky", "sles", "suse", "smartos"
           # Only want MAJOR (e.g. Debian 7, OmniOS r151006, SmartOS 20120809T221258Z)
           platform_version.split(".").first
         when "aix", "alpine", "openbsd", "slackware", "solaris2", "opensuse", "opensuseleap", "ubuntu", "amazon"

--- a/lib/omnibus/packager.rb
+++ b/lib/omnibus/packager.rb
@@ -44,6 +44,7 @@ module Omnibus
       "rhel" => RPM,
       "wrlinux" => RPM,
       "amazon" => RPM,
+      "rocky"  => RPM,
       "aix" => BFF,
       "solaris" => Solaris,
       "omnios" => IPS,


### PR DESCRIPTION
### Description

Packages built on rocky were created as <projetc><version>.el8.<architecture>.rpm  
Update platform, platform_shortname in metadata.rb 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
