### PR TITLE
Updating license_scout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   ignore:
   - dependency-name: license_scout
     versions:
-    - "> 1.0"
+    - "= 1.3.8"
   - dependency-name: aruba
     versions:
     - 1.0.0

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "ohai",             ">= 16", "< 19"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
-  gem.add_dependency "license_scout",    "~> 1.0"
+  gem.add_dependency "license_scout",    "~> 1.3.8"
   gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
   gem.add_dependency "rexml",            "~> 3.2"
 


### PR DESCRIPTION
### Description

License scout got nuked (broken) by some updates to ruby gems. Muthuja corrected that in license_scout v1.3.8. I am forcing omnibus, and downstream, chef, to pick up that new version. 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
