### PR TITLE
whitelist libatomic to fix el-7ppc64 error in chef-foundation

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -11,13 +11,13 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0-buster
+# - label: run-lint-and-specs-ruby-3.0
+#   command:
+#     - .expeditor/run_linux_tests.sh rake
+#   expeditor:
+#     executor:
+#       docker:
+#         image: ruby:3.0-buster
 
 - label: run-lint-and-specs-ruby-3.1
   command:

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -1,4 +1,5 @@
 
+
 # Copyright:: Copyright (c) Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -556,7 +557,20 @@ module Omnibus
                        when "aix"
                          AIX_WHITELIST_LIBS
                        else
-                         WHITELIST_LIBS
+                         # custom condition for el-7ppc64
+                         # on chef-foundation/omnibus#el-7ppc64 is failing on health check
+                         # because of the libatomic.so.1 dependency
+                         # which is not available on ppc64 architecture
+                         # so we need to add it to the whitelist
+                         # for el-7ppc64 architecture
+                         # ref: https://buildkite.com/chef/chef-chef-foundation-main-omnibus-adhoc/builds/906#019850fd-0020-442e-890d-2a4795307622/7-15544
+                         if node["platform"] == "el" || node["platform"] == "redhat" || node["platform"] == "centos" &&
+                             node["platform_version"].start_with?("7") &&
+                             node["kernel"]["machine"] == "ppc64"
+                           EL7PPC64_WHITELIST_LIBS
+                         else
+                           WHITELIST_LIBS
+                         end
                        end
 
       whitelist_libs.each do |reg|

--- a/lib/omnibus/whitelist.rb
+++ b/lib/omnibus/whitelist.rb
@@ -48,6 +48,26 @@ ARCH_WHITELIST_LIBS = [
   /libutil\.so/,
 ].freeze
 
+EL7PPC64_WHITELIST_LIBS = [
+    /libatomic\.so/,
+    /ld-linux/,
+    /libanl\.so/,
+    /libc\.so/,
+    /libcrypt\.so/,
+    /libdl/,
+    /libfreebl\d\.so/,
+    /libgcc_s\.so/,
+    /libm\.so/,
+    /libnsl\.so/,
+    /libpthread/,
+    /libresolv\.so/,
+    /librt\.so/,
+    /libstdc\+\+\.so/,
+    /libutil\.so/,
+    /linux-vdso.+/,
+    /linux-gate\.so/,
+].freeze
+
 AIX_WHITELIST_LIBS = [
   /libc\.a/,
   /libcfg\.a/,


### PR DESCRIPTION
### Description


in one of the chef-foundation build el-7ppc64 platform is failing due to below error https://buildkite.com/chef/chef-chef-foundation-main-omnibus-adhoc/builds/906#019850fd-0020-442e-890d-2a4795307622/7-15544

`


```
[HealthCheck] E \| 2025-07-28T08:55:28-04:00 \| The following libraries cannot be guaranteed to be on target systems:
  | --> /lib/libatomic.so.1 (0x6fe10000)
  |  
  | [HealthCheck] E \| 2025-07-28T08:55:28-04:00 \| The precise failures were:
  | --> /opt/chef/embedded/lib/ossl-modules/fips.so
  | DEPENDS ON: libatomic.so.1
  | COUNT: 1
  | PROVIDED BY: /lib/libatomic.so.1 (0x6fe10000)
  | FAILED BECAUSE: Unsafe dependency
  |  
```

<br class="Apple-interchange-newline">`
--------------------------------------------------

- in order to fix this we have to add libatomic.so.1 in whitelist.rb file , since only single platform needed making a conditional statement for el-7ppc64 and make sure rest of them are excluded .
- Also removing 3.0 ruby tests since its outdated

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
