### PR TITLE
Whitelist libnghttp2

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -172,6 +172,7 @@ MAC_WHITELIST_LIBS = [
   /libc\+\+\.1\.dylib/,
   /libc\+\+\.1\.dylib/,
   /libzstd\.1\.dylib/,
+  /libnghttp2\.14\.dylib/,
   /Security/,
   /SystemConfiguration/,
 ].freeze


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

To fix the chef-workstation vulnerabilities, we have added new versions of some of the packages on https://github.com/chef/omnibus-software/pull/1831. 

We have to whitelist libnghttp2 for the Mac OS as it was a dependency when we added Curl v8.4.0.

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
