### PR TITLE
Remove ruby 2.7 support

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,13 +10,6 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7-buster
 
 - label: run-lint-and-specs-ruby-3.0
   command:

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -32,6 +32,10 @@ Gem::Specification.new do |gem|
   gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
   gem.add_dependency "rexml",            "~> 3.2"
 
+  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
+    gem.add_dependency "ffi", "< 1.17.0"
+  end
+
   gem.add_dependency "mixlib-versioning"
   gem.add_dependency "pedump"
 

--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
 
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
     gem.add_dependency "ffi", "< 1.17.0"
+    gem.add_dependency "train-core", "< 3.12.5"
   end
 
   gem.add_dependency "mixlib-versioning"


### PR DESCRIPTION
### Description
Remove ruby 2.7 
Update  ffi  and  train-core dependency with respect to ruby-version

Error 
ffi-1.17.0-x86_64-linux-gnu requires rubygems version >= 3.3.22, which is
--
  | incompatible with the current version, 3.2.33
  | 🚨 Error: The command exited with status 1


train-core-3.12.5 requires ruby version >= 3.1, which is incompatible with the
--
  | current version, ruby 3.0.7p220
  | 🚨 Error: The command exited with status 1


Briefly describe the new feature or fix here

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
