### PR TITLE
feat: ✨ added enable_progress_bar as a config option

### DIFF
--- a/lib/omnibus/config.rb
+++ b/lib/omnibus/config.rb
@@ -575,6 +575,11 @@ module Omnibus
     # @return [Integer]
     default(:build_retries, 0)
 
+    # Display a progress bar during download.
+    #
+    # @return [true, false]
+    default(:enable_progress_bar, true)
+
     # Use the incremental build caching implemented via git. This will
     # drastically improve build times, but may result in hidden and
     # unexpected bugs.

--- a/lib/omnibus/download_helpers.rb
+++ b/lib/omnibus/download_helpers.rb
@@ -80,9 +80,10 @@ module Omnibus
 
         # Regular HTTP download using OpenURI
         # :enable_progress_bar is a special option we handle.
-        # by default we enable the progress bar.
+        # by default we enable the progress bar, see: ./config.rb
+        # the options.delete is here to still handle the override from ./licensing.rb
         enable_progress_bar = options.delete(:enable_progress_bar)
-        enable_progress_bar = true if enable_progress_bar.nil?
+        enable_progress_bar = Config.enable_progress_bar if enable_progress_bar.nil?
 
         # Safely extract download headers if they exist and ensure we send
         # Accept-Encoding => "identity" by default (tests and some proxies expect it)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -41,6 +41,7 @@ module Omnibus
     include_examples "a configurable", :solaris_linker_mapfile, "files/mapfiles/solaris"
     include_examples "a configurable", :append_timestamp, true
     include_examples "a configurable", :build_retries, 0
+    include_examples "a configurable", :enable_progress_bar, true
     include_examples "a configurable", :use_git_caching, true
     include_examples "a configurable", :fetcher_read_timeout, 60
     include_examples "a configurable", :fetcher_retries, 5


### PR DESCRIPTION
Signed-off-by: David Kling [david.kling@oracle.com](mailto:david.kling@oracle.com)

### Description

Briefly describe the new feature or fix here

Added the `enable_progress_bar` as an config option to turn it off globally.
- speeds up download times by a lot
- avoids issues when downloads go through a proxy
--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
