### PR TITLE
attempting to configure a s3 private acl setting

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -338,6 +338,12 @@ module Omnibus
     # @return [true, false]
     default(:s3_accelerate, false)
 
+
+    # The ACL to use when uploading objects to S3.
+    #
+    # @return [String]
+    default(:s3_acl, "private")
+
     # --------------------------------------------------
     # @!endgroup
     #

--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -338,7 +338,6 @@ module Omnibus
     # @return [true, false]
     default(:s3_accelerate, false)
 
-
     # The ACL to use when uploading objects to S3.
     #
     # @return [String]

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -119,7 +119,7 @@ module Omnibus
     # @return [String]
     #
     def downloaded_file
-      # filename = source[:cached_name] if source[:cached_name]
+      filename = source[:cached_name] if source[:cached_name]
       filename ||= File.basename(source[:url], "?*")
       File.join(Config.cache_dir, filename)
     end

--- a/lib/omnibus/fetchers/net_fetcher.rb
+++ b/lib/omnibus/fetchers/net_fetcher.rb
@@ -119,7 +119,7 @@ module Omnibus
     # @return [String]
     #
     def downloaded_file
-      filename = source[:cached_name] if source[:cached_name]
+      # filename = source[:cached_name] if source[:cached_name]
       filename ||= File.basename(source[:url], "?*")
       File.join(Config.cache_dir, filename)
     end

--- a/lib/omnibus/s3_cache.rb
+++ b/lib/omnibus/s3_cache.rb
@@ -83,7 +83,7 @@ module Omnibus
           md5 = digest(fetcher.downloaded_file, :md5)
 
           File.open(fetcher.downloaded_file, "rb") do |file|
-            store_object(key, file, md5, "public-read")
+            store_object(key, file, md5, Config.s3_acl)
           end
         end
 


### PR DESCRIPTION
### Description

This setting was added as an setting to give the option to host cache out of a private s3 bucket, or public s3 bucket. 

This was required by the aws sdk. 

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
