### PR TITLE
Make RPM packaging use threaded compression

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -401,7 +401,7 @@ module Omnibus
                          else # default to gzip
                            "gzdio"
                          end
-      "w#{compression_level}.#{compression_name}"
+      "w#{compression_level}T.#{compression_name}"
     end
 
     #

--- a/spec/unit/packagers/rpm_spec.rb
+++ b/spec/unit/packagers/rpm_spec.rb
@@ -215,7 +215,7 @@ module Omnibus
         expect(contents).to include("URL: https://example.com")
         expect(contents).to include("Packager: Chef Software")
         expect(contents).to include("Obsoletes: old-project")
-        expect(contents).to include("_binary_payload w9.gzdio")
+        expect(contents).to include("_binary_payload w9T.gzdio")
       end
 
       context "when RPM compression type xz is configured" do
@@ -226,7 +226,7 @@ module Omnibus
         it "has the correct binary_payload line" do
           subject.write_rpm_spec
           contents = File.read(spec_file)
-          expect(contents).to include("_binary_payload w9.xzdio")
+          expect(contents).to include("_binary_payload w9T.xzdio")
         end
 
         context "when RPM compression level is also configured" do
@@ -237,7 +237,7 @@ module Omnibus
           it "has the correct binary_payload line" do
             subject.write_rpm_spec
             contents = File.read(spec_file)
-            expect(contents).to include("_binary_payload w6.xzdio")
+            expect(contents).to include("_binary_payload w6T.xzdio")
           end
         end
       end
@@ -250,7 +250,7 @@ module Omnibus
         it "has the correct binary_payload line" do
           subject.write_rpm_spec
           contents = File.read(spec_file)
-          expect(contents).to include("_binary_payload w9.bzdio")
+          expect(contents).to include("_binary_payload w9T.bzdio")
         end
 
         context "when RPM compression level is also configured" do
@@ -261,7 +261,7 @@ module Omnibus
           it "has the correct binary_payload line" do
             subject.write_rpm_spec
             contents = File.read(spec_file)
-            expect(contents).to include("_binary_payload w6.bzdio")
+            expect(contents).to include("_binary_payload w6T.bzdio")
           end
         end
       end


### PR DESCRIPTION
### Description

Because we set `_binary_payload` on RPM packages, we override the selection of compression algorithm defaults; in this case, we specifically choose a non-threaded compression mode. Unfortunately, this means that compression with any compression algorithm other than GZip can take a very long time. Debian packages, on the other hand, use threaded compression modes by default.

This change forces `_binary_payload` to use threaded compression modes when selecting an algorithm and compression level.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [X] If this change impacts git cache validity, it bumps the git cache
  serial number
- [X] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [X] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan