### PR TITLE
Whitelist libatomic to fix keydb linking issue

### DIFF
--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -17,6 +17,7 @@
 WHITELIST_LIBS = [
     /ld-linux/,
     /libanl\.so/,
+    /libatomic\.so/,
     /libc\.so/,
     /libcrypt\.so/,
     /libdl/,
@@ -35,6 +36,7 @@ WHITELIST_LIBS = [
 
 ARCH_WHITELIST_LIBS = [
   /libanl\.so/,
+  /libatomic\.so/,
   /libc\.so/,
   /libcrypt\.so/,
   /libdb-5\.3\.so/,
@@ -69,6 +71,7 @@ OMNIOS_WHITELIST_LIBS = [
   /libc\.so\.1/,
   /libcrypt\./,
   /libcrypt\.so\.1/,
+  /libatomic\.so/,
   /libdl\.so\.1/,
   /libgcc_s\.so\.1/,
   /libgen\.so\.1/,


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here

--------------------------------------------------
Health check failed for Keydb
```
[HealthCheck] E | 2024-08-01T15:13:22+00:00 | The precise failures were:

    --> /opt/opscode/embedded/bin/keydb-server

    DEPENDS ON: libatomic.so.1

      COUNT: 1

      PROVIDED BY: /lib64/libatomic.so.1 (0x00007f8d50175000)

      FAILED BECAUSE: Unsafe dependency

    --> /opt/opscode/embedded/bin/keydb-benchmark

    DEPENDS ON: libatomic.so.1

      COUNT: 1

      PROVIDED BY: /lib64/libatomic.so.1 (0x00007f5472935000)

      FAILED BECAUSE: Unsafe dependency

    --> /opt/opscode/embedded/bin/keydb-cli

    DEPENDS ON: libatomic.so.1

      COUNT: 1

      PROVIDED BY: /lib64/libatomic.so.1 (0x00007f59ac42a000)

      FAILED BECAUSE: Unsafe dependency
```
Log : https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/6513#01910e3a-5fc0-4154-be97-72a6242e73f2/6-16593

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
