### PR TITLE
Modify spec file - unpin train-core

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |gem|
 
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
     gem.add_dependency "ffi", "< 1.17.0"
-    gem.add_dependency "train-core", "< 3.12.5"
   end
 
   gem.add_dependency "mixlib-versioning"


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

--------------------------------------------------
The latest version of the train-core gem (3.12.6) includes a fix for the issue present in version 3.12.5. We need to revert the changes made to pin the version for Ruby <= 3.1 in the omnibus and omnibus-software repositories.
Current Configuration:
if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
s.add_dependency "train-core", "<3.12.5"

train-core version 3.12.6 requires Ruby version >= 2.7.
train-core version 3.12.5 required Ruby version >= 3.1.
Hence Revert the pinned train-core version changes for Ruby <= 3.1 

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
