### PR TITLE
Fix `undefined method '=~' for false (NoMethodError)`

### DIFF
--- a/lib/omnibus/cli/base.rb
+++ b/lib/omnibus/cli/base.rb
@@ -69,9 +69,7 @@ module Omnibus
         if %w{true false nil}.include?(value)
           log.debug(log_key) { "Detected #{value.inspect} should be an object" }
           value = { "true" => true, "false" => false, "nil" => nil }[value]
-        end
-
-        if value =~ /\A[[:digit:]]+\Z/
+        elsif value =~ /\A[[:digit:]]+\Z/
           log.debug(log_key) { "Detected #{value.inspect} should be an integer" }
           value = value.to_i
         end


### PR DESCRIPTION
### Description

When providing a boolean override in the cli, omnibus will crash due to multi-staged casting.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
