### PR TITLE
add el-10 to the packagers rpm file

### DIFF
--- a/lib/omnibus/packagers/rpm.rb
+++ b/lib/omnibus/packagers/rpm.rb
@@ -448,7 +448,7 @@ module Omnibus
 
           # RHEL 8 and Amazon-2023 has gpg-agent running so we can skip the expect script since the agent
           # takes care of the passphrase entering on the signing
-          if dist_tag != ".el8" && dist_tag != ".el9" && dist_tag != ".amazon2023"
+          if dist_tag != ".el8" && dist_tag != ".el9" && dist_tag != ".el10" && dist_tag != ".amazon2023"
             sign_cmd.prepend("#{signing_script} \"").concat("\"")
           end
 


### PR DESCRIPTION
### Description

Updates the RPM signing condition to skip the expect script for EL-10, as it has gpg-agent running like other modern RHEL versions

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [ ] If this change impacts git cache validity, it bumps the git cache
  serial number
- [ ] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [ ] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
