### PR TITLE
Updating ohai and license_scout

### DIFF
--- a/omnibus.gemspec
+++ b/omnibus.gemspec
@@ -25,10 +25,11 @@ Gem::Specification.new do |gem|
   gem.add_dependency "chef-cleanroom",   "~> 1.0"
   gem.add_dependency "ffi-yajl",         "~> 2.2"
   gem.add_dependency "mixlib-shellout",  ">= 2.0", "< 4.0"
-  gem.add_dependency "ohai",             ">= 16", "< 19"
+  # Require at least Ohai 18.2.6 to pick up fixes while staying within the 18.x series
+  gem.add_dependency "ohai",             ">= 18.2.6", "< 19"
   gem.add_dependency "ruby-progressbar", "~> 1.7"
   gem.add_dependency "thor",             ">= 0.18", "< 2.0"
-  gem.add_dependency "license_scout",    "~> 1.3.17"
+  gem.add_dependency "license_scout",    "~> 1.4.0"
   gem.add_dependency "contracts",        ">= 0.16.0", "< 0.17.0"
   gem.add_dependency "rexml",            "~> 3.4"
 


### PR DESCRIPTION
### Description

Briefly describe the new feature or fix here
Had to load a new version of license_scout and ohai to pick up fixes for licensing 

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
