### PR TITLE
omnibus/cli: only match override value against regex for strings

### DIFF
--- a/lib/omnibus/cli/base.rb
+++ b/lib/omnibus/cli/base.rb
@@ -69,9 +69,7 @@ module Omnibus
         if %w{true false nil}.include?(value)
           log.debug(log_key) { "Detected #{value.inspect} should be an object" }
           value = { "true" => true, "false" => false, "nil" => nil }[value]
-        end
-
-        if value =~ /\A[[:digit:]]+\Z/
+        elsif value =~ /\A[[:digit:]]+\Z/
           log.debug(log_key) { "Detected #{value.inspect} should be an integer" }
           value = value.to_i
         end


### PR DESCRIPTION
### Description

As of Ruby 3.2, `true =~ /regex/` raises an exception (a NoMethodError for `=~`) instead of returning `nil` (seen in 3.1 and earlier), so using `--override key:true` (and false / nil) fails with an error. Instead of always comparing value against a regular expression, only do it if the value didn't match a known true/false/nil value.

This appears to stem from <https://bugs.ruby-lang.org/issues/15231>.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
