### PR TITLE
Truncate `depend fmri` version specifiers to allow Solaris install flexibility

### DIFF
--- a/lib/omnibus/packagers/ips.rb
+++ b/lib/omnibus/packagers/ips.rb
@@ -292,7 +292,10 @@ module Omnibus
       shellout!("pkgdepend generate -md #{source_dir} #{pkg_manifest_file}.2 | pkgfmt > #{pkg_manifest_file}.3")
       shellout!("pkgmogrify -DARCH=`uname -p` #{pkg_manifest_file}.3 #{transform_file} | pkgfmt > #{pkg_manifest_file}.4")
       shellout!("pkgdepend resolve -m #{pkg_manifest_file}.4")
-      shellout!("pkgmogrify #{pkg_manifest_file}.4.res #{versionlock_file} > #{pkg_manifest_file}.5.res")
+      # extra step added to truncate bash and other version requirements that may cause conflicts on
+      # Solaris patch versions slightly older than the OS that the build is running on.
+      shellout!("pkgmogrify -DARCH=`uname -p` #{pkg_manifest_file}.4.res #{transform_file} | pkgfmt > #{pkg_manifest_file}.4.res-transformed")
+      shellout!("pkgmogrify #{pkg_manifest_file}.4.res-transformed #{versionlock_file} > #{pkg_manifest_file}.5.res")
     end
 
     #

--- a/resources/ips/doc-transform.erb
+++ b/resources/ips/doc-transform.erb
@@ -1,4 +1,7 @@
 <transform dir path=<%= pathdir %>$ -> edit group bin sys>
+<transform dir path=<%= pathdir %>$ -> edit group bin sys>
+<transform depend fmri=pkg:/shell -> edit fmri '@.+' ''>
+<transform depend fmri=pkg:/system -> edit fmri '@.+' ''>
 <transform file depend -> edit pkg.debug.depend.file ruby env>
 <transform file depend -> edit pkg.debug.depend.file make env>
 <transform file depend -> edit pkg.debug.depend.file perl env>

--- a/spec/unit/packagers/ips_spec.rb
+++ b/spec/unit/packagers/ips_spec.rb
@@ -246,7 +246,9 @@ module Omnibus
         expect(subject).to receive(:shellout!)
           .with("pkgdepend resolve -m #{staging_dir}/project.p5m.4")
         expect(subject).to receive(:shellout!)
-          .with("pkgmogrify #{staging_dir}/project.p5m.4.res #{staging_dir}/version-lock > #{staging_dir}/project.p5m.5.res")
+          .with("pkgmogrify -DARCH=`uname -p` #{staging_dir}/project.p5m.4.res #{staging_dir}/doc-transform | pkgfmt > #{staging_dir}/project.p5m.4.res-transformed")
+        expect(subject).to receive(:shellout!)
+          .with("pkgmogrify #{staging_dir}/project.p5m.4.res-transformed #{staging_dir}/version-lock > #{staging_dir}/project.p5m.5.res")
         subject.generate_pkg_deps
       end
     end


### PR DESCRIPTION
## Description

Installing a package built on Solaris 5.11 11.4.45.119.2 was uninstallable on Solaris  5.11 11.4.36.101.2 due to bash 5.1.16 being a `pkgdepend resolve`d requirement for bash, while 5.11 11.4.45.119.2 has at max bash 5.1.8 available to it. Recommended practice [per this discussion](https://forums.oracle.com/ords/apexds/post/while-packaging-is-there-a-way-to-circumvent-that-pkgdepend-6809) is to either build on the oldest possible operating system that you will support or use [`transform`](https://docs.oracle.com/cd/E26502_01/html/E21383/xformrules.html) to remove the version tag from the `depend` directive in the manifest.

### The Problem
#### Error output example
```
pkg install: No matching version of developer/versioning/chef can be installed:
  Reject:  pkg://Omnibus/developer/versioning/chef@18.3.64-1
  Reason:  No version matching 'require' dependency shell/bash@5.1.16-11.4.45.0.1.119.0 can be installed
    ----------------------------------------
    Reject:  pkg://solaris/shell/bash@5.1.16-11.4.45.0.1.119.0
    Reason:  No version matching 'require' dependency library/ncurses@6.3-11.4.45.0.0.117.0 can be installed
      ----------------------------------------
      Reject:  pkg://solaris/library/ncurses@6.3-11.4.45.0.1.119.0
      Reason:  No version matching 'require' dependency shell/bash@5.1.16-11.4.45.0.0.117.0 can be installed
        ----------------------------------------
        Reject:  pkg://solaris/shell/bash@5.1.16-11.4.48.0.1.126.0
        Reason:  No version matching 'require' dependency system/library@11.4-11.4.48.0.0.124.0 can be installed
          ----------------------------------------
          Reject:  pkg://solaris/system/library@11.4-11.4.48.0.1.126.1
          Reason:  No version matching 'require' dependency system/library/ldap@11.4-11.4.48.0.1.126 can be installed
            ----------------------------------------
            Reject:  pkg://solaris/system/library/ldap@11.4-11.4.48.0.1.126.1
            Reason:  No version matching 'require' dependency system/library/pam-core@11.4-11.4.48.0.1.126 can be installed
              ----------------------------------------
              Reject:  pkg://solaris/system/library/pam-core@11.4-11.4.48.0.1.126.1
              Reason:  No version matching 'require' dependency system/library/libc@11.4-11.4.48.0.1.126 can be installed
```

#### Root cause

Root cause for this is error is the `pkgdepend resolve -m` call in `ips.rb#generate_pkg_deps`:
```
shellout!("pkgdepend resolve -m #{pkg_manifest_file}.4")
```

Which generates the following `depend fmri` requirements:
```
depend fmri=pkg:/shell/bash@5.1.16-11.4.45.0.1.119.0 type=require
depend fmri=pkg:/shell/ksh93@93.21.1.20120801-11.4.45.0.1.119.0 type=require
depend fmri=pkg:/system/core-os@11.4-11.4.45.0.1.119.3 type=require
depend fmri=pkg:/system/library/gcc/gcc-c-runtime@11.2.0-11.4.45.0.1.119.0 type=require
depend fmri=pkg:/system/library/libc@11.4-11.4.45.0.1.119.3 type=require
depend fmri=pkg:/system/library/math@11.4-11.4.0.1.0.17.0 type=require
depend fmri=pkg:/system/library/security/crypto@11.4-11.4.45.0.1.119.3 type=require
depend fmri=pkg:/system/library@11.4-11.4.45.0.1.119.3 type=require
depend fmri=pkg:/system/linker@11.4-11.4.45.0.1.119.3 type=require
```

### The changes

#### Explanation of strategy
A depend directive appears as the following:
```
depend fmri=pkg:/shell/bash@5.1.16-11.4.45.0.1.119.0 type=require
^      ^                                             ^
|      |                                             |
|      +-attribute                                   +-attribute
+- action
```

The can be transformed using:
```
<transform depend fmri=pkg:/shell/bash -> edit fmri '@.+' ''>
 ^         ^      ^                    ^       ^     ^    ^
 |         |      |                    |       |     |    +-replacement string
 |         |      |                    |       |     | 
 |         |      |                    |       |     +-match regex
 |         |      |                    |       |     
 |         |      |                    |       +-name of attribute to modify
 |         |      |                    |       
 |         |      |                    +- matching-criteria / operation separator
 |         |      |                   
 |         |      +-"attribute=<value-regexp>" matching criteria
 |         |      
 |         +-"action-type matching criteria
 |         
 +- transform directive
```

Resulting in the following directive, with the version removed.
```
depend facet.version-lock.*>=false fmri=pkg:/shell/bash type=require
```

Since the attribute matching criteria is a regex, the transforms added can be reduced from:
```
<transform depend fmri=pkg:/shell/bash -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/shell/ksh93 -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/core-os -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/library/libc -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/library/math -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/library/security/crypto -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/library -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system/linker -> edit fmri '@.+' ''>
```

to:
```
<transform depend fmri=pkg:/shell -> edit fmri '@.+' ''>
<transform depend fmri=pkg:/system -> edit fmri '@.+' ''>
```

*Caveat:* the above transform risks truncating more than aforementioned `depend` requirements, but currently the main problem is requirements being _too strict_, and we do not separately specify the OS packages included.

#### Additional `pkgmogrify` step added:
Because `pkgdepend resolve` is the step added the strict package versions, we need to insert a step to `pkgmogrify` them out. The prior `pkgmogrify` step has been left intact since the `dir` and `file` transforms are likely important to have happen earlier.

```ruby
shellout!("pkgmogrify -DARCH=`uname -p` #{pkg_manifest_file}.4.res #{transform_file} | pkgfmt > #{pkg_manifest_file}.4.res-transformed")
shellout!("pkgmogrify #{pkg_manifest_file}.4.res-transformed #{versionlock_file} > #{pkg_manifest_file}.5.res")
```

## Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
